### PR TITLE
Add ParmEd version check needed for GROMACS functionality

### DIFF
--- a/openmoltools/gromacs.py
+++ b/openmoltools/gromacs.py
@@ -4,6 +4,14 @@ import logging
 import mdtraj.utils
 from distutils.spawn import find_executable
 import parmed
+# If ParmEd is older than 2.0.4 then halt - newer ParmEd is required to have correct FudgeLJ/FudgeQQ retained in GROMACS topologies.
+try:
+    ver = parmed.version
+except:
+    oldParmEd = Exception('ERROR: ParmEd is too old, please upgrade to 2.0.4 or later')
+    raise oldParmEd
+if ver < (2,0,4):
+    raise RuntimeError("ParmEd is too old, please upgrade to 2.0.4 or later")
 
 from openmoltools.utils import getoutput
 

--- a/openmoltools/utils.py
+++ b/openmoltools/utils.py
@@ -553,6 +553,15 @@ def amber_to_gromacs( molecule_name, in_prmtop, in_crd, out_top = None, out_gro 
 
     #Import ParmEd
     import parmed
+    #Require version 2.0.4 or later of ParmEd, otherwise ParmEd corrupts [ defaults ] section in GROMACS topologies with incorrect FudgeLJ/FudgeQQ
+    try:
+        ver = parmed.version
+    except:
+        oldParmEd = Exception('ERROR: ParmEd is too old, please upgrade to 2.0.4 or later')
+        raise oldParmEd
+    if ver < (2,0,4):
+        raise RuntimeError("ParmEd is too old, please upgrade to 2.0.4 or later")
+
 
     #Read AMBER to ParmEd object
     structure = parmed.amber.AmberParm( in_prmtop, in_crd )

--- a/openmoltools/utils.py
+++ b/openmoltools/utils.py
@@ -435,6 +435,16 @@ def randomize_mol2_residue_names(mol2_filenames):
     re-write the MOL2 files using ParmEd with the unique identifiers.
     """
     import parmed
+
+    # We require at least ParmEd 2.5.1 because of issues with the .mol2 writer (issue #691 on ParmEd) prior to that.
+    try: #Try to get version tag
+        ver = parmed.version
+    except: #If too old for version tag, it is too old
+        oldParmEd = Exception('ERROR: ParmEd is too old, please upgrade to 2.0.4 or later')
+        raise oldParmEd
+    if ver < (2,5,1):
+        raise RuntimeError("ParmEd is too old, please upgrade to 2.0.4 or later")
+
     names = get_unique_names(len(mol2_filenames))
 
     for k, filename in enumerate(mol2_filenames):


### PR DESCRIPTION
Earlier versions of ParmEd could harm GROMACS files (modifying FudgeLJ and FudgeQQ to incorrect values). This adds version checks to ensure ParmEd version is new enough.