### PR TITLE
Implementing generation of ffxml files for multiple molecules

### DIFF
--- a/openmoltools/forcefield_generators.py
+++ b/openmoltools/forcefield_generators.py
@@ -256,9 +256,10 @@ def generateResidueTemplate(molecule, residue_atoms=None):
     # Create temporary directory for running antechamber.
     import tempfile
     tmpdir = tempfile.mkdtemp()
-    input_mol2_filename = os.path.join(tmpdir, template_name + '.tripos.mol2')
-    gaff_mol2_filename = os.path.join(tmpdir, template_name + '.gaff.mol2')
-    frcmod_filename = os.path.join(tmpdir, template_name + '.frcmod')
+    prefix = 'molecule'
+    input_mol2_filename = os.path.join(tmpdir, prefix + '.tripos.mol2')
+    gaff_mol2_filename = os.path.join(tmpdir, prefix + '.gaff.mol2')
+    frcmod_filename = os.path.join(tmpdir, prefix + '.frcmod')
 
     # Write Tripos mol2 file as antechamber input.
     _writeMolecule(molecule, input_mol2_filename)
@@ -311,7 +312,7 @@ def generateResidueTemplate(molecule, residue_atoms=None):
             template.addExternalBondByName(bond.GetEnd().GetName())
 
     # Generate ffxml file contents for parmchk-generated frcmod output.
-    leaprc = StringIO("parm = loadamberparams %s" % frcmod_filename)
+    leaprc = StringIO('parm = loadamberparams %s' % frcmod_filename)
     params = parmed.amber.AmberParameterSet.from_leaprc(leaprc)
     params = parmed.openmm.OpenMMParameterSet.from_parameterset(params)
     ffxml = StringIO()

--- a/openmoltools/forcefield_generators.py
+++ b/openmoltools/forcefield_generators.py
@@ -150,6 +150,67 @@ def generateOEMolFromTopologyResidue(residue):
 
     return molecule
 
+def _ensureUniqueAtomNames(molecule):
+    """
+    Ensure all atom names are unique and not blank.
+    If any atom names are degenerate or blank, Tripos atom names are assigned to all atoms.
+
+    Parameters
+    ----------
+    molecule : openeye.oechem.OEMol
+        The molecule to be modified
+
+    """
+    from openeye import oechem
+    atom_names = set()
+    atom_names_are_unique = True
+    for atom in molecule.GetAtoms():
+        atom_name = atom.GetName()
+        if (atom_name in atom_names) or (atom_name == ""):
+            atom_names_are_unique = False
+        atom_names.add(atom_name)
+    if not atom_names_are_unique:
+        oechem.OETriposAtomNames(molecule)
+
+def _computeNetCharge(molecule):
+    """
+    Compute the net formal charge on the molecule.
+    Formal charges are assigned by this function.
+
+    Parameters
+    ----------
+    molecule : openeye.oechem.OEMol
+        The molecule for which a net formal charge is to be computed
+
+    Returns
+    -------
+    net_charge : float
+        The net formal charge on the molecule
+
+    """
+    from openeye import oechem
+    oechem.OEAssignFormalCharges(molecule)
+    charges = [ atom.GetFormalCharge() for atom in molecule.GetAtoms() ]
+    net_charge = np.array(charges).sum()
+    return net_charge
+
+def _writeMolecule(molecule, output_filename):
+    """
+    Write the molecule to a file.
+
+    Parameters
+    ----------
+    molecule : openeye.oechem.OEMol
+        The molecule to write (will be modified by writer).
+    output_filename : str
+        The filename of file to be written; type is autodetected by extension.
+
+    """
+    from openeye import oechem
+    ofs = oechem.oemolostream(output_filename)
+    oechem.OEWriteMolecule(ofs, molecule)
+    ofs.close()
+
 def generateResidueTemplate(molecule, residue_atoms=None):
     """
     Generate an residue template for simtk.openmm.app.ForceField using GAFF/AM1-BCC.
@@ -161,7 +222,8 @@ def generateResidueTemplate(molecule, residue_atoms=None):
     molecule : openeye.oechem.OEMol
         The molecule to be parameterized.
         The molecule must have explicit hydrogens.
-        Charge will be inferred from the net formal charge.
+        Net charge will be inferred from the net formal charge on each molecule.
+        Partial charges will be determined automatically using oequacpac and canonical AM1-BCC charging rules.
     residue_atomset : set of OEAtom, optional, default=None
         If not None, only the atoms in this set will be used to construct the residue template
 
@@ -172,20 +234,21 @@ def generateResidueTemplate(molecule, residue_atoms=None):
     additional_parameters_ffxml : str
         Contents of ForceField `ffxml` file defining additional parameters from parmchk(2).
 
-    Note that this method preserves stereochemistry during AM1-BCC charge parameterization.
+    Notes
+    -----
+    The residue template will be named after the molecule title.
+    This method preserves stereochemistry during AM1-BCC charge parameterization.
+    Atom names in molecules will be assigned Tripos atom names if any are blank or not unique.
 
     """
