### PR TITLE
Pin conda-build to 2.1.5 until its fixed

### DIFF
--- a/devtools/travis-ci/install.sh
+++ b/devtools/travis-ci/install.sh
@@ -10,4 +10,4 @@ PIP_ARGS="-U"
 
 export PATH=$HOME/miniconda/bin:$PATH
 
-conda install --yes conda-build jinja2 anaconda-client pip
+conda install --yes conda-build=2.1.5 jinja2 anaconda-client pip


### PR DESCRIPTION
Conda build does not work with --yes and --use-local automatically since conda-build=2.1.6, so pin this until they fix it