### PR TITLE
Change version # for a release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,8 +24,9 @@ except ImportError:
 
 
 ##########################
-VERSION = "0.7.5.dev0"
-ISRELEASED = False
+#VERSION = "0.7.5.dev0"
+VERSION = "0.7.5"
+ISRELEASED = True
 __version__ = VERSION
 ##########################
 


### PR DESCRIPTION
In #245 I brought in some changes I need to roll out in a release for use on Orion, so this adjusts `setup.py` to make the version number 0.7.5 for a release.