### PR TITLE
Implement function to standardize_water

### DIFF
--- a/openmoltools/packmol.py
+++ b/openmoltools/packmol.py
@@ -84,9 +84,11 @@ def pack_box(pdb_filenames_or_trajectories, n_molecules_list, tolerance=2.0, box
     Parameters
     ----------
     pdb_filenames_or_trajectories : list({str, Trajectory})
-        List of pdb filenames or trajectories for each component of mixture.  If this is
-        a list of trajectories, the trajectories will be saved to as
-        temporary files to be run in packmol.
+        List of pdb filenames or trajectories for each component of mixture.
+        If this is a list of trajectories, the trajectories will be saved to
+        as temporary files to be run in packmol. Water molecules must have
+        MDTraj-standard residue name (HOH) and atom names (O, H1, H2), otherwise
+        MDtraj won't be able to perceive the bonds.
     n_molecules_list : list(int)
         The number of molecules of each mixture component.
     tolerance : float, optional, default=2.0
@@ -103,11 +105,20 @@ def pack_box(pdb_filenames_or_trajectories, n_molecules_list, tolerance=2.0, box
 
     Notes
     -----
+    Water molecules must have MDTraj-standard residue name (HOH) and atom
+    names (O, H1, H2), otherwise MDTraj won't be able to perceive the bonds
+    and the Topology of the returned Trajectory will be incorrect.
     Be aware that MDTraj uses nanometers internally, but packmol uses angstrom
-    units.  The present function takes `tolerance` and `box_size` in 
-    angstrom units, but the output trajectory will have data in nm.  
+    units. The present function takes `tolerance` and `box_size` in angstrom
+    units, but the output trajectory will have data in nm.
     Also note that OpenMM is pretty picky about the format of unit cell input, 
     so use the example in tests/test_packmol.py to ensure that you do the right thing.
+
+    See Also
+    --------
+    standardize_water
+        Standardize residue and atom names of a water molecule.
+
     """
     assert len(pdb_filenames_or_trajectories) == len(n_molecules_list), "Must input same number of pdb filenames as num molecules"
     

--- a/openmoltools/packmol.py
+++ b/openmoltools/packmol.py
@@ -87,8 +87,8 @@ def pack_box(pdb_filenames_or_trajectories, n_molecules_list, tolerance=2.0, box
         List of pdb filenames or trajectories for each component of mixture.
         If this is a list of trajectories, the trajectories will be saved to
         as temporary files to be run in packmol. Water molecules must have
-        MDTraj-standard residue name (HOH) and atom names (O, H1, H2), otherwise
-        MDtraj won't be able to perceive the bonds.
+        MDTraj-standard residue and atom names as defined in
+        mdtraj/formats/pdb/data/pdbNames.xml.
     n_molecules_list : list(int)
         The number of molecules of each mixture component.
     tolerance : float, optional, default=2.0
@@ -105,9 +105,9 @@ def pack_box(pdb_filenames_or_trajectories, n_molecules_list, tolerance=2.0, box
 
     Notes
     -----
-    Water molecules must have MDTraj-standard residue name (HOH) and atom
-    names (O, H1, H2), otherwise MDTraj won't be able to perceive the bonds
-    and the Topology of the returned Trajectory will be incorrect.
+    Water molecules must have MDTraj-standard residue and atom names as defined
+    in mdtraj/formats/pdb/data/pdbNames.xml, otherwise MDTraj won't be able to
+    perceive the bonds and the Topology of the returned Trajectory will be incorrect.
     Be aware that MDTraj uses nanometers internally, but packmol uses angstrom
     units. The present function takes `tolerance` and `box_size` in angstrom
     units, but the output trajectory will have data in nm.

--- a/openmoltools/tests/test_packmol.py
+++ b/openmoltools/tests/test_packmol.py
@@ -1,9 +1,8 @@
+import os
 import tempfile
-import numpy as np
 import mdtraj as md
 from unittest import skipIf
 import logging
-from mdtraj.testing import eq
 from openmoltools import utils, packmol
 import simtk.unit as u
 from simtk.openmm import app
@@ -17,6 +16,43 @@ try:
     from rdkit.Chem import AllChem
 except ImportError:
     HAVE_RDKIT = False
+
+
+def test_standardize_water():
+    """Test utility function standardize_water.
+
+    The water bonds must be recognized even when residue names do not
+    match the standard definition in mdtraj.formats.pdb.data.residues.xml.
+
+    """
+    water_filepath = utils.get_data_filename("chemicals/water/water.mol2")
+    water_traj = md.load(water_filepath)
+
+    # Store in pdb format and lose CONECT records.
+    water_pdb_filepath = tempfile.mktemp(suffix='.pdb')
+    water_traj.save_pdb(water_pdb_filepath)
+    with open(water_pdb_filepath, 'r') as f:
+        pdb_lines = f.readlines()
+    with open(water_pdb_filepath, 'w') as f:
+        for line in pdb_lines:
+            if line[:6] != 'CONECT':
+                f.write(line)
+
+    # Test pre-condition: MDTraj cannot detect water bonds automatically.
+    water_traj = md.load(water_pdb_filepath)
+    assert water_traj.topology.n_bonds == 0
+
+    # The function modifies the Trajectory and bonds are now recognized.
+    assert packmol.standardize_water(water_traj) is True
+    assert water_traj.topology.n_bonds == 2
+
+    # The second time, the Trajectory object is not modified.
+    assert packmol.standardize_water(water_traj) is False
+
+    # Remove temporary file.
+    os.remove(water_pdb_filepath)
+
+
 @skipIf(not HAVE_RDKIT, "Skipping testing of packmol conversion because rdkit not found.")
 @skipIf(packmol.PACKMOL_PATH is None, "Skipping testing of packmol conversion because packmol not found.")
 def test_packmol_simulation_ternary():

--- a/openmoltools/tests/test_packmol.py
+++ b/openmoltools/tests/test_packmol.py
@@ -46,9 +46,6 @@ def test_standardize_water():
     assert packmol.standardize_water(water_traj) is True
     assert water_traj.topology.n_bonds == 2
 
-    # The second time, the Trajectory object is not modified.
-    assert packmol.standardize_water(water_traj) is False
-
     # Remove temporary file.
     os.remove(water_pdb_filepath)
 


### PR DESCRIPTION
This implement a function to solve the problem brought up in #253 . Currently it's a separated function `packmol.standardize_water` that can optionally be called on a water molecule to standardize its residue/atom names and make MDTraj automatically perceive bonds. Right now I preferred this to making it all automatic and hidden inside `packmol.pack_box` because
1) It'd involve loading as a `Trajectory` object every molecule before invoking packmol to check if it is a water.
2) I'd prefer `packmol.pack_box` to not have unexpected side effects on the output files.

We can always integrate the two functions later if we notice significant advantages. Currently this is how it works
```python
>>> water_traj = mdtraj.load('water.pdb')
>>> is_water = packmol.standardize_water(water_traj)
>>> packmol.pack_box([water_traj, 'benzene.pdb'], [1000, 1])
```