-    # Generate a unique residue template name to avoid namespace collisions.
-    # TODO: Can we come up with a more intelligent name?
-    #from uuid import uuid4
-    #template_name = str(uuid4())
+    # Set the template name based on the molecule title.
     template_name = molecule.GetTitle()
 
+    # If any atom names are not unique, atom names
+    _ensureUniqueAtomNames(molecule)
+
     # Compute net formal charge.
-    from openeye import oechem
-    oechem.OEAssignFormalCharges(molecule)
-    charges = [ atom.GetFormalCharge() for atom in molecule.GetAtoms() ]
-    net_charge = np.array(charges).sum()
+    net_charge = _computeNetCharge(molecule)
 
     # Generate canonical AM1-BCC charges and a reference conformation.
     molecule = get_charges(molecule, strictStereo=False, keep_confs=1)
@@ -198,14 +261,13 @@ def generateResidueTemplate(molecule, residue_atoms=None):
     frcmod_filename = os.path.join(tmpdir, template_name + '.frcmod')
 
     # Write Tripos mol2 file as antechamber input.
-    ofs = oechem.oemolostream(input_mol2_filename)
-    oechem.OEWriteMolecule(ofs, molecule)
-    ofs.close()
+    _writeMolecule(molecule, input_mol2_filename)
 
     # Parameterize the molecule with antechamber.
     run_antechamber(template_name, input_mol2_filename, charge_method=None, net_charge=net_charge, gaff_mol2_filename=gaff_mol2_filename, frcmod_filename=frcmod_filename)
 
     # Read the resulting GAFF mol2 file as a ParmEd structure.
+    from openeye import oechem
     ifs = oechem.oemolistream(gaff_mol2_filename)
     ifs.SetFlavor(oechem.OEFormat_MOL2, oechem.OEIFlavor_MOL2_DEFAULT | oechem.OEIFlavor_MOL2_M2H | oechem.OEIFlavor_MOL2_Forcefield)
     m2h = True
@@ -256,6 +318,90 @@ def generateResidueTemplate(molecule, residue_atoms=None):
     params.write(ffxml)
 
     return template, ffxml.getvalue()
