### PR TITLE
Fix issues relating to whitespace handling in [ molecules ] section in GROMACS topologies

### DIFF
--- a/openmoltools/gromacs.py
+++ b/openmoltools/gromacs.py
@@ -69,7 +69,7 @@ def extract_section(lines, section):
        status = False
 
     # Locate end of section.
-        fnd_end = False
+    fnd_end = False
     for idx in range(start_index, nlines):
        # get line
        line , comments = stripcomments(lines[idx])
@@ -83,7 +83,8 @@ def extract_section(lines, section):
              break
        if elements != []:
            end_index = idx + 1
-        if not fnd_end:
+
+    if not fnd_end:
         end_index=end_index + 1
 
     # compute indices of lines in section. The indices are related to the section without the header

--- a/openmoltools/gromacs.py
+++ b/openmoltools/gromacs.py
@@ -93,92 +93,6 @@ def extract_section(lines, section):
     # return these indices
     return status, indices
 
-def change_molecules_section( input_topology, output_topology, molecule_names, molecule_numbers):
-    """Create a GROMACS topology file where the  molecule numbers are replaced by new molecule numbers in the gromacs [ molecules ] section.
-
-    Parameters
-    ----------
-    input_topology : str
-        The input gromacs topology file name
-    output_topology : str
-        Output topology file names to be written/created
-    molecule_names : list (str)
-        Molecule names to be searched in the gromacs [ molecules ] section
-    molecule_numbers : list (int)
-        The new molecule numbers to be used in [ molecules ] section
-
-    Returns
-    -------
-    nothing is returned
-
-    Notes
-    -----
-    This function reads in a gromacs topology file and changes the number of atoms related to the passed molecule name list.
-    If in the topology file one molecule name is not present in the passed molecule name list an exception is raised.
-
-    """
-
-    #The molecule name list and the molecule number list must have the same size otherwise an exception is raised
-    if (len(molecule_names) != len(molecule_numbers)):
-        raise ValueError("The molecule name list and the molecule name number must have the same size")
-
-    #Check for non negative integer number of molecules
-    check_nni = all(item >=0  and isinstance(item, int) for item in molecule_numbers)
-
-    if not check_nni:
-        raise ValueError("The molecule number list contains a non negative integer value")
-
-        #Read in the topology file
-    try:
-        file = open(input_topology, 'r')
-        text = file.readlines()
-        file.close()
-    except IOError:
-        raise NameError(input_topology)
-
-
-    #Extract the [ molecules ] section from the gromacs topolgy file
-    check , indices = extract_section(text, "molecules")
-
-    if(check == False):
-        raise ValueError("In the selected gromacs topology file is missing the [ molecules ] section")
-
-    counter = 0
-    for idx in indices:
-
-        #Read in the molecule name and the molecule number present in the topology file
-        line = text[idx]
-        line = line.split()
-
-        #Skip comments
-        if line[0] == ';':
-            continue
-
-        #The current name of the molecule in the topology file
-        mol_name = line[0]
-
-        #Check if the molecule name in the gromacs topology is present in the passed molecule name list otherwise an exception is raised
-        try:
-            index_name = molecule_names.index(mol_name)
-        except ValueError:
-            msg = "In the selected gromacs topology file the molecule name '%s' does not match any molecule names in the passed molecule name list: %s" % (mol_name , molecule_names)
-            raise ValueError(msg)
-
-        #Create a valid string to re-write back in the output topology file
-        line[1] = str(molecule_numbers[index_name])
-        strg = ' '.join(line)+'\n'
-        text[idx] = strg
-
-    if (counter != len(molecule_names)):
-        raise ValueError("The passed molecule list contains more molecule names than the gromacs topology file")
-
-    try:
-        file = open( output_topology, 'w')
-        file.writelines( text )
-        file.close()
-    except IOError:
-        msg = "It was not possible to write the output topology file: %s" % output_topology
-        raise NameError(msg)
 
 def merge_topologies( input_topologies, output_topology, system_name, molecule_names = None, molecule_numbers = None ):
     """Merge GROMACS topology files specified in a list of input topologies and write the result into a final topology file specified. Currently these are required to be SINGLE-MOLECULE topology files. Optionally specify a list of molecule names to be used in the [ moleculetype ] and [ molecules ] sections, overriding what is already present.
@@ -419,9 +333,7 @@ def merge_topologies( input_topologies, output_topology, system_name, molecule_n
     file.close()
     
     return True
-   
 
- 
 def change_molecules_section( input_topology, output_topology, molecule_names, molecule_numbers):
     """Create a GROMACS topology file where the  molecule numbers are replaced by new molecule numbers in the gromacs [ molecules ] section.
         
