### PR TITLE
Schrodinger suite wrapper functions and removed logging configuration

### DIFF
--- a/openmoltools/amber.py
+++ b/openmoltools/amber.py
@@ -10,7 +10,6 @@ import mdtraj.utils
 from openmoltools.utils import getoutput
 
 logger = logging.getLogger(__name__)
-logging.basicConfig(level=logging.DEBUG, format="LOG: %(message)s")
 
 
 # http://ambermd.org/tutorials/advanced/tutorial15/Tutorial2.xhtml

--- a/openmoltools/gromacs.py
+++ b/openmoltools/gromacs.py
@@ -8,7 +8,6 @@ import parmed
 from openmoltools.utils import getoutput
 
 logger = logging.getLogger(__name__)
-logging.basicConfig(level=logging.DEBUG, format="LOG: %(message)s")
 
 GROMACS_PATH = find_executable('gmx')
 

--- a/openmoltools/openeye.py
+++ b/openmoltools/openeye.py
@@ -6,7 +6,6 @@ from openmoltools.amber import run_antechamber
 import logging
 
 logger = logging.getLogger(__name__)
-logging.basicConfig(level=logging.DEBUG, format="LOG: %(message)s")
 
 
 # Note: We recommend having every function return *copies* of input, to avoid headaches associated with in-place changes

--- a/openmoltools/schrodinger.py
+++ b/openmoltools/schrodinger.py
@@ -165,7 +165,6 @@ def run_structconvert(input_file_path, output_file_path):
     run_and_log_error(cmd)
 
 
-@need_schrodinger
 def autoconvert_maestro(func):
     @wraps(func)
     def _autoconvert_maestro(input_file_path, output_file_path, *args, **kwargs):
@@ -227,6 +226,7 @@ def autoconvert_maestro(func):
     return _autoconvert_maestro
 
 