+
+def generateForceFieldFromMolecules(molecules):
+    """
+    Generate ffxml file containing additional parameters and residue templates for simtk.openmm.app.ForceField using GAFF/AM1-BCC.
+
+    This requires the OpenEye toolkit.
+
+    Parameters
+    ----------
+    molecules : list of openeye.oechem.OEMol
+        The molecules to be parameterized.
+        All molecules must have explicit hydrogens.
+        Net charge will be inferred from the net formal charge on each molecule.
+        Partial charges will be determined automatically using oequacpac and canonical AM1-BCC charging rules.
+
+    Returns
+    -------
+    ffxml : str
+        Contents of ForceField `ffxml` file defining additional parameters from parmchk(2) and residue templates.
+
+    Notes
+    -----
+    This method preserves stereochemistry during AM1-BCC charge parameterization.
+    Residue template names will be set from molecule names.
+    Atom names in molecules will be assigned Tripos atom names if any are blank or not unique.
+
+    """
+    # Check template names are unique.
+    template_names = set()
+    for molecule in molecules:
+        template_name = molecule.GetTitle()
+        if template_name in template_names:
+            raise Exception("Molecule '%s' has template name collision." % template_name)
+        template_names.add(template_name)
+
+    # Process molecules.
+    import tempfile
+    tmpdir = tempfile.mkdtemp()
+    olddir = os.getcwd()
+    os.chdir(tmpdir)
+    leaprc = ""
+    for (molecule_index, molecule) in enumerate(molecules):
+        # Set the template name based on the molecule title.
+        template_name = molecule.GetTitle()
+
+        # If any atom names are not unique, atom names
+        _ensureUniqueAtomNames(molecule)
+
+        # Compute net formal charge.
+        net_charge = _computeNetCharge(molecule)
+
+        # Generate canonical AM1-BCC charges and a reference conformation.
+        molecule = get_charges(molecule, strictStereo=False, keep_confs=1)
+
+        # Create a unique prefix.
+        prefix = 'molecule-%010d' % molecule_index
+
+        # Create temporary directory for running antechamber.
+        input_mol2_filename = prefix + '.tripos.mol2'
+        gaff_mol2_filename  = prefix + '.gaff.mol2'
+        frcmod_filename     = prefix + '.frcmod'
+
+        # Write Tripos mol2 file as antechamber input.
+        _writeMolecule(molecule, input_mol2_filename)
+
+        # Parameterize the molecule with antechamber.
+        run_antechamber(template_name, input_mol2_filename, charge_method=None, net_charge=net_charge, gaff_mol2_filename=gaff_mol2_filename, frcmod_filename=frcmod_filename)
+
+        # Append to leaprc input for parmed.
+        leaprc += '%s = loadmol2 %s\n' % (template_name, gaff_mol2_filename)
+        leaprc += 'loadamberparams %s\n' % frcmod_filename
+
+    # Generate ffxml file contents for parmchk-generated frcmod output.
+    print(leaprc) # DEBUG
+    leaprc = StringIO(leaprc)
+    params = parmed.amber.AmberParameterSet.from_leaprc(leaprc)
+    params = parmed.openmm.OpenMMParameterSet.from_parameterset(params)
+    ffxml = StringIO()
+    params.write(ffxml)
+
+    # TODO: Clean up temporary directory.
+    os.chdir(olddir)
+
+    return ffxml.getvalue()
 
 def createStructureFromResidue(residue):
     # Create ParmEd structure for residue.

--- a/openmoltools/parameters/gaff.xml
+++ b/openmoltools/parameters/gaff.xml
@@ -1,10 +1,8 @@
 <ForceField>
  <Info>
-  <DateGenerated>2016-01-26</DateGenerated>
-  <Reference>Wang, J., Wang, W., Kollman P. A.; Case, D. A. "Automatic atom type and bond type perception in molecular mechanical calculations". Journal of Molecular Graphics and Modelling , 25, 2006, 247260.
-Wang, J., Wolf, R. M.; Caldwell, J. W.;Kollman, P. A.; Case, D. A. "Development and testing of a general AMBER force field". Journal of Computational Chemistry, 25, 2004, 1157-1174.
-</Reference>
-  <OriginalFile>gaff.dat</OriginalFile>
+  <DateGenerated>2016-02-20</DateGenerated>
+  <Source md5hash="1ec3413c17124b03b76884d9d3322845" sourcePackage="AmberTools" sourcePackageVersion="15">leaprc.gaff</Source>
+  <Reference>Wang, J., Wolf, R.M., Caldwell, J.W., Kollman, P.A., and Case, D.A. (2004). Development and testing of a general amber force field. J. Comput. Chem. 25, 1157-1174.</Reference>
  </Info>
  <AtomTypes>
   <Type name="c" class="c" element="C" mass="12.01"/>
@@ -79,8 +77,6 @@ Wang, J., Wolf, R. M.; Caldwell, J. W.;Kollman, P. A.; Case, D. A. "Development 
   <Type name="sx" class="sx" element="S" mass="32.06"/>
   <Type name="sy" class="sy" element="S" mass="32.06"/>
  </AtomTypes>
- <Residues>
- </Residues>
  <HarmonicBondForce>
   <Bond type1="ow" type2="hw" length="0.09572" k="462750.4"/>
   <Bond type1="hw" type2="hw" length="0.15136" k="462750.4"/>

