### PR TITLE
Implementing an alternative box volume estimator in `packmol.py` without affecting any existing code

### DIFF
--- a/openmoltools/packmol.py
+++ b/openmoltools/packmol.py
@@ -3,9 +3,9 @@ import shutil
 import os
 import mdtraj as md
 from mdtraj.utils import enter_temp_directory
+from mdtraj.utils.delay_import import import_
 import tempfile
 from distutils.spawn import find_executable
-from openeye.oechem import *
 
 PACKMOL_PATH = find_executable("packmol")
 
@@ -184,15 +184,19 @@ def approximate_volume_by_density( pdb_filenames, n_molecules_list, density = 1.
     By default, boxes are only modestly large. This approach has not been extensively tested for stability but has been used in th Mobley lab for perhaps ~100 different systems without substantial problems.
     """
 
+    oechem = import_("openeye.oechem")
+
     #Load molecules to get molecular weights
     wts = []
     mass = 0.0 #For calculating total mass
     for (idx,filenm) in enumerate(pdb_filenames):
-        mol = OEMol()
-        istr = oemolistream( pdb_filenames[i] )
-        OEReadMolecule( istr, mol )
-        wts.append( OECalculateMolecularWeight(mol) )
+        mol = oechem.OEMol()
+        istr = oechem.oemolistream( pdb_filenames[idx] )
+        oechem.OEReadMolecule( istr, mol )
+        wts.append( oechem.OECalculateMolecularWeight(mol) )
         mass += n_molecules_list[idx] * wts[idx] * 1./6.022e23
+    print(wts)
+    print(mass)
 
     #Estimate volume based on mass and density
     #Density = mass/volume so volume = mass/density (volume units are ml)

--- a/openmoltools/packmol.py
+++ b/openmoltools/packmol.py
@@ -160,13 +160,13 @@ def approximate_volume(pdb_filenames, n_molecules_list, box_scaleup_factor=2.0):
     return box_size
 
 
-def approximate_volume_by_density( pdb_filenames, n_molecules_list, density = 1.0, box_scaleup_factor = 1.1):
+def approximate_volume_by_density( smiles_strings, n_molecules_list, density = 1.0, box_scaleup_factor = 1.1):
     """Generate an approximate box size based on the number and molecular weight of molecules present, and a target density for the final solvated mixture. If no density is specified, the target density is assumed to be 1 g/ml.
 
     Parameters
     ---------- 
-    pdb_filenames : list(str)
-        List of pdb filenames for each component of mixture.
+    smiles_strings : list(str)
+        List of smiles strings for each component of mixture.
     n_molecules_list : list(int)
         The number of molecules of each mixture component.
     box_scaleup_factor : float, optional, default = 1.1
@@ -189,10 +189,9 @@ def approximate_volume_by_density( pdb_filenames, n_molecules_list, density = 1.
     #Load molecules to get molecular weights
     wts = []
     mass = 0.0 #For calculating total mass
-    for (idx,filenm) in enumerate(pdb_filenames):
+    for (idx,smi) in enumerate(smiles_strings):
         mol = oechem.OEMol()
-        istr = oechem.oemolistream( pdb_filenames[idx] )
-        oechem.OEReadMolecule( istr, mol )
+        oechem.OEParseSmiles(mol, smi)
         wts.append( oechem.OECalculateMolecularWeight(mol) )
         mass += n_molecules_list[idx] * wts[idx] * 1./6.022e23
     print(wts)

--- a/openmoltools/packmol.py
+++ b/openmoltools/packmol.py
@@ -206,7 +206,5 @@ def approximate_volume_by_density( smiles_strings, n_molecules_list, density = 1
 
     #Compute final box size
     box_size = edge*box_scaleup_factor/units.angstroms
-    print box_size
-    raw_input()
 
     return box_size

--- a/openmoltools/tests/test_packmol.py
+++ b/openmoltools/tests/test_packmol.py
@@ -63,7 +63,8 @@ def test_packmol_simulation_ternary_bydensity():
         pdb_filenames.append(pdb_filename)
 
     pdb_filenames = pdb_filenames[0:2] + [ligand_traj]  # Test passing BOTH pdb filenames and trajectories as input.
-    trj = packmol.pack_box(pdb_filenames, [6, 11, 23], estimator = 'density')
+    size = packmol.approximate_volume_by_density( smiles_list, [12, 22, 46] )
+    trj = packmol.pack_box(pdb_filenames, [12, 22, 46], box_size = size)
 
     xyz = trj.openmm_positions(0)
     top = trj.top.to_openmm()
@@ -81,4 +82,6 @@ def test_packmol_simulation_ternary_bydensity():
 
     simulation = app.Simulation(top, system, integrator)
     simulation.context.setPositions(xyz)
+
+    simulation.step(25)
 

--- a/openmoltools/tests/test_packmol.py
+++ b/openmoltools/tests/test_packmol.py
@@ -52,6 +52,8 @@ def test_packmol_simulation_ternary():
 
     simulation.step(25)
 
+@skipIf(not HAVE_RDKIT, "Skipping testing of packmol conversion because rdkit not found.")
+@skipIf(packmol.PACKMOL_PATH is None, "Skipping testing of packmol conversion because packmol not found.")
 def test_packmol_simulation_ternary_bydensity():
     smiles_list = ["Cc1ccccc1", "c1ccccc1", "CC"]
     pdb_filenames = []

--- a/openmoltools/tests/test_packmol.py
+++ b/openmoltools/tests/test_packmol.py
@@ -51,3 +51,34 @@ def test_packmol_simulation_ternary():
     simulation.context.setPositions(xyz)
 
     simulation.step(25)
+
+def test_packmol_simulation_ternary_bydensity():
+    smiles_list = ["Cc1ccccc1", "c1ccccc1", "CC"]
+    pdb_filenames = []
+    ligand_trajectories, ffxml = utils.smiles_to_mdtraj_ffxml(smiles_list)
+
+    for k, ligand_traj in enumerate(ligand_trajectories):
+        pdb_filename = tempfile.mktemp(suffix=".pdb")
+        ligand_traj.save(pdb_filename)
+        pdb_filenames.append(pdb_filename)
+
+    pdb_filenames = pdb_filenames[0:2] + [ligand_traj]  # Test passing BOTH pdb filenames and trajectories as input.
+    trj = packmol.pack_box(pdb_filenames, [6, 11, 23], estimator = 'density')
+
+    xyz = trj.openmm_positions(0)
+    top = trj.top.to_openmm()
+    top.setUnitCellDimensions(mm.Vec3(*trj.unitcell_lengths[0])*u.nanometer)
+
+    forcefield = app.ForceField(ffxml)
+
+    temperature = 300 * u.kelvin
+    friction = 0.1 / u.picosecond
+    timestep = 0.1 * u.femtosecond
+
+    system = forcefield.createSystem(top, nonbondedMethod=app.PME, nonbondedCutoff=1.0 * u.nanometers, constraints=None)
+
+    integrator = mm.LangevinIntegrator(temperature, friction, timestep)
+
+    simulation = app.Simulation(top, system, integrator)
+    simulation.context.setPositions(xyz)
+


### PR DESCRIPTION
Addressing issue #111 by implementing `approximate_volume_by_density` in packmol.py; this allows for estimation of box volumes based on the expected density of the mixture rather than based on an estimated molecular volume. Also implemented a test of this functionality.

This is not used (even optionally) by `pack_box` so it will not affect any existing pipelines. My group will be using this in-house and if there is interest later in adjusting `packmol.pack_box` to allow this box selection option to be chosen by the user, we can think about doing so. Note however that this would require some adjustments, as `approximate_volume_by_density` needs to obtain the molecular weight if the components of the system, which I currently do by taking their SMILES strings rather than their file names (since the currently available files in @kyleabeauchamp 's workflow use gaff atom types, which OE tools can't use to calculate molecular weights). 