+@need_schrodinger
 @autoconvert_maestro
 def run_maesubset(input_file_path, output_file_path, range):
     """Run Schrodinger's maesubset command line utility to extract a range of
@@ -266,6 +266,7 @@ def run_maesubset(input_file_path, output_file_path, range):
         f.write(output)
 
 
+@need_schrodinger
 @autoconvert_maestro
 def run_epik(input_file_path, output_file_path, max_structures=32, ph=7.4,
              ph_tolerance=None, tautomerize=True, extract_range=None):

--- a/openmoltools/schrodinger.py
+++ b/openmoltools/schrodinger.py
@@ -1,0 +1,327 @@
+#!/usr/bin/env python
+
+"""Miscellaneous wrapper functions to Schrodinger's computational chemistry tools."""
+
+import os
+import sys
+import csv
+import shutil
+import logging
+import subprocess
+from functools import wraps
+
+import mdtraj
+
+from openmoltools import utils
+
+logger = logging.getLogger(__name__)
+
+
+def run_and_log_error(command):
+    """Run the process specified by the command and log eventual errors.
+
+    Parameters
+    ----------
+    command : str
+        The command to be run.
+
+    Returns
+    -------
+    output : str
+        The output of the process.
+
+    Raises
+    ------
+    subprocess.CalledProcessError
+        In case the commands fails.
+
+    """
+    try:
+        output = subprocess.check_output(command)
+    except subprocess.CalledProcessError as e:
+        logger.error(e.output)
+        logger.error(str(e))
+        raise e
+    return output
+
+
+def is_schrodinger_suite_installed():
+    """Check that Schrodinger's suite is installed.
+
+    Currently only checks whether the environmental variable SCHRODINGER
+    is defined. This should contain the path to its main installation folder.
+
+    Returns
+    -------
+    bool
+        True if the Schrodinger's suite is found, False otherwise.
+
+    """
+    try:
+        os.environ['SCHRODINGER']
+    except KeyError:
+        return False
+    return True
+
+
+def need_schrodinger(func):
+    @wraps(func)
+    def _need_schrodinger(*args, **kwargs):
+        """Decorator that checks if the Schrodinger's suite is installed."""
+        if not is_schrodinger_suite_installed():
+            err_msg = "Cannot locate Schrodinger's suite!"
+            logger.error(err_msg)
+            raise RuntimeError(err_msg)
+        return func(*args, **kwargs)
+    return _need_schrodinger
+
+
+@need_schrodinger
+def run_proplister(input_file_path):
+    """Run proplister utility on a file and return its properties.
+
+    Parameters
+    ----------
+    input_file_path: str
+        The path to the file describing the molecule with its properties.
+
+    Returns
+    -------
+    properties: list of dict
+        A list containing a dictionary for each molecule in the input file
+        representing their properties. Each dictionary is in the format
+        property_name -> property_value.
+
+    """
+    proplister_path = os.path.join(os.environ['SCHRODINGER'], 'utilities', 'proplister')
+
+    # Normalize path
+    input_file_path = os.path.abspath(input_file_path)
+
+    # Run proplister, we need the list in case there are spaces in paths
+    cmd = [proplister_path, '-a', '-c', input_file_path]
+    output = run_and_log_error(cmd)
+
+    output = output.replace('\_', '_')  # Parse '\_' characters in names
+
+    # The output is a cvs file. The first line are the property names and then each row
+    # contains the values for each molecule. We use the csv module to avoid splitting
+    # strings that contain commas (e.g. "2,2-dimethylpropane").
+    properties = []
+    csv_reader = csv.reader(output.split('\n'))
+    names = csv_reader.next()
+    for values in csv_reader:
+        if len(values) == 0:
+            continue  # proplister prints a final empty line
+
+        # Convert raw strings into literals (e.g. convert '\\n' to '\n')
+        if sys.version_info < (3, 0):  # Python 2
+            converted_values = [v.decode('string_escape') for v in values]
+        else:  # Python 3 doesn't have decode on strings
+            converted_values = [bytes(v, "utf-8").decode("unicode_escape")
+                                for v in values]
+
+        properties.append(dict(zip(names, converted_values)))
+
+    return properties
+
+
+@need_schrodinger
+def run_structconvert(input_file_path, output_file_path):
+    """Run Schrodinger's structconvert command line utility to convert from one
+    format to another.
+
+    The input and output formats are inferred from the given files extensions.
+
+    Parameters
+    ----------
+    input_file_path : str
+        Path to the input file describing the molecule.
+    output_file_path : str
+        Path were the converted file will be saved.
+
+    """
+    formats_map = {'sdf': 'sd'}  # convert common extensions to format code
+
+    # Locate structconvert executable
+    structconvert_path = os.path.join(os.environ['SCHRODINGER'], 'utilities',
+                                      'structconvert')
+
+    # Normalize paths
+    input_file_path = os.path.abspath(input_file_path)
+    output_file_path = os.path.abspath(output_file_path)
+
+    # Determine input and output format
+    input_format = os.path.splitext(input_file_path)[1][1:]
+    output_format = os.path.splitext(output_file_path)[1][1:]
+    if input_format in formats_map:
+        input_format = formats_map[input_format]
+    if output_format in formats_map:
+        output_format = formats_map[output_format]
+
+    # Run structconvert, we need the list in case there are spaces in paths
+    cmd = [structconvert_path, '-i' + input_format, input_file_path,
+           '-o' + output_format, output_file_path]
+    run_and_log_error(cmd)
+
+
+@need_schrodinger
+def autoconvert_maestro(func):
+    @wraps(func)
+    def _autoconvert_maestro(input_file_path, output_file_path, *args, **kwargs):
+        """Decorator that make a function support more than only Maestro files.
+
+        Input and output formats are inferred from extensions. If the input file
+        is not in Maestro format, this automatically uses the utility structconvert
+        to create a temporary Maestro file. Similarly, if the output file path does
+        not have a 'mae' extension, a temporary output file is created and converted
+        at the end of the wrapped function execution.
+
+        The decorated function must take as first two parameters the input and the
+        output paths respectively.
+
+        """
+        is_input_mae = os.path.splitext(input_file_path)[1] == '.mae'
+        is_output_mae = os.path.splitext(output_file_path)[1] == '.mae'
+
+        # If they are both in Maestro format just call the function
+        if is_output_mae and is_input_mae:
+            return func(input_file_path, output_file_path, *args, **kwargs)
+
+        # Otherwise we create a temporary directory to host temp files
+        # First transform desired paths into absolute
+        input_file_path = os.path.abspath(input_file_path)
+        output_file_path = os.path.abspath(output_file_path)
+        with mdtraj.utils.enter_temp_directory():
+            # Convert input file if necessary
+            if is_input_mae:
+                func_input = input_file_path
+            else:
+                func_input = os.path.splitext(os.path.basename(input_file_path))[0] + '.mae'
+                run_structconvert(input_file_path, func_input)
+
+            # Determine if we need to convert output
+            if is_output_mae:
+                func_output = output_file_path
+            else:
+                func_output = os.path.splitext(os.path.basename(output_file_path))[0] + '.mae'
+
+            # Execute function
+            return_value = func(func_input, func_output, *args, **kwargs)
+
+            # Delete temporary input
+            if not is_input_mae:
+                os.remove(func_input)
+
+            # Convert temporary output
+            if not is_output_mae:
+                run_structconvert(func_output, output_file_path)
+                os.remove(func_output)
+
+            # Copy any other output file in the temporary folder
+            output_dir = os.path.dirname(output_file_path)
+            for file_name in os.listdir('.'):
+                shutil.copy2(file_name, os.path.join(output_dir, file_name))
+
+        return return_value
+    return _autoconvert_maestro
+
+
+@autoconvert_maestro
+def run_maesubset(input_file_path, output_file_path, range):
+    """Run Schrodinger's maesubset command line utility to extract a range of
+    structures from a file.
+
+    Parameters
+    ----------
+    input_file_path : str
+        Path to the input file with multiple structures.
+    output_file_path : str
+        Path to output file.
+    range : int or list of ints
+        The 0-based indices of the structures to extract from the input files.
+
+    """
+
+    # Locate maesubset executable
+    maesubset_path = os.path.join(os.environ['SCHRODINGER'], 'utilities', 'maesubset')
+
+    # Normalize paths
+    input_file_path = os.path.abspath(input_file_path)
+    output_file_path = os.path.abspath(output_file_path)
+
+    # Determine molecules to extract
+    try:  # if range is a list of ints
+        range_str = [str(i + 1) for i in range]
+    except TypeError:  # if range is an int
+        range_str = [str(range + 1)]
+    range_str = ','.join(range_str)
+
+    # Run maesubset, we need the list in case there are spaces in paths
+    cmd = [maesubset_path, '-n', range_str, input_file_path]
+    output = run_and_log_error(cmd)
+
+    # Save result
+    with open(output_file_path, 'w') as f:
+        f.write(output)
+
+
+@autoconvert_maestro
+def run_epik(input_file_path, output_file_path, max_structures=32, ph=7.4,
+             ph_tolerance=None, tautomerize=True, extract_range=None):
+    """Run Schrodinger's epik command line utility to enumerate protonation and
+    tautomeric states.
+
+    Parameters
+    ----------
+    input_file_path : str
+        Path to input file describing the molecule.
+    output_file_path : str
+        Path to the output file created by epik.
+    max_structures : int, optional
+        Maximum number of generated structures (default is 32).
+    ph : float, optional
+        Target pH for generated states (default is 7.4).
+    ph_tolerance : float, optional
+        Equivalent of -pht option in Epik command (default is None).
+    tautomerize : bool, optional
+        Whether or not tautomerize the input structure (default is True).
+    extract_range : int or list of ints, optional
+        If not None, the function uses the Schrodinger's utility maesubset to
+        extract only a subset of the generated structures. This is the 0-based
+        indices of the structures to extract from the input files.
+    """
+
+    # Locate epik executable
+    epik_path = os.path.join(os.environ['SCHRODINGER'], 'epik')
+
+    # Normalize paths as we'll run in a different working directory
+    input_file_path = os.path.abspath(input_file_path)
+    output_file_path = os.path.abspath(output_file_path)
+    output_dir = os.path.dirname(output_file_path)
+
+    # Preparing epik command arguments for format()
+    epik_args = dict(ms=max_structures, ph=ph)
+    epik_args['pht'] = '-pht {}'.format(ph_tolerance) if ph_tolerance else ''
+    epik_args['nt'] = '' if tautomerize else '-nt'
+
+    # Determine if we need to convert input and/or output file
+    if extract_range is None:
+        epik_output = output_file_path
+    else:
+        epik_output = os.path.splitext(output_file_path)[0] + '-full.mae'
+
+    # Epik command. We need list in case there's a space in the paths
+    cmd = [epik_path, '-imae', input_file_path, '-omae', epik_output]
+    cmd += '-ms {ms} -ph {ph} {pht} {nt} -pKa_atom -WAIT -NO_JOBCONTROL'.format(
+            **epik_args).split()
+
+    # We run with output_dir as working directory to save there the log file
+    with utils.temporary_cd(output_dir):
+        run_and_log_error(cmd)
+
+    # Check if we need to extract a range of structures
+    if extract_range is not None:
+        run_maesubset(epik_output, output_file_path, extract_range)
+        os.remove(epik_output)
+

