### PR TITLE
Re-activate RDKit as requirement to enable testing of packmol tools.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,8 +37,7 @@ script:
   # Install package prerequisites
   - conda install --yes --quiet pip nose nose-timer
   - conda install --yes --quiet packmol
-  # rdkit stuff is broken now
-  # - conda install --yes --quiet rdkit
+  - conda install --yes --quiet rdkit
   # Install OpenEye toolkit if we have unencrypted the license file.
   - if [ "$TRAVIS_SECURE_ENV_VARS" == true ] ; then pip install $OPENEYE_CHANNEL openeye-toolkits; fi
   # Test the package

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - ambermini
     - pytables
     - parmed-dev
-#    - rdkit    # rdkit is an optional dependency, may want to comment this out for the release version.
+    - rdkit    # rdkit is an optional dependency, may want to comment this out for the release version.
   run:
     - python
     - setuptools
@@ -38,7 +38,7 @@ requirements:
     - pytables
     - parmed-dev
     - libgfortran ==1.0 # [linux]
-#    - rdkit    # rdkit is an optional dependency, may want to comment this out for the release version.
+    - rdkit    # rdkit is an optional dependency, may want to comment this out for the release version.
 
 test:
   requires:


### PR DESCRIPTION
This re-activates RDKit as a requirement as per #221 to allow the existing `packmol` tests to work.

I expect that this will initially fail at least on the OpenEye betas because of #219 ; it may also fail because of https://github.com/omnia-md/conda-recipes/issues/512 - library issues with omnia RDKit.
