### PR TITLE
Prepare setup.py for release 0.7.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,8 +24,8 @@ except ImportError:
 
 
 ##########################
-VERSION = "0.7.0.dev0"
-ISRELEASED = False
+VERSION = "0.7.0"
+ISRELEASED = True
 __version__ = VERSION
 ##########################
 


### PR DESCRIPTION
Do we want to wait for Christopher Bayly comments on the new OpenEye warnings (see #201) before releasing or can I proceed?