@@ -451,14 +363,20 @@ def change_molecules_section( input_topology, output_topology, molecule_names, m
     if (len(molecule_names) != len(molecule_numbers)):
         raise ValueError("The molecule name list and the molecule name number must have the same size")
     
+    #Check for non negative integer number of molecules
+    check_nni = all(item >=0  and isinstance(item, int) for item in molecule_numbers)
+
+    if not check_nni:
+        raise ValueError("The molecule number list contains a non negative integer value")
+
     #Read in the topology file
     try:
         file = open(input_topology, 'r')
+        text = file.readlines()
+        file.close()
     except IOError:
         raise NameError(input_topology)
 
-    text = file.readlines()
-    file.close()
 
     #Extract the [ molecules ] section from the gromacs topolgy file
     check , indices = extract_section(text, "molecules")
@@ -468,15 +386,17 @@ def change_molecules_section( input_topology, output_topology, molecule_names, m
 
     counter = 0
 
-    for idx in range(indices[0],indices[-1]):
+
+    for idx in indices:
 
         #Read in the molecule name and the molecule number present in the topology file
-        line = text[idx]
+        line = text[idx]		
         line = line.split()
-        
+   
         #Skip comments
         if line[0] == ';':
             continue
+        
         #The current name of the molecule in the topology file
         mol_name = line[0]
 
@@ -502,3 +422,4 @@ def change_molecules_section( input_topology, output_topology, molecule_names, m
     except IOError:
         msg = "It was not possible to write the output topology file: %s" % output_topology
         raise NameError(msg)
+

--- a/openmoltools/gromacs.py
+++ b/openmoltools/gromacs.py
@@ -80,7 +80,8 @@ def extract_section(lines, section):
           if (elements[0]=='['):
              fnd_end = True
              break
-    if not fnd_end: end_index = nlines
+
+    if not fnd_end: end_index += 1
 
     # compute indices of lines in section
     indices = range(start_index, end_index)

--- a/openmoltools/gromacs.py
+++ b/openmoltools/gromacs.py
@@ -41,7 +41,7 @@ def extract_section(lines, section):
     status : bool
         Whether or not section is found. True if found, False if not. 
     indices :  list (int)
-        Line indices within lines belonging to section
+        Line indices within lines belonging to section excluding the header and counting from zero
 
     """
 
@@ -69,26 +69,115 @@ def extract_section(lines, section):
        status = False
 
     # Locate end of section.
-    fnd_end = False
-    for end_index in range(start_index, nlines):
+        fnd_end = False
+    for idx in range(start_index, nlines):
        # get line
-       line,comments = stripcomments(lines[end_index])
+       line , comments = stripcomments(lines[idx])
        # split into elements
        elements = line.split()
        # see if keyword is matched
        if (len(elements) == 3):
           if (elements[0]=='['):
+             end_index = end_index + 1
              fnd_end = True
              break
+       if elements != []:
+           end_index = idx + 1
+        if not fnd_end:
+        end_index=end_index + 1
 
-    if not fnd_end: end_index += 1
-
-    # compute indices of lines in section
-    indices = range(start_index, end_index)
+    # compute indices of lines in section. The indices are related to the section without the header
+    indices = range(start_index, end_index-1)
 
     # return these indices
     return status, indices
 
+def change_molecules_section( input_topology, output_topology, molecule_names, molecule_numbers):
+    """Create a GROMACS topology file where the  molecule numbers are replaced by new molecule numbers in the gromacs [ molecules ] section.
+
+    Parameters
+    ----------
+    input_topology : str
+        The input gromacs topology file name
+    output_topology : str
+        Output topology file names to be written/created
+    molecule_names : list (str)
+        Molecule names to be searched in the gromacs [ molecules ] section
+    molecule_numbers : list (int)
+        The new molecule numbers to be used in [ molecules ] section
+
+    Returns
+    -------
+    nothing is returned
+
+    Notes
+    -----
+    This function reads in a gromacs topology file and changes the number of atoms related to the passed molecule name list.
+    If in the topology file one molecule name is not present in the passed molecule name list an exception is raised.
+
+    """
+
+    #The molecule name list and the molecule number list must have the same size otherwise an exception is raised
+    if (len(molecule_names) != len(molecule_numbers)):
+        raise ValueError("The molecule name list and the molecule name number must have the same size")
+
+    #Check for non negative integer number of molecules
+    check_nni = all(item >=0  and isinstance(item, int) for item in molecule_numbers)
+
+    if not check_nni:
+        raise ValueError("The molecule number list contains a non negative integer value")
+
+        #Read in the topology file
+    try:
+        file = open(input_topology, 'r')
+        text = file.readlines()
+        file.close()
+    except IOError:
+        raise NameError(input_topology)
+
+
+    #Extract the [ molecules ] section from the gromacs topolgy file
+    check , indices = extract_section(text, "molecules")
+
+    if(check == False):
+        raise ValueError("In the selected gromacs topology file is missing the [ molecules ] section")
+
+    counter = 0
+    for idx in indices:
+
+        #Read in the molecule name and the molecule number present in the topology file
+        line = text[idx]
+        line = line.split()
+
+        #Skip comments
+        if line[0] == ';':
+            continue
+
+        #The current name of the molecule in the topology file
+        mol_name = line[0]
+
+        #Check if the molecule name in the gromacs topology is present in the passed molecule name list otherwise an exception is raised
+        try:
+            index_name = molecule_names.index(mol_name)
+        except ValueError:
+            msg = "In the selected gromacs topology file the molecule name '%s' does not match any molecule names in the passed molecule name list: %s" % (mol_name , molecule_names)
+            raise ValueError(msg)
+
+        #Create a valid string to re-write back in the output topology file
+        line[1] = str(molecule_numbers[index_name])
+        strg = ' '.join(line)+'\n'
+        text[idx] = strg
+
+    if (counter != len(molecule_names)):
+        raise ValueError("The passed molecule list contains more molecule names than the gromacs topology file")
+
+    try:
+        file = open( output_topology, 'w')
+        file.writelines( text )
+        file.close()
+    except IOError:
+        msg = "It was not possible to write the output topology file: %s" % output_topology
+        raise NameError(msg)
 
 def merge_topologies( input_topologies, output_topology, system_name, molecule_names = None, molecule_numbers = None ):
     """Merge GROMACS topology files specified in a list of input topologies and write the result into a final topology file specified. Currently these are required to be SINGLE-MOLECULE topology files. Optionally specify a list of molecule names to be used in the [ moleculetype ] and [ molecules ] sections, overriding what is already present.

--- a/openmoltools/gromacs.py
+++ b/openmoltools/gromacs.py
@@ -278,9 +278,9 @@ def merge_topologies( input_topologies, output_topology, system_name, molecule_n
         if molecule_numbers != None:
             #If molecule numbers are provided, build with existing names and new numbers
             new_contents = []
+            topnr = 0
             for line in section_contents['molecules']:
                 entry, comments = stripcomments(line)
-                topnr = 0
                 if len(entry) > 1:
                     new_contents.append( '%s    %s\n' % ( entry.split()[0], molecule_numbers[topnr] ) )
                     topnr +=1


### PR DESCRIPTION
Also fixing an issue where the wrong molecule number could be edited when modifying molecule numbers in topology files where names were not also provided.