### PR TITLE
Update devtools miniconda url

### DIFF
--- a/devtools/travis-ci/install.sh
+++ b/devtools/travis-ci/install.sh
@@ -1,5 +1,5 @@
 MINICONDA=Miniconda2-latest-Linux-x86_64.sh
-MINICONDA_MD5=$(curl -s http://repo.continuum.io/miniconda/ | grep -A3 $MINICONDA | sed -n '4p' | sed -n 's/ *<td>\(.*\)<\/td> */\1/p')
+MINICONDA_MD5=$(curl -s https://repo.continuum.io/miniconda/ | grep -A3 $MINICONDA | sed -n '4p' | sed -n 's/ *<td>\(.*\)<\/td> */\1/p')
 wget http://repo.continuum.io/miniconda/$MINICONDA
 if [[ $MINICONDA_MD5 != $(md5sum $MINICONDA | cut -d ' ' -f 1) ]]; then
     echo "Miniconda MD5 mismatch"


### PR DESCRIPTION
Why:

Currently, builds are experiencing an md5 checksum issue.
This command is broken due to some change on either the webpage, or perhaps
curl, leading to an empty md5 sum to check against.

This change addresses the need by:

* Updating the url to https.