### PR TITLE
Adding assignment of checkmol functional group descriptors

### DIFF
--- a/openmoltools/tests/test_utils.py
+++ b/openmoltools/tests/test_utils.py
@@ -19,6 +19,9 @@ except ImportError:
 OBABEL_PATH = find_executable("obabel")
 SKIP_SMILES = not ((HAVE_RDKIT) & (OBABEL_PATH is not None))
 
+CHECKMOL_PATH = find_executable("checkmol")
+SKIP_CHECKMOL = (CHECKMOL_PATH is None)
+
 logging.basicConfig(level=logging.DEBUG, format="LOG: %(message)s")
 
 def test_enter_temp_directory():
@@ -65,6 +68,12 @@ def test_acpype_conversion():
         gaff_mol2_filename, frcmod_filename = utils.run_antechamber(molecule_name, input_filename, charge_method=None)
         prmtop, inpcrd = utils.run_tleap(molecule_name, gaff_mol2_filename, frcmod_filename)
         out_top, out_gro = utils.convert_via_acpype( molecule_name, prmtop, inpcrd ) 
+
+
+@skipIf(SKIP_CHECKMOL, "Skipping testing of checkmol descriptors since checkmol is not found (under that name)." )
+def test_checkmol_descriptors():
+    input_filename = utils.get_data_filename("chemicals/sustiva/sustiva.mol2")
+    utils.get_checkmol_descriptors( input_filename )
 
 
 @skipIf(SKIP_SMILES, "Skipping testing of smiles conversion because openbabel or rdkit not found.")

--- a/openmoltools/utils.py
+++ b/openmoltools/utils.py
@@ -11,7 +11,6 @@ import mdtraj as md
 from mdtraj.utils import enter_temp_directory
 from mdtraj.utils.delay_import import import_
 import openmoltools.acpype as acpype
-import commands
 
 try:
     from subprocess import getoutput  # If python 3
@@ -589,7 +588,7 @@ def get_checkmol_descriptors( molecule_filename, executable_name = 'checkmol' ):
         oechem.OEWriteMolecule( ofs, mol )
         ofs.close()
         #Run checkmol
-        groups = commands.getoutput('%s %s' % (executable_name, fname) )
+        groups = getoutput('%s %s' % (executable_name, fname) )
         #Split to separate groups
         groups = groups.split('\n')
         #Store results


### PR DESCRIPTION
Adding a utilities function which assigns functional group descriptors to compounds from a file; added a test thereof to the test_utils.py module. Checkmol is required for this to work. Test will be skipped (and function will raise an exception) if checkmol is not present.