--- a/openmoltools/tests/test_schrodinger.py
+++ b/openmoltools/tests/test_schrodinger.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python
+
+"""Test functions in openmoltools.schrodinger."""
+
+import unittest
+
+from openmoltools.schrodinger import *
+
+
+@unittest.skipIf(not is_schrodinger_suite_installed(), "This test requires Schrodinger's suite")
+def test_structconvert():
+    """Test run_structconvert() function."""
+    benzene_path = utils.get_data_filename("chemicals/benzene/benzene.pdb")
+
+    def collect_lines(pdb_path):
+        """Collect all HETATM and CONNECT lines in the pdb."""
+        all_lines = []
+        with open(pdb_path, 'r') as f:
+            for line in f:
+                field = line[:6]
+                n_atom = line[10:11]
+                if n_atom == '4' or n_atom == '9':
+                    continue  # Discard atoms 4 and 9 which have a -0.000
+                if field == 'HETATM' or field == 'CONECT':
+                    all_lines.append(line.strip())
+        return all_lines
+
+    with mdtraj.utils.enter_temp_directory():
+        # Convert from pdb to mol2 and back
+        run_structconvert(benzene_path, 'benzene.mol2')
+        run_structconvert('benzene.mol2', 'benzene.pdb')
+        new_lines = collect_lines('benzene.pdb')
+
+    # The new pdb should be equal to the old one
+    original_lines = collect_lines(benzene_path)
+    assert original_lines == new_lines
+
+
+@unittest.skipIf(not is_schrodinger_suite_installed(), "This test requires Schrodinger's suite")
+def test_proplister():
+    """Test run_proplister() function."""
+    benzene_path = utils.get_data_filename("chemicals/benzene/benzene.sdf")
+    properties = run_proplister(benzene_path)
+
+    assert len(properties) == 1
+    assert len(properties[0]) == 23
+
+    # Test subset of properties
+    expected = {'i_sd_PUBCHEM_COMPOUND_CID': '241',
+                'r_sd_PUBCHEM_CONFORMER_RMSD': '0.4',
+                'i_sd_PUBCHEM_CONFORMER_DIVERSEORDER': '1',
+                's_sd_PUBCHEM_MMFF94_PARTIAL_CHARGES': ('12\n1 -0.15\n10 0.15\n11 0.15\n'
+                                                        '12 0.15\n2 -0.15\n3 -0.15\n4 -0.15\n'
+                                                        '5 -0.15\n6 -0.15\n7 0.15\n8 0.15\n'
+                                                        '9 0.15')
+                }
+    assert set(expected.items()) < set(properties[0].items())
+
+
+@unittest.skipIf(not is_schrodinger_suite_installed(), "This test requires Schrodinger's suite")
+def test_epik_maesubset_autoconvert():
+    """Test run_epik and run_maesubset functions and autoconvert_maestro decorator."""
+    imatinib_path = utils.get_data_filename("chemicals/imatinib/imatinib.sdf")
+
+    with mdtraj.utils.enter_temp_directory():
+        run_structconvert(imatinib_path, 'imatinib.mae')
+        run_epik('imatinib.mae', 'imatinib-epik.mae', ph=7.0)
+        run_maesubset('imatinib-epik.mae', 'imatinib02.mae', range=[0, 2])
+        run_structconvert('imatinib02.mae', 'imatinib02.sdf')
+
+        # The 4 lines above should be equivalent to
+        run_epik(imatinib_path, 'imatinib-auto02.sdf', ph=7.0, tautomerize=True,
+                 extract_range=[0, 2])
+
+        # Check that results contain indeed 2 molecules
+        assert len(run_proplister('imatinib02.sdf')) == 2  # 2 molecules
+        assert len(run_proplister('imatinib-auto02.sdf')) == 2
+
+        # Check that results are identical
+        with open('imatinib02.sdf', 'r') as f:
+            lines = f.readlines()
+        with open('imatinib-auto02.sdf', 'r') as f:
+            assert f.readlines() == lines

