### PR TITLE
Changed conda package recipe name to openmoltools-dev

### DIFF
--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -1,5 +1,5 @@
 package:
-  name: openmoltools
+  name: openmoltools-dev
   version: !!str dev
 
 #source:
@@ -17,7 +17,7 @@ requirements:
     - mdtraj
     - numpy
     - scipy
-    - pandas    
+    - pandas
     - openmm-dev
     - ambermini
     - pytables


### PR DESCRIPTION
This fixes the inability of travis-ci to upload `openmoltools-dev` packages to binstar.

See https://github.com/omnia-md/conda-recipes/pull/226#issuecomment-112937973