### PR TITLE
AMBER changes - move functions from utils to amber; parse output for errors

### DIFF
--- a/openmoltools/amber.py
+++ b/openmoltools/amber.py
@@ -3,7 +3,7 @@ import tempfile
 import logging
 import os
 from distutils.spawn import find_executable
-import utils
+import .utils
 
 try:
     from subprocess import getoutput  # If python 3

--- a/openmoltools/amber.py
+++ b/openmoltools/amber.py
@@ -114,7 +114,7 @@ def build_mixture_prmtop(mol2_filenames, frcmod_filenames, box_filename, prmtop_
 
     return tleap_commands
 
-def check_for_errors( outputtext, other_errors = None ):
+def check_for_errors( outputtext, other_errors = None, ignore_errors = None ):
     """Check AMBER package output for the string 'ERROR' (upper or lowercase) and (optionally) specified other strings and raise an exception if it is found (to avoid silent failures which might be noted to log but otherwise ignored).
 
     Parameters
@@ -122,7 +122,9 @@ def check_for_errors( outputtext, other_errors = None ):
     outputtext : str
         String listing output text from an (AMBER) command which should be checked for errors.
     other_errors : list(str), default None
-        If specified, provide strings for other errors which will be chcked for, such as "improper number of arguments", etc. 
+        If specified, provide strings for other errors which will be chcked for, such as "improper number of arguments", etc.
+    ignore_errors: list(str), default None
+        If specified, AMBER output lines containing errors but also containing any of the specified strings will be ignored (because, for example, AMBER issues an "ERROR" for non-integer charges in some cases when only a warning is needed). 
 
     Notes
     -----
@@ -136,6 +138,17 @@ def check_for_errors( outputtext, other_errors = None ):
             for err in other_errors:
                 if err.upper() in line.upper():
                     error_lines.append( line )
+
+    if not ignore_errors == None:
+        new_error_lines = []
+        for ign in ignore_errors:
+            ignore = False
+            for err in error_lines:
+                if ign in err:
+                    ignore = True
+            if not ignore:
+                new_error_lines.append( err )
+        error_lines = new_error_lines 
 
     if len(error_lines) > 0:
         print("Unexpected errors encountered running AMBER tool. Offending output:")

--- a/openmoltools/amber.py
+++ b/openmoltools/amber.py
@@ -3,7 +3,7 @@ import tempfile
 import logging
 import os
 from distutils.spawn import find_executable
-import .utils
+import openmoltools.utils as utils
 
 try:
     from subprocess import getoutput  # If python 3

--- a/openmoltools/amber.py
+++ b/openmoltools/amber.py
@@ -139,7 +139,7 @@ def check_for_errors( outputtext, other_errors = None, ignore_errors = None ):
                 if err.upper() in line.upper():
                     error_lines.append( line )
 
-    if not ignore_errors == None:
+    if not ignore_errors == None and len(error_lines)>0:
         new_error_lines = []
         for ign in ignore_errors:
             ignore = False

--- a/openmoltools/amber.py
+++ b/openmoltools/amber.py
@@ -41,7 +41,7 @@ def build_mixture_prmtop(mol2_filenames, frcmod_filenames, box_filename, prmtop_
     ----------
     mol2_filenames : list(str)
         Filenames of GAFF flavored mol2 files.  Each must contain exactly
-        ONE ligand.
+        ONE ligand. Filenames cannot contain spaces (tleap limitation)
     frcmod_filenames : str
         Filename of input GAFF frcmod filenames.
     box_filename : str
@@ -80,6 +80,10 @@ def build_mixture_prmtop(mol2_filenames, frcmod_filenames, box_filename, prmtop_
     if len(all_names) != len(mol2_filenames):
         raise(ValueError("Must have UNIQUE residue names in each mol2 file."))
     
+    #Check for spaces in filenames; AMBER can't handle these.
+    for name in mol2_filenames:
+        assert ' ' not in name, "Error: tleap cannot process mol2 filenames containing spaces."
+
     all_names = [md.load(filename).top.residue(0).name for filename in mol2_filenames]
     
     mol2_section = "\n".join("%s = loadmol2 %s" % (all_names[k], filename) for k, filename in enumerate(mol2_filenames))
@@ -97,7 +101,38 @@ def build_mixture_prmtop(mol2_filenames, frcmod_filenames, box_filename, prmtop_
 
     output = getoutput(cmd)
     logger.debug(output)
+    check_for_errors( output, other_errors = ['Improper number of arguments'] )
 
     file_handle.close()
 
     return tleap_commands
+
+def check_for_errors( outputtext, other_errors = None ):
+    """Check AMBER package output for the string 'ERROR' (upper or lowercase) and (optionally) specified other strings and raise an exception if it is found (to avoid silent failures which might be noted to log but otherwise ignored).
+
+    Parameters
+    ----------
+    outputtext : str
+        String listing output text from an (AMBER) command which should be checked for errors.
+    other_errors : list(str), default None
+        If specified, provide strings for other errors which will be chcked for, such as "improper number of arguments", etc. 
+
+    Notes
+    -----
+    If error(s) are found, raise a RuntimeError and attept to print the appropriate errors from the processed text."""
+    lines = outputtext.split('\n')
+    error_lines = []
+    for line in lines:
+        if 'ERROR' in line.upper():
+            error_lines.append( line )
+        if not other_errors == None:
+            for err in other_errors:
+                if err.upper() in line.upper():
+                    error_lines.append( line )
+
+    if len(error_lines) > 0:
+        print("Unexpected errors encountered running AMBER tool. Offending output:")
+        for line in error_lines: print(line)
+        raise(RuntimeError("Error encountered running AMBER tool. Exiting."))
+
+    return

--- a/openmoltools/amber.py
+++ b/openmoltools/amber.py
@@ -3,7 +3,7 @@ import tempfile
 import logging
 import os
 from distutils.spawn import find_executable
-import openmoltools.utils as utils
+from mdtraj.utils.delay_import import import_
 
 try:
     from subprocess import getoutput  # If python 3
@@ -210,7 +210,7 @@ def run_antechamber(molecule_name, input_filename, charge_method="bcc", net_char
     frcmod_filename : str
         Amber frcmod file produced by prmchk
     """
-
+    utils = import_("openmoltools.utils")
     ext = utils.parse_ligand_filename(input_filename)[1]
 
     filetype = ext[1:]

--- a/openmoltools/amber.py
+++ b/openmoltools/amber.py
@@ -108,7 +108,7 @@ def build_mixture_prmtop(mol2_filenames, frcmod_filenames, box_filename, prmtop_
 
     output = getoutput(cmd)
     logger.debug(output)
-    check_for_errors( output, other_errors = ['Improper number of arguments'] )
+    check_for_errors( output, other_errors = ['Improper number of arguments'], ignore_errors = ['unperturbed charge of the unit', 'ignoring the error'] )
 
     file_handle.close()
 

--- a/openmoltools/amber.py
+++ b/openmoltools/amber.py
@@ -1,7 +1,14 @@
 import mdtraj as md
 import tempfile
 import logging
-from .utils import getoutput
+import os
+from distutils.spawn import find_executable
+import utils
+
+try:
+    from subprocess import getoutput  # If python 3
+except ImportError:
+    from commands import getoutput  # If python 2
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.DEBUG, format="LOG: %(message)s")
@@ -136,3 +143,152 @@ def check_for_errors( outputtext, other_errors = None ):
         raise(RuntimeError("Error encountered running AMBER tool. Exiting."))
 
     return
+
+
+def find_gaff_dat():
+    AMBERHOME = None
+    
+    try:
+        AMBERHOME = os.environ['AMBERHOME']
+    except KeyError:
+        pass
+    
+    if AMBERHOME is None:
+        full_path = find_executable("parmchk2")
+        try:
+            AMBERHOME = os.path.split(full_path)[0]
+            AMBERHOME = os.path.join(AMBERHOME, "../")
+        except:
+            raise(ValueError("Cannot find AMBER GAFF"))
+
+    if AMBERHOME is None:
+        raise(ValueError("Cannot find AMBER GAFF"))
+
+    return os.path.join(AMBERHOME, 'dat', 'leap', 'parm', 'gaff.dat')
+
+GAFF_DAT_FILENAME = find_gaff_dat()
+
+
+def run_antechamber(molecule_name, input_filename, charge_method="bcc", net_charge=None, gaff_mol2_filename=None, frcmod_filename=None):
+    """Run AmberTools antechamber and parmchk2 to create GAFF mol2 and frcmod files.
+
+    Parameters
+    ----------
+    molecule_name : str
+        Name of the molecule to be parameterized, will be used in output filenames.
+    ligand_filename : str
+        The molecule to be parameterized.  Must be tripos mol2 format.
+    charge_method : str, optional
+        If not None, the charge method string will be passed to Antechamber.
+    net_charge : int, optional
+        If not None, net charge of the molecule to be parameterized.
+        If None, Antechamber sums up partial charges from the input file.
+    gaff_mol2_filename : str, optional, default=None
+        Name of GAFF mol2 filename to output.  If None, uses local directory
+        and molecule_name
+    frcmod_filename : str, optional, default=None
+        Name of GAFF frcmod filename to output.  If None, uses local directory
+        and molecule_name
+
+    Returns
+    -------
+    gaff_mol2_filename : str
+        GAFF format mol2 filename produced by antechamber
+    frcmod_filename : str
+        Amber frcmod file produced by prmchk
+    """
+
+    ext = utils.parse_ligand_filename(input_filename)[1]
+
+    filetype = ext[1:]
+    if filetype != "mol2":
+        raise(ValueError("Must input mol2 filename"))
+
+
+    if gaff_mol2_filename is None:
+        gaff_mol2_filename = molecule_name + '.gaff.mol2'
+    if frcmod_filename is None:
+        frcmod_filename = molecule_name + '.frcmod'
+
+    cmd = "antechamber -i %s -fi mol2 -o %s -fo mol2 -s 2" % (input_filename, gaff_mol2_filename)
+    if charge_method is not None:
+        cmd += ' -c %s' % charge_method
+
+    if net_charge is not None:
+        cmd += ' -nc %d' % net_charge
+
+    logger.debug(cmd)
+
+    output = getoutput(cmd)
+    logger.debug(output)
+
+    cmd = "parmchk2 -i %s -f mol2 -o %s" % (gaff_mol2_filename, frcmod_filename)
+    logger.debug(cmd)
+
+    output = getoutput(cmd)
+    logger.debug(output)
+    check_for_errors( output  )
+
+    return gaff_mol2_filename, frcmod_filename
+
+
+def run_tleap(molecule_name, gaff_mol2_filename, frcmod_filename, prmtop_filename=None, inpcrd_filename=None):
+    """Run AmberTools tleap to create simulation files for AMBER
+
+    Parameters
+    ----------
+    molecule_name : str
+        The name of the molecule    
+    gaff_mol2_filename : str
+        GAFF format mol2 filename produced by antechamber
+    frcmod_filename : str
+        Amber frcmod file produced by prmchk
+    prmtop_filename : str, optional, default=None
+        Amber prmtop file produced by tleap, defaults to molecule_name
+    inpcrd_filename : str, optional, default=None
+        Amber inpcrd file produced by tleap, defaults to molecule_name  
+
+    Returns
+    -------
+    prmtop_filename : str
+        Amber prmtop file produced by tleap
+    inpcrd_filename : str
+        Amber inpcrd file produced by tleap
+    """
+    if prmtop_filename is None:
+        prmtop_filename = "%s.prmtop" % molecule_name
+    if inpcrd_filename is None:
+        inpcrd_filename = "%s.inpcrd" % molecule_name
+    
+    assert ' ' not in gaff_mol2_filename, "Error: tleap cannot process mol2 filenames containing spaces."
+    assert ' ' not in frcmod_filename, "Error: tleap cannot process filenames containing spaces."
+    assert ' ' not in prmtop_filename, "Error: tleap cannot process filenames containing spaces."
+    assert ' ' not in inpcrd_filename, "Error: tleap cannot process filenames containing spaces."
+
+    tleap_input = """
+source leaprc.ff99SB
+source leaprc.gaff
+LIG = loadmol2 %s
+check LIG
+loadamberparams %s
+saveamberparm LIG %s %s
+quit
+
+""" % (gaff_mol2_filename, frcmod_filename, prmtop_filename, inpcrd_filename)
+
+    file_handle = tempfile.NamedTemporaryFile('w')  # FYI Py3K defaults to 'wb' mode, which won't work here.
+    file_handle.writelines(tleap_input)
+    file_handle.flush()
+
+    cmd = "tleap -f %s " % file_handle.name
+    logger.debug(cmd)
+
+    output = getoutput(cmd)
+    logger.debug(output)
+
+    check_for_errors( output, other_errors = ['Improper number of arguments'] )
+
+    file_handle.close()
+
+    return prmtop_filename, inpcrd_filename
+

--- a/openmoltools/tests/test_amber.py
+++ b/openmoltools/tests/test_amber.py
@@ -62,3 +62,24 @@ def test_amber_binary_mixture():
 
         tleap_cmd = amber.build_mixture_prmtop(mol2_filenames, frcmod_filenames, box_filename, prmtop_filename, inpcrd_filename)
         print(tleap_cmd)
+
+
+def test_run_antechamber():
+    molecule_name = "sustiva"
+    input_filename = utils.get_data_filename("chemicals/sustiva/sustiva.mol2")
+    with utils.enter_temp_directory():  # Prevents creating tons of GAFF files everywhere.
+        gaff_mol2_filename, frcmod_filename = amber.run_antechamber(molecule_name, input_filename, charge_method=None)
+
+def test_run_tleap():
+    molecule_name = "sustiva"
+    input_filename = utils.get_data_filename("chemicals/sustiva/sustiva.mol2")
+    with utils.enter_temp_directory():  # Prevents creating tons of GAFF files everywhere.
+        gaff_mol2_filename, frcmod_filename = amber.run_antechamber(molecule_name, input_filename, charge_method=None)
+        prmtop, inpcrd = utils.run_tleap(molecule_name, gaff_mol2_filename, frcmod_filename)
+
+def test_run_antechamber_charges():
+    molecule_name = "acetate"
+    input_filename = utils.get_data_filename("chemicals/acetate/acetate.mol2")
+    with utils.enter_temp_directory():  # Prevents creating tons of GAFF files everywhere.
+        gaff_mol2_filename, frcmod_filename = amber.run_antechamber(molecule_name, input_filename, charge_method=None, net_charge=-1)
+

--- a/openmoltools/tests/test_utils.py
+++ b/openmoltools/tests/test_utils.py
@@ -36,30 +36,11 @@ def test_parse_ligand_filename():
     eq(name, "sustiva")
     eq(ext, ".mol2")
 
-def test_run_antechamber():
-    molecule_name = "sustiva"
-    input_filename = utils.get_data_filename("chemicals/sustiva/sustiva.mol2")
-    with utils.enter_temp_directory():  # Prevents creating tons of GAFF files everywhere.
-        gaff_mol2_filename, frcmod_filename = utils.run_antechamber(molecule_name, input_filename, charge_method=None)
-
-def test_run_tleap():
-    molecule_name = "sustiva"
-    input_filename = utils.get_data_filename("chemicals/sustiva/sustiva.mol2")
-    with utils.enter_temp_directory():  # Prevents creating tons of GAFF files everywhere.
-        gaff_mol2_filename, frcmod_filename = utils.run_antechamber(molecule_name, input_filename, charge_method=None)
-        prmtop, inpcrd = utils.run_tleap(molecule_name, gaff_mol2_filename, frcmod_filename)
-
 def test_run_test_molecule():
     molecule_name = "sustiva"
     input_filename = utils.get_data_filename("chemicals/sustiva/sustiva.mol2")
     with utils.enter_temp_directory():  # Prevents creating tons of GAFF files everywhere.
         utils.test_molecule(molecule_name, input_filename)
-
-def test_run_antechamber_charges():
-    molecule_name = "acetate"
-    input_filename = utils.get_data_filename("chemicals/acetate/acetate.mol2")
-    with utils.enter_temp_directory():  # Prevents creating tons of GAFF files everywhere.
-        gaff_mol2_filename, frcmod_filename = utils.run_antechamber(molecule_name, input_filename, charge_method=None, net_charge=-1)
 
 def test_acpype_conversion():
     molecule_name = 'sustiva'

--- a/openmoltools/utils.py
+++ b/openmoltools/utils.py
@@ -11,7 +11,6 @@ import mdtraj as md
 from mdtraj.utils import enter_temp_directory
 from mdtraj.utils.delay_import import import_
 import openmoltools.acpype as acpype
-import openmoltools.amber as amber
 
 try:
     from subprocess import getoutput  # If python 3
@@ -31,10 +30,9 @@ logging.basicConfig(level=logging.DEBUG, format="LOG: %(message)s")
 
 def find_gaff_dat():
     print("Warning: find_gaff_dat has been moved to openmoltools.amber.")
+    amber = import_("openmoltools.amber") 
     
     return amber.find_gaff_dat()
-
-GAFF_DAT_FILENAME = amber.find_gaff_dat()
 
 
 def parse_ligand_filename(filename):
@@ -45,10 +43,12 @@ def parse_ligand_filename(filename):
 
 def run_antechamber(*args, **kwargs):
     print("Warning: run_antechamber has been moved to openmoltools.amber.")
+    amber = import_("openmoltools.amber") 
     return amber.run_antechamber(*args, **kwargs)
 
 def run_tleap(*args, **kwargs):
     print("Warning: run_tleap has been moved to openmoltools.amber.")
+    amber = import_("openmoltools.amber") 
     return amber.run_tleap(*args, **kwargs)
 
 def convert_via_acpype( molecule_name, in_prmtop, in_crd, out_top = None, out_gro = None, debug = False, is_sorted = False ):
@@ -148,6 +148,8 @@ def create_ffxml_file(gaff_mol2_filenames, frcmod_filenames, ffxml_filename=None
     # Generate ffxml file.
     parser = amber_parser.AmberParser(override_mol2_residue_name=override_mol2_residue_name)
 
+    amber = import_("openmoltools.amber") 
+    GAFF_DAT_FILENAME = amber.find_gaff_dat()
     filenames = [GAFF_DAT_FILENAME]
     filenames.extend([filename for filename in gaff_mol2_filenames])
     filenames.extend([filename for filename in frcmod_filenames])
@@ -183,6 +185,8 @@ def create_ffxml_simulation(molecule_name, gaff_mol2_filename, frcmod_filename):
     """
 
     # Generate ffxml file.
+    amber = import_("openmoltools.amber") 
+    GAFF_DAT_FILENAME = amber.find_gaff_dat()
     parser = amber_parser.AmberParser()
     parser.parse_filenames([GAFF_DAT_FILENAME, gaff_mol2_filename, frcmod_filename])
 
@@ -262,6 +266,7 @@ def test_molecule(molecule_name, tripos_mol2_filename, charge_method="bcc"):
     """
 
     # Generate GAFF parameters.
+    amber = import_("openmoltools.amber") 
     (gaff_mol2_filename, frcmod_filename) = amber.run_antechamber(molecule_name, tripos_mol2_filename, charge_method=charge_method)
 
     # Create simulations.
@@ -345,6 +350,7 @@ def smiles_to_mdtraj_ffxml(smiles_strings, base_molecule_name="lig"):
         convert_molecule(pdb_filename, mol2_filename)  # This is necessary because PDB double bonds are not handled by antechamber...
         print(mol2_filename)
 
+        amber = import_("openmoltools.amber") 
         gaff_mol2_filename, frcmod_filename = amber.run_antechamber(molecule_name, mol2_filename)
         traj = md.load(gaff_mol2_filename)
         print(gaff_mol2_filename)

--- a/openmoltools/utils.py
+++ b/openmoltools/utils.py
@@ -11,6 +11,7 @@ import mdtraj as md
 from mdtraj.utils import enter_temp_directory
 from mdtraj.utils.delay_import import import_
 import openmoltools.acpype as acpype
+import openmoltools.amber as amber
 
 try:
     from subprocess import getoutput  # If python 3
@@ -29,27 +30,11 @@ logging.basicConfig(level=logging.DEBUG, format="LOG: %(message)s")
 
 
 def find_gaff_dat():
-    AMBERHOME = None
+    print("Warning: find_gaff_dat has been moved to openmoltools.amber.")
     
-    try:
-        AMBERHOME = os.environ['AMBERHOME']
-    except KeyError:
-        pass
-    
-    if AMBERHOME is None:
-        full_path = find_executable("parmchk2")
-        try:
-            AMBERHOME = os.path.split(full_path)[0]
-            AMBERHOME = os.path.join(AMBERHOME, "../")
-        except:
-            raise(ValueError("Cannot find AMBER GAFF"))
+    return amber.find_gaff_dat()
 
-    if AMBERHOME is None:
-        raise(ValueError("Cannot find AMBER GAFF"))
-
-    return os.path.join(AMBERHOME, 'dat', 'leap', 'parm', 'gaff.dat')
-
-GAFF_DAT_FILENAME = find_gaff_dat()
+GAFF_DAT_FILENAME = amber.find_gaff_dat()
 
 
 def parse_ligand_filename(filename):
@@ -58,132 +43,13 @@ def parse_ligand_filename(filename):
     return name, ext
 
 
-def run_antechamber(molecule_name, input_filename, charge_method="bcc", net_charge=None, gaff_mol2_filename=None, frcmod_filename=None):
-    """Run AmberTools antechamber and parmchk2 to create GAFF mol2 and frcmod files.
+def run_antechamber(*args, **kwargs):
+    print("Warning: run_antechamber has been moved to openmoltools.amber.")
+    return amber.run_antechamber(*args, **kwargs)
 
-    Parameters
-    ----------
-    molecule_name : str
-        Name of the molecule to be parameterized, will be used in output filenames.
-    ligand_filename : str
-        The molecule to be parameterized.  Must be tripos mol2 format.
-    charge_method : str, optional
-        If not None, the charge method string will be passed to Antechamber.
-    net_charge : int, optional
-        If not None, net charge of the molecule to be parameterized.
-        If None, Antechamber sums up partial charges from the input file.
-    gaff_mol2_filename : str, optional, default=None
-        Name of GAFF mol2 filename to output.  If None, uses local directory
-        and molecule_name
-    frcmod_filename : str, optional, default=None
-        Name of GAFF frcmod filename to output.  If None, uses local directory
-        and molecule_name
-
-    Returns
-    -------
-    gaff_mol2_filename : str
-        GAFF format mol2 filename produced by antechamber
-    frcmod_filename : str
-        Amber frcmod file produced by prmchk
-    """
-
-    ext = parse_ligand_filename(input_filename)[1]
-
-    filetype = ext[1:]
-    if filetype != "mol2":
-        raise(ValueError("Must input mol2 filename"))
-
-
-    if gaff_mol2_filename is None:
-        gaff_mol2_filename = molecule_name + '.gaff.mol2'
-    if frcmod_filename is None:
-        frcmod_filename = molecule_name + '.frcmod'
-
-    cmd = "antechamber -i %s -fi mol2 -o %s -fo mol2 -s 2" % (input_filename, gaff_mol2_filename)
-    if charge_method is not None:
-        cmd += ' -c %s' % charge_method
-
-    if net_charge is not None:
-        cmd += ' -nc %d' % net_charge
-
-    logger.debug(cmd)
-
-    output = getoutput(cmd)
-    logger.debug(output)
-
-    cmd = "parmchk2 -i %s -f mol2 -o %s" % (gaff_mol2_filename, frcmod_filename)
-    logger.debug(cmd)
-
-    output = getoutput(cmd)
-    logger.debug(output)
-
-    return gaff_mol2_filename, frcmod_filename
-
-
-def convert_molecule(in_filename, out_filename):
-    """Use openbabel to convert filenames.  May not work for all file formats!"""
-
-    molecule_name, ext_in = parse_ligand_filename(in_filename)
-    molecule_name, ext_out = parse_ligand_filename(out_filename)
-
-    cmd = "obabel -i %s %s -o %s -O %s" % (ext_in[1:], in_filename, ext_out[1:], out_filename)
-    print(cmd)
-    output = getoutput(cmd)
-    logger.debug(output)
-
-
-def run_tleap(molecule_name, gaff_mol2_filename, frcmod_filename, prmtop_filename=None, inpcrd_filename=None):
-    """Run AmberTools tleap to create simulation files for AMBER
-
-    Parameters
-    ----------
-    molecule_name : str
-        The name of the molecule    
-    gaff_mol2_filename : str
-        GAFF format mol2 filename produced by antechamber
-    frcmod_filename : str
-        Amber frcmod file produced by prmchk
-    prmtop_filename : str, optional, default=None
-        Amber prmtop file produced by tleap, defaults to molecule_name
-    inpcrd_filename : str, optional, default=None
-        Amber inpcrd file produced by tleap, defaults to molecule_name  
-
-    Returns
-    -------
-    prmtop_filename : str
-        Amber prmtop file produced by tleap
-    inpcrd_filename : str
-        Amber inpcrd file produced by tleap
-    """
-    if prmtop_filename is None:
-        prmtop_filename = "%s.prmtop" % molecule_name
-    if inpcrd_filename is None:
-        inpcrd_filename = "%s.inpcrd" % molecule_name
-
-    tleap_input = """
-source leaprc.ff99SB
-source leaprc.gaff
-LIG = loadmol2 %s
-check LIG
-loadamberparams %s
-saveamberparm LIG %s %s
-quit
-
-""" % (gaff_mol2_filename, frcmod_filename, prmtop_filename, inpcrd_filename)
-
-    file_handle = tempfile.NamedTemporaryFile('w')  # FYI Py3K defaults to 'wb' mode, which won't work here.
-    file_handle.writelines(tleap_input)
-    file_handle.flush()
-
-    cmd = "tleap -f %s " % file_handle.name
-    logger.debug(cmd)
-
-    output = getoutput(cmd)
-    logger.debug(output)
-
-    file_handle.close()
-
-    return prmtop_filename, inpcrd_filename
+def run_tleap(*args, **kwargs):
+    print("Warning: run_tleap has been moved to openmoltools.amber.")
+    return amber.run_tleap(*args, **kwargs)
 
 def convert_via_acpype( molecule_name, in_prmtop, in_crd, out_top = None, out_gro = None, debug = False, is_sorted = False ):
     """Use acpype.py (Sousa Da Silva et al., BMC Research Notes 5:367 (2012)) to convert AMBER prmtop and crd files to GROMACS format using amb2gmx mode. Writes to GROMACS 4.5 (and later) format, rather than the format for earlier GROMACS versions.
@@ -396,7 +262,7 @@ def test_molecule(molecule_name, tripos_mol2_filename, charge_method="bcc"):
     """
 
     # Generate GAFF parameters.
-    (gaff_mol2_filename, frcmod_filename) = run_antechamber(molecule_name, tripos_mol2_filename, charge_method=charge_method)
+    (gaff_mol2_filename, frcmod_filename) = amber.run_antechamber(molecule_name, tripos_mol2_filename, charge_method=charge_method)
 
     # Create simulations.
     simulation_ffxml = create_ffxml_simulation(molecule_name, gaff_mol2_filename, frcmod_filename)
@@ -479,7 +345,7 @@ def smiles_to_mdtraj_ffxml(smiles_strings, base_molecule_name="lig"):
         convert_molecule(pdb_filename, mol2_filename)  # This is necessary because PDB double bonds are not handled by antechamber...
         print(mol2_filename)
 
-        gaff_mol2_filename, frcmod_filename = run_antechamber(molecule_name, mol2_filename)
+        gaff_mol2_filename, frcmod_filename = amber.run_antechamber(molecule_name, mol2_filename)
         traj = md.load(gaff_mol2_filename)
         print(gaff_mol2_filename)
         print(traj)


### PR DESCRIPTION
Attempting to handle #94 and #102 - moving AMBER functionality from `utils` to `amber` (leaving skeleton function calls in place for backwards compatibility) while also adding some processing of AMBER `tleap` and `antechamber` outputs to look for obvious errors, eliminating some silent failures.

Also at the same time added checking of tleap-input filenames for spaces, which result in failures as tleap  can't handle filenames containing spaces. 