### PR TITLE
Fix test failures

### DIFF
--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - openmm-dev
     - ambermini
     - pytables
-    - parmed-dev # need ommparams branch
+    - parmed-dev
 #    - rdkit    # rdkit is an optional dependency, may want to comment this out for the release version.
   run:
     - python
@@ -38,6 +38,7 @@ requirements:
     - pytables
     - parmed-dev
 #    - rdkit    # rdkit is an optional dependency, may want to comment this out for the release version.
+    - openmmtools
 
 test:
   requires:

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -38,11 +38,11 @@ requirements:
     - pytables
     - parmed-dev
 #    - rdkit    # rdkit is an optional dependency, may want to comment this out for the release version.
-    - openmmtools
 
 test:
   requires:
     - nose
+    - openmmtools
   imports:
     - openmoltools
   #commands:

--- a/openmoltools/forcefield_generators.py
+++ b/openmoltools/forcefield_generators.py
@@ -494,7 +494,7 @@ class SystemGenerator(object):
     >>> system_generator = SystemGenerator(['amber99sbildn.xml'], forcefield_kwargs=forcefield_kwargs)
     >>> from openmmtools.testsystems import AlanineDipeptideVacuum
     >>> testsystem = AlanineDipeptideVacuum()
-    >>> system_generator.createSystem(testsystem.topology)
+    >>> system = system_generator.createSystem(testsystem.topology)
     """
 
     def __init__(self, forcefields_to_use, forcefield_kwargs=None, use_gaff=True):

--- a/openmoltools/forcefield_generators.py
+++ b/openmoltools/forcefield_generators.py
@@ -489,6 +489,7 @@ class SystemGenerator(object):
 
     Examples
     --------
+    >>> from simtk.openmm import app
     >>> forcefield_kwargs={ 'nonbondedMethod' : app.NoCutoff, 'implicitSolvent' : None, 'constraints' : None }
     >>> system_generator = SystemGenerator(['amber99sbildn.xml'], forcefield_kwargs=forcefield_kwargs)
     >>> from openmmtools.testsystems import AlanineDipeptideVacuum


### PR DESCRIPTION
@davidlmobley, your binary mixture tests are also failing on travis and I don't know why:
```
======================================================================
ERROR: test_amber.test_amber_box
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/travis/miniconda/envs/_test/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/home/travis/miniconda/envs/_test/lib/python2.7/site-packages/openmoltools-0.7.0.dev0-py2.7.egg/openmoltools/tests/test_amber.py", line 19, in test_amber_box
    box_trj = packmol.pack_box(trj_list, [50])
  File "/home/travis/miniconda/envs/_test/lib/python2.7/site-packages/openmoltools-0.7.0.dev0-py2.7.egg/openmoltools/packmol.py", line 102, in pack_box
    trj = md.load(output_filename)
  File "/home/travis/miniconda/envs/_test/lib/python2.7/site-packages/mdtraj/core/trajectory.py", line 416, in load
    _assert_files_exist(filename_or_filenames)
  File "/home/travis/miniconda/envs/_test/lib/python2.7/site-packages/mdtraj/core/trajectory.py", line 95, in _assert_files_exist
    raise IOError('No such file: %s' % fn)
IOError: No such file: /tmp/tmpGkjxh5.pdb
======================================================================
ERROR: test_amber.test_amber_binary_mixture
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/travis/miniconda/envs/_test/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/home/travis/miniconda/envs/_test/lib/python2.7/site-packages/openmoltools-0.7.0.dev0-py2.7.egg/openmoltools/tests/test_amber.py", line 50, in test_amber_binary_mixture
    box_trj = packmol.pack_box(trj_list, [25, 50])
  File "/home/travis/miniconda/envs/_test/lib/python2.7/site-packages/openmoltools-0.7.0.dev0-py2.7.egg/openmoltools/packmol.py", line 102, in pack_box
    trj = md.load(output_filename)
  File "/home/travis/miniconda/envs/_test/lib/python2.7/site-packages/mdtraj/core/trajectory.py", line 416, in load
    _assert_files_exist(filename_or_filenames)
  File "/home/travis/miniconda/envs/_test/lib/python2.7/site-packages/mdtraj/core/trajectory.py", line 95, in _assert_files_exist
    raise IOError('No such file: %s' % fn)
IOError: No such file: /tmp/tmp5FJPtt.pdb
======================================================================
ERROR: test_amber.test_amber_water_mixture
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/travis/miniconda/envs/_test/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/home/travis/miniconda/envs/_test/lib/python2.7/site-packages/openmoltools-0.7.0.dev0-py2.7.egg/openmoltools/tests/test_amber.py", line 87, in test_amber_water_mixture
    box_trj = packmol.pack_box(trj_list, [300, 25, 3])
  File "/home/travis/miniconda/envs/_test/lib/python2.7/site-packages/openmoltools-0.7.0.dev0-py2.7.egg/openmoltools/packmol.py", line 102, in pack_box
    trj = md.load(output_filename)
  File "/home/travis/miniconda/envs/_test/lib/python2.7/site-packages/mdtraj/core/trajectory.py", line 416, in load
    _assert_files_exist(filename_or_filenames)
  File "/home/travis/miniconda/envs/_test/lib/python2.7/site-packages/mdtraj/core/trajectory.py", line 95, in _assert_files_exist
    raise IOError('No such file: %s' % fn)
IOError: No such file: /tmp/tmpOiRth_.pdb
```