--- a/openmoltools/tests/test_utils.py
+++ b/openmoltools/tests/test_utils.py
@@ -1,3 +1,4 @@
+import os
 import numpy as np
 import mdtraj as md
 from unittest import skipIf
@@ -31,6 +32,22 @@ logging.basicConfig(level=logging.DEBUG, format="LOG: %(message)s")
 def test_enter_temp_directory():
     with utils.enter_temp_directory():
         pass
+
+
+def test_temp_dir_context():
+    """Test the context temporary_directory()."""
+    with utils.temporary_directory() as tmp_dir:
+        assert os.path.isdir(tmp_dir)
+    assert not os.path.exists(tmp_dir)
+
+
+def test_temp_cd_context():
+    """Test the context temporary_cd()."""
+    with utils.temporary_directory() as tmp_dir:
+        with utils.temporary_cd(tmp_dir):
+            assert os.getcwd() == os.path.realpath(tmp_dir)
+        assert os.getcwd() != os.path.realpath(tmp_dir)
+
 
 def test_parse_ligand_filename():
     molecule_name = "sustiva"

--- a/openmoltools/tests/test_utils.py
+++ b/openmoltools/tests/test_utils.py
@@ -29,10 +29,6 @@ SKIP_CHECKMOL = (CHECKMOL_PATH is None)
 
 logging.basicConfig(level=logging.DEBUG, format="LOG: %(message)s")
 
