### PR TITLE
Add standardize to mol2 output

### DIFF
--- a/openmoltools/forcefield_generators.py
+++ b/openmoltools/forcefield_generators.py
@@ -178,6 +178,7 @@ def generateOEMolFromTopologyResidue(residue, geometry=False, tripos_atom_names=
 
     return molecule
 
+
 def _computeNetCharge(molecule):
     """
     Compute the net formal charge on the molecule.
@@ -200,7 +201,8 @@ def _computeNetCharge(molecule):
     net_charge = np.array(charges).sum()
     return net_charge
 
-def _writeMolecule(molecule, output_filename):
+
+def _writeMolecule(molecule, output_filename, standardize=True):
     """
     Write the molecule to a file.
 
@@ -210,10 +212,12 @@ def _writeMolecule(molecule, output_filename):
         The molecule to write (will be modified by writer).
     output_filename : str
         The filename of file to be written; type is autodetected by extension.
+    standardize : bool, optional, default=True
+        Standardize molecular properties such as atom names in the output file.
 
     """
     from openmoltools.openeye import molecule_to_mol2
-    molecule_to_mol2(molecule, tripos_mol2_filename=output_filename, conformer=0, residue_name=molecule.GetTitle())
+    molecule_to_mol2(molecule, tripos_mol2_filename=output_filename, conformer=0, residue_name=molecule.GetTitle(), standardize=standardize)
     #from openeye import oechem
     #ofs = oechem.oemolostream(output_filename)
     #oechem.OEWriteMolecule(ofs, molecule)
@@ -278,7 +282,7 @@ def generateResidueTemplate(molecule, residue_atoms=None, normalize=True):
     frcmod_filename = os.path.join(tmpdir, prefix + '.frcmod')
 
     # Write Tripos mol2 file as antechamber input.
-    _writeMolecule(molecule, input_mol2_filename)
+    _writeMolecule(molecule, input_mol2_filename, standardize=normalize)
 
     # Parameterize the molecule with antechamber.
     run_antechamber(template_name, input_mol2_filename, charge_method=None, net_charge=net_charge, gaff_mol2_filename=gaff_mol2_filename, frcmod_filename=frcmod_filename)
@@ -335,6 +339,7 @@ def generateResidueTemplate(molecule, residue_atoms=None, normalize=True):
     params.write(ffxml)
 
     return template, ffxml.getvalue()
+
 
 def generateForceFieldFromMolecules(molecules, ignoreFailures=False, generateUniqueNames=False, normalize=True):
     """
@@ -422,7 +427,7 @@ def generateForceFieldFromMolecules(molecules, ignoreFailures=False, generateUni
         frcmod_filename     = prefix + '.frcmod'
 
         # Write Tripos mol2 file as antechamber input.
-        _writeMolecule(molecule, input_mol2_filename)
+        _writeMolecule(molecule, input_mol2_filename, standardize=normalize)
 
         # Parameterize the molecule with antechamber.
         run_antechamber(prefix, input_mol2_filename, charge_method=None, net_charge=net_charge, gaff_mol2_filename=gaff_mol2_filename, frcmod_filename=frcmod_filename)

--- a/openmoltools/openeye.py
+++ b/openmoltools/openeye.py
@@ -271,7 +271,7 @@ def get_names_to_charges(molecule):
     return data, molrepr
 
 
-def molecule_to_mol2(molecule, tripos_mol2_filename=None, conformer=0, residue_name="MOL"):
+def molecule_to_mol2(molecule, tripos_mol2_filename=None, conformer=0, residue_name="MOL", standardize=True):
     """Convert OE molecule to tripos mol2 file.
 
     Parameters
@@ -287,6 +287,10 @@ def molecule_to_mol2(molecule, tripos_mol2_filename=None, conformer=0, residue_n
         OpenEye writes mol2 files with <0> as the residue / ligand name.
         This chokes many mol2 parsers, so we replace it with a string of
         your choosing.
+    standardize: bool, optional, default=True
+        Use a high-level writer, which will standardize the molecular properties.
+        Set this to false if you wish to retain things such as atom names.
+        In this case, a low-level writer will be used.
 
     Returns
     -------
@@ -310,7 +314,11 @@ def molecule_to_mol2(molecule, tripos_mol2_filename=None, conformer=0, residue_n
     ofs.SetFormat(oechem.OEFormat_MOL2H)
     for k, mol in enumerate(molecule.GetConfs()):
         if k == conformer:
-            oechem.OEWriteMolecule(ofs, mol)
+            # Standardize will override molecular properties(atom names etc.)
+            if standardize:
+                oechem.OEWriteMolecule(ofs, mol)
+            else:
+                oechem.OEWriteMol2File(ofs, mol)
 
     ofs.close()
 

--- a/openmoltools/tests/test_openeye.py
+++ b/openmoltools/tests/test_openeye.py
@@ -36,6 +36,7 @@ try:
 except ImportError:
     HAVE_PARMED = False
 
+
 @skipIf(not HAVE_OE, "Cannot test openeye module without OpenEye tools.\n" + openeye_exception_message)
 def test_butanol_keepconfs():
     m0 = openmoltools.openeye.iupac_to_oemol("butanol")
@@ -81,8 +82,6 @@ def test_output_mol2_no_standardize():
         text = outfile.read()
     # This should find the text we added, to make sure the molecule is not standardized.
     assert re.search("MyNameIsAtom", text) is not None
-
-
 
 
 @skipIf(not HAVE_OE, "Cannot test openeye module without OpenEye tools.")
@@ -180,7 +179,6 @@ def test_ffxml():
         trajectories, ffxml = openmoltools.openeye.oemols_to_ffxml([charged0, charged1])
 
 
-
 @skipIf(not HAVE_OE, "Cannot test openeye module without OpenEye tools.")
 def test_ffxml_simulation():
     """Test converting toluene and benzene smiles to oemol to ffxml to openmm simulation."""
@@ -237,11 +235,13 @@ def test_ffxml_simulation():
             print("running")
             simulation.step(1)
 
+
 @skipIf(not HAVE_OE, "Cannot test openeye module without OpenEye tools.")
 @raises(RuntimeError)
 def test_charge_fail1():
     with utils.enter_temp_directory():
         openmoltools.openeye.smiles_to_antechamber(smiles_fails_with_strictStereo, "test.mol2",  "test.frcmod", strictStereo=True)
+
 
 @skipIf(not HAVE_OE, "Cannot test openeye module without OpenEye tools.")
 @raises(RuntimeError)
@@ -249,10 +249,12 @@ def test_charge_fail2():
     m = openmoltools.openeye.smiles_to_oemol(smiles_fails_with_strictStereo)
     m = openmoltools.openeye.get_charges(m, strictStereo=True, keep_confs=1)
 
+
 @skipIf(not HAVE_OE, "Cannot test openeye module without OpenEye tools.")
 def test_charge_success1():
     with utils.enter_temp_directory():    
         openmoltools.openeye.smiles_to_antechamber(smiles_fails_with_strictStereo, "test.mol2",  "test.frcmod", strictStereo=False)
+
 
 @skipIf(not HAVE_OE, "Cannot test openeye module without OpenEye tools.")
 def test_charge_success2():

--- a/openmoltools/tests/test_openeye.py
+++ b/openmoltools/tests/test_openeye.py
@@ -3,6 +3,7 @@ import simtk.unit as u
 from simtk.openmm import app
 import simtk.openmm as mm
 import numpy as np
+import re
 from mdtraj.testing import eq
 from unittest import skipIf
 from openmoltools import utils, packmol
@@ -52,6 +53,37 @@ def test_butanol_unnormalized():
     assert m1.NumConfs() == 1, "This OEMol was created to have a single conformation."
     assert m1.NumAtoms() == 15, "Butanol should have 15 atoms"
     assert m0.GetTitle() == m1.GetTitle(), "The title of the molecule should not be changed by normalization."
+
+
+@skipIf(not HAVE_OE, "Cannot test openeye module without OpenEye tools.")
+def test_output_mol2():
+    molecule = openmoltools.openeye.iupac_to_oemol("cyclopentane")
+    openmoltools.openeye.molecule_to_mol2(molecule, tripos_mol2_filename="testing mol2 output.tripos.mol2")
+
+
+@skipIf(not HAVE_OE, "Cannot test openeye module without OpenEye tools.")
+def test_output_mol2_standardize():
+    molecule = openmoltools.openeye.iupac_to_oemol("cyclopentane")
+    list(molecule.GetAtoms())[0].SetName("MyNameIsAtom")
+    openmoltools.openeye.molecule_to_mol2(molecule, tripos_mol2_filename="testing mol2 standardize output.tripos.mol2", standardize=True)
+    with open("testing mol2 standardize output.tripos.mol2", "r") as outfile:
+        text = outfile.read()
+    # This should not find the text we added, to make sure the molecule is standardized.
+    assert re.search("MyNameIsAtom", text) is None
+
+
+@skipIf(not HAVE_OE, "Cannot test openeye module without OpenEye tools.")
+def test_output_mol2_no_standardize():
+    molecule = openmoltools.openeye.iupac_to_oemol("cyclopentane")
+    list(molecule.GetAtoms())[0].SetName("MyNameIsAtom")
+    openmoltools.openeye.molecule_to_mol2(molecule, tripos_mol2_filename="testing mol2 nostandardize output.tripos.mol2", standardize=False)
+    with open("testing mol2 nostandardize output.tripos.mol2", "r") as outfile:
+        text = outfile.read()
+    # This should find the text we added, to make sure the molecule is not standardized.
+    assert re.search("MyNameIsAtom", text) is not None
+
+
+
 
 @skipIf(not HAVE_OE, "Cannot test openeye module without OpenEye tools.")
 def test_butanol():


### PR DESCRIPTION
The molecule_to_mol2 function uses a high-level writer,
which overwrites atomic properties such as atom names in an effort to standardize them.
Sometimes it is desirable to keep the atom names provided in the input.

This change addresses the need by:

* An option called `standardize` is added to molecule_to_mol2
* (Some) functions that depend on it have been updated to
make it accessible.
* Tests of the mol2 reading have been added to validate
that behavior is as expected.