### PR TITLE
Updating meta.yaml to make build and run requirements match (#128)

### DIFF
--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -13,11 +13,13 @@ requirements:
   build:
     - python
     - setuptools
+    - pandas
+    - six
     - mdtraj
     - numpy
+    - numpydoc
     - scipy
-    - pandas
-    - openmm-dev
+    - openmm
     - ambermini
     - pytables
     - parmed
@@ -28,9 +30,10 @@ requirements:
     - pandas
     - six
     - mdtraj
+    - numpy
     - numpydoc
     - scipy
-    - openmm-dev
+    - openmm
     - ambermini
     - pytables
     - parmed


### PR DESCRIPTION
Resolve #128 by making build and run requirements match (though I've not exhaustively checked all of these requirements); also (more importantly) now require openmm rather than openmm-dev. Previously we required openmm-dev as for a while we required features in openmm 6.3 which was not released yet. Now that it is out, it's reasonable to go back to the stable version as a requirement. 

Once this (or any updates/corrections) are merged we should release a new openmoltools version, as the water functionality incorporated by #142 is significant enough for a new point release (as is #147 and possibly others). This will also make it easier for people in my group using the conda install.