### PR TITLE
Set setup.py version to 0.7.1dev0 for ongoing development

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,8 +24,8 @@ except ImportError:
 
 
 ##########################
-VERSION = "0.7.0"
-ISRELEASED = True
+VERSION = "0.7.1dev0"
+ISRELEASED = False
 __version__ = VERSION
 ##########################
 


### PR DESCRIPTION
I wanted to wait for the release on omnia/conda-recipes and I ended up forgetting to set the version to dev in `setup.py`. This is ready to be merged.