### PR TITLE
Fix bug normalization molecule from SMILES to OEMol.

### DIFF
--- a/openmoltools/openeye.py
+++ b/openmoltools/openeye.py
@@ -150,7 +150,7 @@ def smiles_to_oemol(smiles):
     if not oechem.OEParseSmiles(molecule, smiles):
         raise ValueError("The supplied SMILES '%s' could not be parsed." % smiles)
 
-    normalize_molecule(molecule)
+    molecule = normalize_molecule(molecule)
 
     return molecule
 


### PR DESCRIPTION
The function normalize_molecule(mol) returns a copy of mol, but this is not used in smiles_to_oemol().