### PR TITLE
Adjusting several functions in the amber module to remove AMBER- and GROMACS- imposed limitations on filenames

### DIFF
--- a/openmoltools/amber.py
+++ b/openmoltools/amber.py
@@ -48,7 +48,7 @@ def build_mixture_prmtop(mol2_filenames, frcmod_filenames, box_filename, prmtop_
     ----------
     mol2_filenames : list(str)
         Filenames of GAFF flavored mol2 files.  Each must contain exactly
-        ONE ligand. Filenames cannot contain spaces (tleap limitation)
+        ONE ligand. 
     frcmod_filenames : str
         Filename of input GAFF frcmod filenames.
     box_filename : str

--- a/openmoltools/amber.py
+++ b/openmoltools/amber.py
@@ -2,6 +2,7 @@ import mdtraj as md
 import tempfile
 import logging
 import os
+import shutil
 from distutils.spawn import find_executable
 from mdtraj.utils.delay_import import import_
 
@@ -255,7 +256,7 @@ def run_antechamber(molecule_name, input_filename, charge_method="bcc", net_char
     #Use temporary directory to do this to avoid issues with spaces in filenames, etc.
     tempdir = tempfile.mkdtemp()
     startdir = os.getcwd()
-    shutil.copy( input_filename, os.path.join( tempfile, 'in.mol2') )
+    shutil.copy( input_filename, os.path.join( tempdir, 'in.mol2') )
     os.chdir( tempdir )
 
     cmd = "antechamber -i in.mol2 -fi mol2 -o out.mol2 -fo mol2 -s 2" 

--- a/openmoltools/amber.py
+++ b/openmoltools/amber.py
@@ -329,7 +329,7 @@ source leaprc.gaff
 LIG = loadmol2 file.mol2
 check LIG
 loadamberparams file.frcmod
-saveamberparm LIG out.prmtop out.inpcrd %s
+saveamberparm LIG out.prmtop out.inpcrd 
 quit
 
 """ 

--- a/openmoltools/gromacs.py
+++ b/openmoltools/gromacs.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 import logging
+import mdtraj.utils
 from distutils.spawn import find_executable
 try:
     from subprocess import getoutput  # If python 3
@@ -267,8 +268,8 @@ def do_solvate( top_filename, gro_filename, top_solv_filename, gro_solv_filename
 
     return
 
-    def ensure_forcefield( intop, outtop, FF = 'ffamber99sb-ildn.ff'):
-        """Open a topology file, and check to ensure that includes the desired forcefield itp file. If not, remove any [ defaults ] section (which will be provided by the FF) and include the forcefield itp. Useful when working with files set up by acpypi -- these need to have a water model included in order to work, and most water models require a force field included in order for them to work.
+def ensure_forcefield( intop, outtop, FF = 'ffamber99sb-ildn.ff'):
+    """Open a topology file, and check to ensure that includes the desired forcefield itp file. If not, remove any [ defaults ] section (which will be provided by the FF) and include the forcefield itp. Useful when working with files set up by acpypi -- these need to have a water model included in order to work, and most water models require a force field included in order for them to work.
             
             ARGUMENTS:
             - intop: Input topology
@@ -278,7 +279,7 @@ def do_solvate( top_filename, gro_filename, top_solv_filename, gro_solv_filename
         
         Limitations:
         - If you use this on a topology file that already includes a DIFFERENT forcefield, the result will be a topology file including two forcefields.
-        """
+    """
     
     file = open(intop, 'r')
     text= file.readlines()

--- a/openmoltools/gromacs.py
+++ b/openmoltools/gromacs.py
@@ -208,59 +208,71 @@ def do_solvate( top_filename, gro_filename, top_solv_filename, gro_solv_filename
     os.environ['GMX_MAXBACKUP'] = '-1' # Avoids unnecessary GROMACS backup files
     os.environ['GMX_NO_QUOTES'] = '1' # Supresses end-of-file quotes (gcq)
 
-    #copies topology file to new directory
-    shutil.copyfile(top_filename, top_solv_filename) 
+    #Get absolute paths for input/output
+    top_filename = os.path.abspath( top_filename )
+    gro_filename = os.path.abspath( gro_filename )
+    top_solv_filename = os.path.abspath( top_solv_filename )
+    gro_solv_filename = os.path.abspath( gro_solv_filename )
 
-    #string with the Gromacs 5.0.4 box generating commands
-    cmdbox = 'gmx editconf -f %s -o %s -c -d %.2f -bt %s' % (gro_filename, gro_solv_filename, box_dim, box_type)
-    output = getoutput(cmdbox)
-    logger.debug(output)
-    check_for_errors(output)
+    with mdtraj.utils.enter_temp_directory(): #Work on hard coded filenames in temporary directory
 
-    #string with the Gromacs 5.0.4 solvation tool (it is not genbox anymore)
-    cmdsolv = 'gmx solvate -cp %s -cs %s -o %s -p %s' % (gro_solv_filename, water_model, gro_solv_filename, top_solv_filename)
-    output = getoutput(cmdsolv)
-    logger.debug(output)
-    check_for_errors(output)
+        shutil.copy( gro_filename, 'in.gro' )
+        shutil.copy( top_filename, 'out.top' )
 
-    #Insert Force Field specifications
-    ensure_forcefield( top_solv_filename, top_solv_filename, FF = FF)
+        #string with the Gromacs 5.0.4 box generating commands
+        cmdbox = 'gmx editconf -f in.gro -o out.gro -c -d %.2f -bt %s' % ( box_dim, box_type)
+        output = getoutput(cmdbox)
+        logger.debug(output)
+        check_for_errors(output)
 
-    #Insert line for water topology portion of the code
-    try:
-        file = open(top_solv_filename,'r')
-        text = file.readlines()
-        file.close()
-    except:
-        raise NameError('The file %s is missing' % top_solv_filename)
+        #string with the Gromacs 5.0.4 solvation tool (it is not genbox anymore)
+        cmdsolv = 'gmx solvate -cp out.gro -cs %s -o out.gro -p out.top' % (water_model)
+        output = getoutput(cmdsolv)
+        logger.debug(output)
+        check_for_errors(output)
 
-    #Insert water model
-    wateritp = os.path.join(FF, water_top ) # e.g water_top = 'tip3p.itp'
-    index = 0
-    while '[ system ]' not in text[index]:
-        index += 1
-    text[index] = '#include "%s"\n\n' % wateritp + text[index]
+        #Insert Force Field specifications
+        ensure_forcefield( 'out.top', 'out.top', FF = FF)
 
-    #Write the topology file
-    try:
-        file = open(top_solv_filename,'w+')
-        file.writelines( text )
-        file.close()
-    except:
-        raise NameError('The file %s is missing' % top_solv_filename)
+        #Insert line for water topology portion of the code
+        try:
+            file = open('out.top','r')
+            text = file.readlines()
+            file.close()
+        except:
+            raise NameError('The file out.top is missing' )
 
-    #Check if file exist and is not empty;
-    if os.stat( gro_solv_filename ) == 0 or os.stat( top_solv_filename ).st_size == 0:
-        raise(ValueError("Solvent insertion failed"))
+        #Insert water model
+        wateritp = os.path.join(FF, water_top ) # e.g water_top = 'tip3p.itp'
+        index = 0
+        while '[ system ]' not in text[index]:
+            index += 1
+        text[index] = '#include "%s"\n\n' % wateritp + text[index]
+
+        #Write the topology file
+        try:
+            file = open('out.top','w+')
+            file.writelines( text )
+            file.close()
+        except:
+            raise NameError('The file %s is missing' % 'out.top')
+
+        #Check if file exist and is not empty;
+        if os.stat( 'out.gro' ) == 0 or os.stat( 'out.top' ).st_size == 0:
+            raise(ValueError("Solvent insertion failed"))
+
+        #Copy back files
+        shutil.copy( 'out.gro', gro_solv_filename )
+        shutil.copy( 'out.top', top_solv_filename )
 
     return
 
-def ensure_forcefield( intop, outtop, FF = 'ffamber99sb-ildn.ff'):
-    """Open a topology file, and check to ensure that includes the desired forcefield itp file. If not, remove any [ defaults ] section (which will be provided by the FF) and include the forcefield itp. Useful when working with files set up by acpypi -- these need to have a water model included in order to work, and most water models require a force field included in order for them to work.
-        
-        ARGUMENTS:
-        - intop: Input topology
-        - outtop: Output topology
+    def ensure_forcefield( intop, outtop, FF = 'ffamber99sb-ildn.ff'):
+        """Open a topology file, and check to ensure that includes the desired forcefield itp file. If not, remove any [ defaults ] section (which will be provided by the FF) and include the forcefield itp. Useful when working with files set up by acpypi -- these need to have a water model included in order to work, and most water models require a force field included in order for them to work.
+            
+            ARGUMENTS:
+            - intop: Input topology
+            - outtop: Output topology
         OPTIONAL:
         - FF: String corresponding to desired force field; default ffamber99sb.-ildn.ff
         

--- a/openmoltools/tests/test_amber.py
+++ b/openmoltools/tests/test_amber.py
@@ -75,7 +75,7 @@ def test_run_tleap():
     input_filename = utils.get_data_filename("chemicals/sustiva/sustiva.mol2")
     with utils.enter_temp_directory():  # Prevents creating tons of GAFF files everywhere.
         gaff_mol2_filename, frcmod_filename = amber.run_antechamber(molecule_name, input_filename, charge_method=None)
-        prmtop, inpcrd = utils.run_tleap(molecule_name, gaff_mol2_filename, frcmod_filename)
+        prmtop, inpcrd = amber.run_tleap(molecule_name, gaff_mol2_filename, frcmod_filename)
 
 def test_run_antechamber_charges():
     molecule_name = "acetate"

--- a/openmoltools/tests/test_amber.py
+++ b/openmoltools/tests/test_amber.py
@@ -19,7 +19,7 @@ def test_amber_box():
         box_trj = packmol.pack_box(trj_list, [50])
         box_trj.save(box_filename)
     
-        gaff_mol2_filename1, frcmod_filename1 = utils.run_antechamber("etoh", etoh_filename, charge_method=None)
+        gaff_mol2_filename1, frcmod_filename1 = amber.run_antechamber("etoh", etoh_filename, charge_method=None)
         
         mol2_filenames = [gaff_mol2_filename1]
         frcmod_filenames =  [frcmod_filename1]
@@ -50,8 +50,8 @@ def test_amber_binary_mixture():
         box_trj = packmol.pack_box(trj_list, [25, 50])
         box_trj.save(box_filename)
         
-        gaff_mol2_filename0, frcmod_filename0 = utils.run_antechamber("sustiva", sustiva_filename, charge_method=None)
-        gaff_mol2_filename1, frcmod_filename1 = utils.run_antechamber("etoh", etoh_filename, charge_method=None)
+        gaff_mol2_filename0, frcmod_filename0 = amber.run_antechamber("sustiva", sustiva_filename, charge_method=None)
+        gaff_mol2_filename1, frcmod_filename1 = amber.run_antechamber("etoh", etoh_filename, charge_method=None)
         
         mol2_filenames = [gaff_mol2_filename0, gaff_mol2_filename1]
         frcmod_filenames = [frcmod_filename0, frcmod_filename1]

--- a/openmoltools/tests/test_utils.py
+++ b/openmoltools/tests/test_utils.py
@@ -4,6 +4,7 @@ from unittest import skipIf
 import logging
 from mdtraj.testing import eq
 from openmoltools import utils
+from openmoltools import amber
 import simtk.unit as u
 from simtk.openmm import app
 import simtk.openmm as mm
@@ -50,7 +51,7 @@ def test_acpype_conversion():
     input_filename = utils.get_data_filename("chemicals/sustiva/sustiva.mol2")
     with utils.enter_temp_directory(): # Prevents creating tons of GAFF files everywhere.
         gaff_mol2_filename, frcmod_filename = amber.run_antechamber(molecule_name, input_filename, charge_method=None)
-        prmtop, inpcrd = utils.run_tleap(molecule_name, gaff_mol2_filename, frcmod_filename)
+        prmtop, inpcrd = amber.run_tleap(molecule_name, gaff_mol2_filename, frcmod_filename)
         out_top, out_gro = utils.convert_via_acpype( molecule_name, prmtop, inpcrd ) 
 
 def test_parmed_conversion():
@@ -59,7 +60,7 @@ def test_parmed_conversion():
     with utils.enter_temp_directory(): # Prevents creating tons of GAFF files everywhere.
         #Make sure conversion runs
         gaff_mol2_filename, frcmod_filename = amber.run_antechamber(molecule_name, input_filename, charge_method=None)
-        prmtop, inpcrd = utils.run_tleap(molecule_name, gaff_mol2_filename, frcmod_filename)
+        prmtop, inpcrd = amber.run_tleap(molecule_name, gaff_mol2_filename, frcmod_filename)
         out_top, out_gro = utils.amber_to_gromacs( molecule_name, prmtop, inpcrd, precision = 8 ) 
 
         #Test energies before and after conversion

--- a/openmoltools/tests/test_utils.py
+++ b/openmoltools/tests/test_utils.py
@@ -49,7 +49,7 @@ def test_acpype_conversion():
     molecule_name = 'sustiva'
     input_filename = utils.get_data_filename("chemicals/sustiva/sustiva.mol2")
     with utils.enter_temp_directory(): # Prevents creating tons of GAFF files everywhere.
-        gaff_mol2_filename, frcmod_filename = utils.run_antechamber(molecule_name, input_filename, charge_method=None)
+        gaff_mol2_filename, frcmod_filename = amber.run_antechamber(molecule_name, input_filename, charge_method=None)
         prmtop, inpcrd = utils.run_tleap(molecule_name, gaff_mol2_filename, frcmod_filename)
         out_top, out_gro = utils.convert_via_acpype( molecule_name, prmtop, inpcrd ) 
 
@@ -58,7 +58,7 @@ def test_parmed_conversion():
     input_filename = utils.get_data_filename("chemicals/sustiva/sustiva.mol2")
     with utils.enter_temp_directory(): # Prevents creating tons of GAFF files everywhere.
         #Make sure conversion runs
-        gaff_mol2_filename, frcmod_filename = utils.run_antechamber(molecule_name, input_filename, charge_method=None)
+        gaff_mol2_filename, frcmod_filename = amber.run_antechamber(molecule_name, input_filename, charge_method=None)
         prmtop, inpcrd = utils.run_tleap(molecule_name, gaff_mol2_filename, frcmod_filename)
         out_top, out_gro = utils.amber_to_gromacs( molecule_name, prmtop, inpcrd, precision = 8 ) 
 


### PR DESCRIPTION
Revised a number of functions in the `amber` module to remove AMBER (`tleap`/`teleap` and `antechamber`)-imposed limitations on characters which were allowed in filenames - formerly no spaces were allowed in filenames. Now work involving antechamber or tleap is done in a temporary directory with hard-coded filenames, and results are copied to/from user-specified filenames, so that now anything which is a valid filename ought to be correctly handled.

Updates were in particular (in `openmoltools.amber`) to:
* run_tleap
* build_mixture_prmtop
* run_antechamber

At the same time I also made a couple of minor fixes to the tests (specifically, amber modules from `utils` were still being used (resulting in a warning and a call to the correct version) rather than the correct versions from `amber`).