### PR TITLE
Generate globally unique residue template names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,9 +51,9 @@ env:
     - CONDA_PY=34  OPENEYE_CHANNEL="-i https://pypi.anaconda.org/openeye/channel/main/simple"
     - CONDA_PY=35  OPENEYE_CHANNEL="-i https://pypi.anaconda.org/openeye/channel/main/simple"
     # OpenEye beta
-    #- CONDA_PY=27  OPENEYE_CHANNEL="--pre -i https://pypi.anaconda.org/openeye/channel/beta/simple"
-    #- CONDA_PY=34  OPENEYE_CHANNEL="--pre -i https://pypi.anaconda.org/openeye/channel/beta/simple"
-    #- CONDA_PY=35  OPENEYE_CHANNEL="--pre -i https://pypi.anaconda.org/openeye/channel/beta/simple"
+    - CONDA_PY=27  OPENEYE_CHANNEL="--pre -i https://pypi.anaconda.org/openeye/channel/beta/simple"
+    - CONDA_PY=34  OPENEYE_CHANNEL="--pre -i https://pypi.anaconda.org/openeye/channel/beta/simple"
+    - CONDA_PY=35  OPENEYE_CHANNEL="--pre -i https://pypi.anaconda.org/openeye/channel/beta/simple"
 
   global:
     - ORGNAME="omnia"

--- a/openmoltools/forcefield_generators.py
+++ b/openmoltools/forcefield_generators.py
@@ -249,8 +249,9 @@ def generateResidueTemplate(molecule, residue_atoms=None):
     Atom names in molecules will be assigned Tripos atom names if any are blank or not unique.
 
     """
-    # Set the template name based on the molecule title.
-    template_name = molecule.GetTitle()
+    # Set the template name based on the molecule title plus a globally unique UUID.
+    from uuid import uuid4
+    template_name = molecule.GetTitle() + '-' + str(uuid4())
 
     # If any atom names are not unique, atom names
     _ensureUniqueAtomNames(molecule)


### PR DESCRIPTION
Because of changes in https://github.com/pandegroup/openmm/pull/1373 we now need to ensure residue template names are globally unique.

In this PR:
* residue templates generated on the fly are named as `[resname]-[uuid]`
* residue templates generated in batch calls have an option to use the same globally unique naming scheme

cc: https://github.com/choderalab/perses/pull/195