-def test_enter_temp_directory():
-    with utils.enter_temp_directory():
-        pass
-
 
 def test_temp_dir_context():
     """Test the context temporary_directory()."""

--- a/openmoltools/utils.py
+++ b/openmoltools/utils.py
@@ -20,7 +20,6 @@ from distutils.spawn import find_executable
 from openmoltools import amber_parser, system_checker
 
 logger = logging.getLogger(__name__)
-logging.basicConfig(level=logging.DEBUG, format="LOG: %(message)s")
 
 
 def getoutput(cmd):

--- a/openmoltools/utils.py
+++ b/openmoltools/utils.py
@@ -317,6 +317,28 @@ def get_data_filename(relative_path):
 
     return fn
 
+
+@contextlib.contextmanager
+def temporary_cd(dir_path):
+    """Context to temporary change the working directory."""
+    prev_dir = os.getcwd()
+    os.chdir(os.path.abspath(dir_path))
+    try:
+        yield
+    finally:
+        os.chdir(prev_dir)
+
+
+@contextlib.contextmanager
+def temporary_directory():
+    """Context for safe creation of temporary directories."""
+    tmp_dir = tempfile.mkdtemp()
+    try:
+        yield tmp_dir
+    finally:
+        shutil.rmtree(tmp_dir)
+
+
 def smiles_to_mdtraj_ffxml(smiles_strings, base_molecule_name="lig"):
     """Generate an MDTraj object from a smiles string.
 


### PR DESCRIPTION
This PR I have added wrapper functions to Schrodinger's tools ``epik``, ``structconvert``, ``maesubset`` and ``proplister``. I also removed ``logging`` configurations from non-test modules (see #194).

In the last commit, I removed a test for ``enter_temp_directory()`` which is an ``mdtraj`` function, not ``openmoltools``.