--- a/openmoltools/tests/test_forcefield_generators.py
+++ b/openmoltools/tests/test_forcefield_generators.py
@@ -27,7 +27,7 @@ except Exception as e:
     HAVE_OE = False
     openeye_exception_message = str(e)
 
-IUPAC_molecule_names = ['naproxen', 'aspirin', 'imatinib', 'bosutinib']
+IUPAC_molecule_names = ['naproxen', 'aspirin', 'imatinib', 'bosutinib', 'dibenzyl ketone']
 def createOEMolFromIUPAC(iupac_name='bosutinib'):
     from openeye import oechem, oeiupac, oeomega
 
@@ -119,9 +119,9 @@ def test_generate_ffxml_from_molecules():
     # Create an ffxml file.
     from openmoltools.forcefield_generators import generateForceFieldFromMolecules
     ffxml = generateForceFieldFromMolecules(molecules)
-    print(ffxml)
     # Create a ForceField.
-    forcefield = ForceField('gaff.xml')
+    gaff_xml_filename = utils.get_data_filename("parameters/gaff.xml")
+    forcefield = ForceField(gaff_xml_filename)
     forcefield.loadFile(StringIO(ffxml))
     # Parameterize the molecules.
     from openmoltools.forcefield_generators import generateTopologyFromOEMol
@@ -175,6 +175,9 @@ def test_generateResidueTemplate():
     """
     from openeye import oechem, oeiupac
 
+    from pkg_resources import resource_filename
+    gaff_xml_filename = utils.get_data_filename("parameters/gaff.xml")
+
     # Test independent ForceField instances.
     for molecule_name in IUPAC_molecule_names:
         mol = createOEMolFromIUPAC(molecule_name)
@@ -182,7 +185,7 @@ def test_generateResidueTemplate():
         from openmoltools.forcefield_generators import generateResidueTemplate
         [template, ffxml] = generateResidueTemplate(mol)
         # Create a ForceField object.
-        forcefield = ForceField('gaff.xml')
+        forcefield = ForceField(gaff_xml_filename)
         # Add the additional parameters and template to the forcefield.
         forcefield.registerResidueTemplate(template)
         forcefield.loadFile(StringIO(ffxml))
@@ -196,7 +199,7 @@ def test_generateResidueTemplate():
         check_potential_is_finite(system, positions)
 
     # Test adding multiple molecules to a single ForceField instance.
-    forcefield = ForceField('gaff.xml')
+    forcefield = ForceField(gaff_xml_filename)
     for molecule_name in IUPAC_molecule_names:
         mol = createOEMolFromIUPAC(molecule_name)
         # Generate an ffxml residue template.
@@ -256,7 +259,8 @@ def test_gaffResidueTemplateGenerator():
     pdb_filename = utils.get_data_filename("chemicals/imatinib/imatinib.pdb")
     pdb = PDBFile(pdb_filename)
     # Create a ForceField object.
-    forcefield = ForceField('gaff.xml')
+    gaff_xml_filename = utils.get_data_filename("parameters/gaff.xml")
+    forcefield = ForceField(gaff_xml_filename)
     # Add the residue template generator.
     from openmoltools.forcefield_generators import gaffTemplateGenerator
     forcefield.registerTemplateGenerator(gaffTemplateGenerator)
@@ -279,7 +283,8 @@ def test_gaffResidueTemplateGenerator():
     pdb_filename = utils.get_data_filename("chemicals/proteins/T4-lysozyme-L99A-p-xylene-implicit.pdb")
     pdb = PDBFile(pdb_filename)
     # Create a ForceField object.
-    forcefield = ForceField('amber99sb.xml', 'gaff.xml')
+    gaff_xml_filename = utils.get_data_filename("parameters/gaff.xml")
+    forcefield = ForceField('amber99sb.xml', gaff_xml_filename)
     # Add the residue template generator.
     from openmoltools.forcefield_generators import gaffTemplateGenerator
     forcefield.registerTemplateGenerator(gaffTemplateGenerator)


### PR DESCRIPTION
* Implement #187.
* Also fixes #189, except that atom names are replaced with Tripos atom names rather than throwing an exception.

This doesn't work yet because mol2 files are not processed as residues by `parmed`:
https://github.com/ParmEd/ParmEd/issues/592