### PR TITLE
Gaff2 template generator

### DIFF
--- a/openmoltools/forcefield_generators.py
+++ b/openmoltools/forcefield_generators.py
@@ -223,7 +223,7 @@ def _writeMolecule(molecule, output_filename, standardize=True):
     #oechem.OEWriteMolecule(ofs, molecule)
     #ofs.close()
 
-def generateResidueTemplate(molecule, residue_atoms=None, normalize=True):
+def generateResidueTemplate(molecule, residue_atoms=None, normalize=True, gaff_version='gaff'):
     """
     Generate an residue template for simtk.openmm.app.ForceField using GAFF/AM1-BCC.
 
@@ -241,12 +241,14 @@ def generateResidueTemplate(molecule, residue_atoms=None, normalize=True):
     normalize : bool, optional, default=True
         If True, normalize the molecule by checking aromaticity, adding
         explicit hydrogens, and renaming by IUPAC name.
+    gaff_version : str, default = 'gaff'
+        One of ['gaff', 'gaff2']; selects which atom types to use.
         
 
     Returns
     -------
     template : simtk.openmm.app.forcefield._TemplateData
-        Residue template for ForceField using atom types and parameters from `gaff.xml`.
+        Residue template for ForceField using atom types and parameters from `gaff.xml` or `gaff2.xml`.
     additional_parameters_ffxml : str
         Contents of ForceField `ffxml` file defining additional parameters from parmchk(2).
 
@@ -285,7 +287,7 @@ def generateResidueTemplate(molecule, residue_atoms=None, normalize=True):
     _writeMolecule(molecule, input_mol2_filename, standardize=normalize)
 
     # Parameterize the molecule with antechamber.
-    run_antechamber(template_name, input_mol2_filename, charge_method=None, net_charge=net_charge, gaff_mol2_filename=gaff_mol2_filename, frcmod_filename=frcmod_filename)
+    run_antechamber(template_name, input_mol2_filename, charge_method=None, net_charge=net_charge, gaff_mol2_filename=gaff_mol2_filename, frcmod_filename=frcmod_filename, gaff_version=gaff_version)
 
     # Read the resulting GAFF mol2 file as a ParmEd structure.
     from openeye import oechem
@@ -341,7 +343,7 @@ def generateResidueTemplate(molecule, residue_atoms=None, normalize=True):
     return template, ffxml.getvalue()
 
 
-def generateForceFieldFromMolecules(molecules, ignoreFailures=False, generateUniqueNames=False, normalize=True, gaff_version = 'gaff'):
+def generateForceFieldFromMolecules(molecules, ignoreFailures=False, generateUniqueNames=False, normalize=True, gaff_version='gaff'):
     """
     Generate ffxml file containing additional parameters and residue templates for simtk.openmm.app.ForceField using GAFF/AM1-BCC.
 

--- a/openmoltools/forcefield_generators.py
+++ b/openmoltools/forcefield_generators.py
@@ -341,7 +341,7 @@ def generateResidueTemplate(molecule, residue_atoms=None, normalize=True):
     return template, ffxml.getvalue()
 
 
-def generateForceFieldFromMolecules(molecules, ignoreFailures=False, generateUniqueNames=False, normalize=True):
+def generateForceFieldFromMolecules(molecules, ignoreFailures=False, generateUniqueNames=False, normalize=True, gaff_version = 'gaff'):
     """
     Generate ffxml file containing additional parameters and residue templates for simtk.openmm.app.ForceField using GAFF/AM1-BCC.
 
@@ -361,7 +361,9 @@ def generateForceFieldFromMolecules(molecules, ignoreFailures=False, generateUni
         If True, will generate globally unique names for templates.
     normalize : bool, optional, default=True
         If True, normalize the molecule by checking aromaticity, adding
-        explicit hydrogens, and renaming by IUPAC name.
+        explicit hydrogens, and renaming by IUPAC name.        
+    gaff_version : str, default = 'gaff'
+        One of ['gaff', 'gaff2']; selects which atom types to use.
 
     Returns
     -------
@@ -430,7 +432,7 @@ def generateForceFieldFromMolecules(molecules, ignoreFailures=False, generateUni
         _writeMolecule(molecule, input_mol2_filename, standardize=normalize)
 
         # Parameterize the molecule with antechamber.
-        run_antechamber(prefix, input_mol2_filename, charge_method=None, net_charge=net_charge, gaff_mol2_filename=gaff_mol2_filename, frcmod_filename=frcmod_filename)
+        run_antechamber(prefix, input_mol2_filename, charge_method=None, net_charge=net_charge, gaff_mol2_filename=gaff_mol2_filename, frcmod_filename=frcmod_filename, gaff_version=gaff_version)
 
         # Append to leaprc input for parmed.
         leaprc += '%s = loadmol2 %s\n' % (prefix, gaff_mol2_filename)

--- a/openmoltools/parameters/gaff2.xml
+++ b/openmoltools/parameters/gaff2.xml
@@ -1,0 +1,6653 @@
+<ForceField>
+ <Info>
+  <DateGenerated>2016-08-24</DateGenerated>
+  <Source md5hash="18b7d5da516dad62cfdea5d5c2f4b83c" sourcePackage="AmberTools" sourcePackageVersion="16">leaprc.gaff2</Source>
+  <Reference>Wang, J., Wolf, R.M., Caldwell, J.W., Kollman, P.A., and Case, D.A. (2004). Development and testing of a general amber force field. J. Comput. Chem. 25, 1157-1174.</Reference>
+ </Info>
+ <AtomTypes>
+  <Type name="c" class="c" element="C" mass="12.01"/>
+  <Type name="cs" class="cs" element="C" mass="12.01"/>
+  <Type name="c1" class="c1" element="C" mass="12.01"/>
+  <Type name="c2" class="c2" element="C" mass="12.01"/>
+  <Type name="c3" class="c3" element="C" mass="12.01"/>
+  <Type name="ca" class="ca" element="C" mass="12.01"/>
+  <Type name="cp" class="cp" element="C" mass="12.01"/>
+  <Type name="cq" class="cq" element="C" mass="12.01"/>
+  <Type name="cc" class="cc" element="C" mass="12.01"/>
+  <Type name="cd" class="cd" element="C" mass="12.01"/>
+  <Type name="ce" class="ce" element="C" mass="12.01"/>
+  <Type name="cf" class="cf" element="C" mass="12.01"/>
+  <Type name="cg" class="cg" element="C" mass="12.01"/>
+  <Type name="ch" class="ch" element="C" mass="12.01"/>
+  <Type name="cx" class="cx" element="C" mass="12.01"/>
+  <Type name="cy" class="cy" element="C" mass="12.01"/>
+  <Type name="cu" class="cu" element="C" mass="12.01"/>
+  <Type name="cv" class="cv" element="C" mass="12.01"/>
+  <Type name="cz" class="cz" element="C" mass="12.01"/>
+  <Type name="h1" class="h1" element="H" mass="1.008"/>
+  <Type name="h2" class="h2" element="H" mass="1.008"/>
+  <Type name="h3" class="h3" element="H" mass="1.008"/>
+  <Type name="h4" class="h4" element="H" mass="1.008"/>
+  <Type name="h5" class="h5" element="H" mass="1.008"/>
+  <Type name="ha" class="ha" element="H" mass="1.008"/>
+  <Type name="hc" class="hc" element="H" mass="1.008"/>
+  <Type name="hn" class="hn" element="H" mass="1.008"/>
+  <Type name="ho" class="ho" element="H" mass="1.008"/>
+  <Type name="hp" class="hp" element="H" mass="1.008"/>
+  <Type name="hs" class="hs" element="H" mass="1.008"/>
+  <Type name="hw" class="hw" element="H" mass="1.008"/>
+  <Type name="hx" class="hx" element="H" mass="1.008"/>
+  <Type name="f" class="f" element="F" mass="19.0"/>
+  <Type name="cl" class="cl" element="Cl" mass="35.45"/>
+  <Type name="br" class="br" element="Br" mass="79.9"/>
+  <Type name="i" class="i" element="I" mass="126.9"/>
+  <Type name="n" class="n" element="N" mass="14.01"/>
+  <Type name="n1" class="n1" element="N" mass="14.01"/>
+  <Type name="n2" class="n2" element="N" mass="14.01"/>
+  <Type name="n3" class="n3" element="N" mass="14.01"/>
+  <Type name="n4" class="n4" element="N" mass="14.01"/>
+  <Type name="na" class="na" element="N" mass="14.01"/>
+  <Type name="nb" class="nb" element="N" mass="14.01"/>
+  <Type name="nc" class="nc" element="N" mass="14.01"/>
+  <Type name="nd" class="nd" element="N" mass="14.01"/>
+  <Type name="ne" class="ne" element="N" mass="14.01"/>
+  <Type name="nf" class="nf" element="N" mass="14.01"/>
+  <Type name="nh" class="nh" element="N" mass="14.01"/>
+  <Type name="no" class="no" element="N" mass="14.01"/>
+  <Type name="ns" class="ns" element="N" mass="14.01"/>
+  <Type name="nt" class="nt" element="N" mass="14.01"/>
+  <Type name="nx" class="nx" element="N" mass="14.01"/>
+  <Type name="ny" class="ny" element="N" mass="14.01"/>
+  <Type name="nz" class="nz" element="N" mass="14.01"/>
+  <Type name="n+" class="n+" element="N" mass="14.01"/>
+  <Type name="nu" class="nu" element="N" mass="14.01"/>
+  <Type name="nv" class="nv" element="N" mass="14.01"/>
+  <Type name="n7" class="n7" element="N" mass="14.01"/>
+  <Type name="n8" class="n8" element="N" mass="14.01"/>
+  <Type name="n9" class="n9" element="N" mass="14.01"/>
+  <Type name="o" class="o" element="O" mass="16.0"/>
+  <Type name="oh" class="oh" element="O" mass="16.0"/>
+  <Type name="os" class="os" element="O" mass="16.0"/>
+  <Type name="ow" class="ow" element="O" mass="16.0"/>
+  <Type name="p2" class="p2" element="P" mass="30.97"/>
+  <Type name="p3" class="p3" element="P" mass="30.97"/>
+  <Type name="p4" class="p4" element="P" mass="30.97"/>
+  <Type name="p5" class="p5" element="P" mass="30.97"/>
+  <Type name="pb" class="pb" element="P" mass="30.97"/>
+  <Type name="pc" class="pc" element="P" mass="30.97"/>
+  <Type name="pd" class="pd" element="P" mass="30.97"/>
+  <Type name="pe" class="pe" element="P" mass="30.97"/>
+  <Type name="pf" class="pf" element="P" mass="30.97"/>
+  <Type name="px" class="px" element="P" mass="30.97"/>
+  <Type name="py" class="py" element="P" mass="30.97"/>
+  <Type name="s" class="s" element="S" mass="32.06"/>
+  <Type name="s2" class="s2" element="S" mass="32.06"/>
+  <Type name="s4" class="s4" element="S" mass="32.06"/>
+  <Type name="s6" class="s6" element="S" mass="32.06"/>
+  <Type name="sh" class="sh" element="S" mass="32.06"/>
+  <Type name="ss" class="ss" element="S" mass="32.06"/>
+  <Type name="sx" class="sx" element="S" mass="32.06"/>
+  <Type name="sy" class="sy" element="S" mass="32.06"/>
+ </AtomTypes>
+ <HarmonicBondForce>
+  <Bond type1="ow" type2="hw" length="0.0957" k="512941.664"/>
+  <Bond type1="hw" type2="hw" length="0.1514" k="12694.256"/>
+  <Bond type1="br" type2="br" length="0.2542" k="67789.168"/>
+  <Bond type1="br" type2="c1" length="0.1787" k="189961.968"/>
+  <Bond type1="br" type2="c2" length="0.1893" k="141343.888"/>
+  <Bond type1="br" type2="c" length="0.1946" k="122574.464"/>
+  <Bond type1="br" type2="c3" length="0.1978" k="112742.064"/>
+  <Bond type1="br" type2="ca" length="0.1908" k="135687.12"/>
+  <Bond type1="br" type2="cc" length="0.1885" k="144373.104"/>
+  <Bond type1="br" type2="cx" length="0.1926" k="129394.384"/>
+  <Bond type1="br" type2="n1" length="0.186" k="118415.568"/>
+  <Bond type1="br" type2="n2" length="0.2038" k="74031.696"/>
+  <Bond type1="br" type2="n" length="0.1873" k="114248.304"/>
+  <Bond type1="br" type2="n3" length="0.1952" k="92391.088"/>
+  <Bond type1="br" type2="n4" length="0.1926" k="98985.072"/>
+  <Bond type1="br" type2="na" length="0.2002" k="81127.76"/>
+  <Bond type1="br" type2="nh" length="0.1944" k="94365.936"/>
+  <Bond type1="br" type2="no" length="0.2101" k="63303.92"/>
+  <Bond type1="br" type2="o" length="0.18" k="161987.744"/>
+  <Bond type1="br" type2="oh" length="0.1866" k="134616.016"/>
+  <Bond type1="br" type2="os" length="0.1887" k="127093.184"/>
+  <Bond type1="br" type2="p2" length="0.221" k="111394.816"/>
+  <Bond type1="br" type2="p3" length="0.2231" k="106106.24"/>
+  <Bond type1="br" type2="p4" length="0.2171" k="122072.384"/>
+  <Bond type1="br" type2="p5" length="0.2196" k="115093.472"/>
+  <Bond type1="br" type2="s" length="0.222" k="141586.56"/>
+  <Bond type1="br" type2="s4" length="0.2341" k="107779.84"/>
+  <Bond type1="br" type2="s6" length="0.2214" k="143569.776"/>
+  <Bond type1="br" type2="sh" length="0.2209" k="145251.744"/>
+  <Bond type1="br" type2="ss" length="0.2203" k="147293.536"/>
+  <Bond type1="c1" type2="c1" length="0.1198" k="700635.904"/>
+  <Bond type1="c1" type2="c2" length="0.1307" k="448399.28"/>
+  <Bond type1="c1" type2="c3" length="0.1467" k="247575.648"/>
+  <Bond type1="c1" type2="ca" length="0.144" k="272478.816"/>
+  <Bond type1="c1" type2="ce" length="0.1315" k="434039.792"/>
+  <Bond type1="c1" type2="cg" length="0.1216" k="650042.976"/>
+  <Bond type1="c1" type2="ch" length="0.1219" k="640511.824"/>
+  <Bond type1="c1" type2="cl" length="0.1631" k="218814.832"/>
+  <Bond type1="c1" type2="cx" length="0.1444" k="268236.24"/>
+  <Bond type1="c1" type2="f" length="0.127" k="403496.592"/>
+  <Bond type1="c1" type2="ha" length="0.1067" k="362936.896"/>
+  <Bond type1="c1" type2="hc" length="0.106" k="375062.128"/>
+  <Bond type1="c1" type2="i" length="0.1989" k="128457.168"/>
+  <Bond type1="c1" type2="n1" length="0.1153" k="746040.672"/>
+  <Bond type1="c1" type2="n2" length="0.1197" k="616512.4"/>
+  <Bond type1="c1" type2="n3" length="0.1347" k="335548.432"/>
+  <Bond type1="c1" type2="n4" length="0.1417" k="259115.12"/>
+  <Bond type1="c1" type2="n" length="0.133" k="358870.048"/>
+  <Bond type1="c1" type2="na" length="0.1362" k="317582.336"/>
+  <Bond type1="c1" type2="ne" length="0.1202" k="602922.768"/>
+  <Bond type1="c1" type2="nf" length="0.1202" k="602922.768"/>
+  <Bond type1="c1" type2="nh" length="0.1342" k="342284.672"/>
+  <Bond type1="c1" type2="no" length="0.1405" k="270688.064"/>
+  <Bond type1="c1" type2="o" length="0.1172" k="665239.264"/>
+  <Bond type1="c1" type2="oh" length="0.1326" k="353305.328"/>
+  <Bond type1="c1" type2="os" length="0.1318" k="364325.984"/>
+  <Bond type1="c1" type2="p2" length="0.177" k="180732.064"/>
+  <Bond type1="c1" type2="p3" length="0.179" k="170590.048"/>
+  <Bond type1="c1" type2="p4" length="0.179" k="170590.048"/>
+  <Bond type1="c1" type2="p5" length="0.1753" k="189920.128"/>
+  <Bond type1="c1" type2="s2" length="0.1595" k="318410.768"/>
+  <Bond type1="c1" type2="s" length="0.1603" k="310126.448"/>
+  <Bond type1="c1" type2="s4" length="0.1746" k="200020.304"/>
+  <Bond type1="c1" type2="s6" length="0.1722" k="214764.72"/>
+  <Bond type1="c1" type2="sh" length="0.168" k="243835.152"/>
+  <Bond type1="c1" type2="ss" length="0.169" k="236647.04"/>
+  <Bond type1="c2" type2="c2" length="0.1334" k="403195.344"/>
+  <Bond type1="c2" type2="c3" length="0.151" k="213852.608"/>
+  <Bond type1="c2" type2="ca" length="0.1385" k="333356.016"/>
+  <Bond type1="c2" type2="cc" length="0.1359" k="366501.664"/>
+  <Bond type1="c2" type2="cd" length="0.1359" k="366501.664"/>
+  <Bond type1="c2" type2="ce" length="0.1346" k="385354.768"/>
+  <Bond type1="c2" type2="cf" length="0.1346" k="385354.768"/>
+  <Bond type1="c2" type2="cl" length="0.1731" k="161251.36"/>
+  <Bond type1="c2" type2="cu" length="0.1325" k="418441.84"/>
+  <Bond type1="c2" type2="cx" length="0.1485" k="232940.016"/>
+  <Bond type1="c2" type2="cy" length="0.1509" k="214145.488"/>
+  <Bond type1="c2" type2="f" length="0.1339" k="308009.344"/>
+  <Bond type1="c2" type2="h4" length="0.1087" k="329891.664"/>
+  <Bond type1="c2" type2="h5" length="0.1091" k="323113.584"/>
+  <Bond type1="c2" type2="ha" length="0.1088" k="328176.224"/>
+  <Bond type1="c2" type2="hc" length="0.1087" k="329582.048"/>
+  <Bond type1="c2" type2="hx" length="0.1083" k="335883.152"/>
+  <Bond type1="c2" type2="i" length="0.217" k="82081.712"/>
+  <Bond type1="c2" type2="n1" length="0.1306" k="394082.592"/>
+  <Bond type1="c2" type2="n2" length="0.1282" k="434023.056"/>
+  <Bond type1="c2" type2="n3" length="0.134" k="345313.888"/>
+  <Bond type1="c2" type2="n" length="0.1399" k="276302.992"/>
+  <Bond type1="c2" type2="n4" length="0.1512" k="185309.36"/>
+  <Bond type1="c2" type2="na" length="0.1401" k="274185.888"/>
+  <Bond type1="c2" type2="nc" length="0.1313" k="383396.656"/>
+  <Bond type1="c2" type2="nd" length="0.1313" k="383396.656"/>
+  <Bond type1="c2" type2="ne" length="0.1292" k="417354.0"/>
+  <Bond type1="c2" type2="nf" length="0.1292" k="417354.0"/>
+  <Bond type1="c2" type2="nh" length="0.1387" k="289022.352"/>
+  <Bond type1="c2" type2="no" length="0.1448" k="231751.76"/>
+  <Bond type1="c2" type2="o" length="0.1225" k="531560.464"/>
+  <Bond type1="c2" type2="oh" length="0.1339" k="336669.744"/>
+  <Bond type1="c2" type2="os" length="0.136" k="310670.368"/>
+  <Bond type1="c2" type2="p2" length="0.1669" k="244747.264"/>
+  <Bond type1="c2" type2="p3" length="0.1834" k="150565.424"/>
+  <Bond type1="c2" type2="p4" length="0.1822" k="155736.848"/>
+  <Bond type1="c2" type2="p5" length="0.1863" k="139059.424"/>
+  <Bond type1="c2" type2="pe" length="0.1689" k="230212.048"/>
+  <Bond type1="c2" type2="pf" length="0.1689" k="230212.048"/>
+  <Bond type1="c2" type2="s2" length="0.161" k="303457.152"/>
+  <Bond type1="c2" type2="s" length="0.1734" k="207233.52"/>
+  <Bond type1="c2" type2="s4" length="0.176" k="191978.656"/>
+  <Bond type1="c2" type2="s6" length="0.176" k="191978.656"/>
+  <Bond type1="c2" type2="sh" length="0.1782" k="180104.464"/>
+  <Bond type1="c2" type2="ss" length="0.1736" k="206011.792"/>
+  <Bond type1="c3" type2="c3" length="0.1538" k="194572.736"/>
+  <Bond type1="c3" type2="ca" length="0.1516" k="209467.776"/>
+  <Bond type1="c3" type2="cc" length="0.1502" k="219777.152"/>
+  <Bond type1="c3" type2="cd" length="0.1502" k="219777.152"/>
+  <Bond type1="c3" type2="ce" length="0.1516" k="209250.208"/>
+  <Bond type1="c3" type2="cf" length="0.1516" k="209392.464"/>
+  <Bond type1="c3" type2="cl" length="0.1804" k="130139.136"/>
+  <Bond type1="c3" type2="cu" length="0.1478" k="238337.376"/>
+  <Bond type1="c3" type2="cv" length="0.1489" k="229425.456"/>
+  <Bond type1="c3" type2="cx" length="0.1518" k="207484.56"/>
+  <Bond type1="c3" type2="cy" length="0.1532" k="198263.024"/>
+  <Bond type1="c3" type2="f" length="0.135" k="295097.52"/>
+  <Bond type1="c3" type2="h1" length="0.1097" k="314569.856"/>
+  <Bond type1="c3" type2="h2" length="0.1096" k="315749.744"/>
+  <Bond type1="c3" type2="h3" length="0.1095" k="317540.496"/>
+  <Bond type1="c3" type2="hc" length="0.1097" k="314569.856"/>
+  <Bond type1="c3" type2="hx" length="0.1091" k="323414.832"/>
+  <Bond type1="c3" type2="i" length="0.2212" k="74450.096"/>
+  <Bond type1="c3" type2="n1" length="0.1433" k="244579.904"/>
+  <Bond type1="c3" type2="n2" length="0.1466" k="217492.688"/>
+  <Bond type1="c3" type2="n" length="0.1462" k="220722.736"/>
+  <Bond type1="c3" type2="n3" length="0.1465" k="218563.792"/>
+  <Bond type1="c3" type2="n4" length="0.1511" k="186254.944"/>
+  <Bond type1="c3" type2="na" length="0.1463" k="219952.88"/>
+  <Bond type1="c3" type2="nc" length="0.1456" k="225358.608"/>
+  <Bond type1="c3" type2="nd" length="0.1456" k="225358.608"/>
+  <Bond type1="c3" type2="nh" length="0.1464" k="219107.712"/>
+  <Bond type1="c3" type2="no" length="0.1533" k="172690.416"/>
+  <Bond type1="c3" type2="o" length="0.1317" k="366610.448"/>
+  <Bond type1="c3" type2="oh" length="0.1423" k="245517.12"/>
+  <Bond type1="c3" type2="os" length="0.1432" k="238287.168"/>
+  <Bond type1="c3" type2="p2" length="0.1855" k="142013.328"/>
+  <Bond type1="c3" type2="p3" length="0.1858" k="140758.128"/>
+  <Bond type1="c3" type2="p4" length="0.1839" k="148598.944"/>
+  <Bond type1="c3" type2="p5" length="0.1839" k="148272.592"/>
+  <Bond type1="c3" type2="px" length="0.1829" k="152866.624"/>
+  <Bond type1="c3" type2="py" length="0.184" k="148188.912"/>
+  <Bond type1="c3" type2="s" length="0.1845" k="150649.104"/>
+  <Bond type1="c3" type2="s4" length="0.1831" k="156883.264"/>
+  <Bond type1="c3" type2="s6" length="0.1808" k="167418.576"/>
+  <Bond type1="c3" type2="sh" length="0.1843" k="151276.704"/>
+  <Bond type1="c3" type2="ss" length="0.1839" k="153100.928"/>
+  <Bond type1="c3" type2="sx" length="0.1842" k="151996.352"/>
+  <Bond type1="c3" type2="sy" length="0.1809" k="166849.552"/>
+  <Bond type1="ca" type2="ca" length="0.1398" k="316787.376"/>
+  <Bond type1="ca" type2="cc" length="0.1456" k="257893.392"/>
+  <Bond type1="ca" type2="cd" length="0.1456" k="257893.392"/>
+  <Bond type1="ca" type2="ce" length="0.1476" k="239751.568"/>
+  <Bond type1="ca" type2="cf" length="0.1476" k="239751.568"/>
+  <Bond type1="ca" type2="cg" length="0.1433" k="279591.616"/>
+  <Bond type1="ca" type2="ch" length="0.1433" k="279591.616"/>
+  <Bond type1="ca" type2="cl" length="0.175" k="152272.496"/>
+  <Bond type1="ca" type2="cp" length="0.1406" k="308310.592"/>
+  <Bond type1="ca" type2="cq" length="0.1406" k="308310.592"/>
+  <Bond type1="ca" type2="cx" length="0.149" k="228555.184"/>
+  <Bond type1="ca" type2="cy" length="0.1515" k="209610.032"/>
+  <Bond type1="ca" type2="f" length="0.1349" k="295884.112"/>
+  <Bond type1="ca" type2="h4" length="0.1089" k="326477.52"/>
+  <Bond type1="ca" type2="h5" length="0.1088" k="328335.216"/>
+  <Bond type1="ca" type2="ha" length="0.1086" k="331138.496"/>
+  <Bond type1="ca" type2="i" length="0.2129" k="90600.336"/>
+  <Bond type1="ca" type2="n1" length="0.1335" k="352008.288"/>
+  <Bond type1="ca" type2="n2" length="0.1303" k="398760.304"/>
+  <Bond type1="ca" type2="n" length="0.1412" k="263767.728"/>
+  <Bond type1="ca" type2="n4" length="0.1484" k="204204.304"/>
+  <Bond type1="ca" type2="na" length="0.1384" k="292478.336"/>
+  <Bond type1="ca" type2="nb" length="0.1339" k="346636.032"/>
+  <Bond type1="ca" type2="nc" length="0.1352" k="330218.016"/>
+  <Bond type1="ca" type2="nd" length="0.1352" k="330218.016"/>
+  <Bond type1="ca" type2="ne" length="0.1408" k="267834.576"/>
+  <Bond type1="ca" type2="nf" length="0.1408" k="267834.576"/>
+  <Bond type1="ca" type2="nh" length="0.1386" k="290419.808"/>
+  <Bond type1="ca" type2="no" length="0.1469" k="215375.584"/>
+  <Bond type1="ca" type2="o" length="0.1236" k="507477.36"/>
+  <Bond type1="ca" type2="oh" length="0.1364" k="305892.24"/>
+  <Bond type1="ca" type2="os" length="0.137" k="299181.104"/>
+  <Bond type1="ca" type2="p2" length="0.184" k="148063.392"/>
+  <Bond type1="ca" type2="p3" length="0.1826" k="154121.824"/>
+  <Bond type1="ca" type2="p4" length="0.1806" k="162958.432"/>
+  <Bond type1="ca" type2="p5" length="0.1795" k="168062.912"/>
+  <Bond type1="ca" type2="pe" length="0.1829" k="152699.264"/>
+  <Bond type1="ca" type2="pf" length="0.1829" k="152699.264"/>
+  <Bond type1="ca" type2="px" length="0.1825" k="154423.072"/>
+  <Bond type1="ca" type2="py" length="0.1816" k="158305.824"/>
+  <Bond type1="ca" type2="s" length="0.1739" k="204195.936"/>
+  <Bond type1="ca" type2="s4" length="0.1788" k="177016.672"/>
+  <Bond type1="ca" type2="s6" length="0.1767" k="188154.48"/>
+  <Bond type1="ca" type2="sh" length="0.1781" k="180673.488"/>
+  <Bond type1="ca" type2="ss" length="0.1781" k="180832.48"/>
+  <Bond type1="ca" type2="sx" length="0.1825" k="159284.88"/>
+  <Bond type1="ca" type2="sy" length="0.1791" k="175543.904"/>
+  <Bond type1="c" type2="c1" length="0.146" k="253826.544"/>
+  <Bond type1="c" type2="c2" length="0.1406" k="308084.656"/>
+  <Bond type1="c" type2="c" length="0.1548" k="187761.184"/>
+  <Bond type1="c" type2="c3" length="0.1524" k="203526.496"/>
+  <Bond type1="c" type2="ca" length="0.1491" k="228161.888"/>
+  <Bond type1="c" type2="cc" length="0.1468" k="247148.88"/>
+  <Bond type1="cc" type2="cc" length="0.1428" k="284662.624"/>
+  <Bond type1="cc" type2="cd" length="0.1373" k="348217.584"/>
+  <Bond type1="cc" type2="ce" length="0.1454" k="259257.376"/>
+  <Bond type1="cc" type2="cf" length="0.1366" k="357890.992"/>
+  <Bond type1="cc" type2="cg" length="0.1426" k="286821.568"/>
+  <Bond type1="cc" type2="ch" length="0.1427" k="285482.688"/>
+  <Bond type1="cc" type2="cl" length="0.1735" k="159058.944"/>
+  <Bond type1="cc" type2="cx" length="0.1472" k="243115.504"/>
+  <Bond type1="c" type2="cd" length="0.1468" k="247148.88"/>
+  <Bond type1="c" type2="ce" length="0.1482" k="234638.72"/>
+  <Bond type1="c" type2="cf" length="0.1482" k="234638.72"/>
+  <Bond type1="cc" type2="f" length="0.1341" k="305423.632"/>
+  <Bond type1="c" type2="cg" length="0.1451" k="261843.088"/>
+  <Bond type1="c" type2="ch" length="0.1451" k="261843.088"/>
+  <Bond type1="cc" type2="h4" length="0.1082" k="337966.784"/>
+  <Bond type1="cc" type2="h5" length="0.1082" k="337640.432"/>
+  <Bond type1="cc" type2="ha" length="0.1084" k="334770.208"/>
+  <Bond type1="c" type2="cl" length="0.1803" k="130733.264"/>
+  <Bond type1="cc" type2="n2" length="0.129" k="419019.232"/>
+  <Bond type1="cc" type2="n" length="0.1381" k="296084.944"/>
+  <Bond type1="cc" type2="n4" length="0.1493" k="198087.296"/>
+  <Bond type1="cc" type2="na" length="0.138" k="296637.232"/>
+  <Bond type1="cc" type2="nc" length="0.1369" k="308862.88"/>
+  <Bond type1="cc" type2="nd" length="0.1317" k="377154.128"/>
+  <Bond type1="cc" type2="ne" length="0.1379" k="298411.248"/>
+  <Bond type1="cc" type2="nf" length="0.1298" k="405914.944"/>
+  <Bond type1="cc" type2="nh" length="0.1373" k="304151.696"/>
+  <Bond type1="cc" type2="no" length="0.1429" k="248211.616"/>
+  <Bond type1="cc" type2="oh" length="0.1347" k="325891.76"/>
+  <Bond type1="cc" type2="os" length="0.1362" k="307858.72"/>
+  <Bond type1="cc" type2="pd" length="0.1733" k="201459.6"/>
+  <Bond type1="cc" type2="sh" length="0.1769" k="186840.704"/>
+  <Bond type1="cc" type2="ss" length="0.1756" k="194120.864"/>
+  <Bond type1="cc" type2="sx" length="0.1811" k="165903.968"/>
+  <Bond type1="cc" type2="sy" length="0.1784" k="179117.04"/>
+  <Bond type1="c" type2="cu" length="0.1412" k="301415.36"/>
+  <Bond type1="c" type2="cx" length="0.1498" k="222505.12"/>
+  <Bond type1="c" type2="cy" length="0.1551" k="186087.584"/>
+  <Bond type1="cd" type2="cd" length="0.1428" k="284662.624"/>
+  <Bond type1="cd" type2="ce" length="0.1366" k="357890.992"/>
+  <Bond type1="cd" type2="cf" length="0.1454" k="259257.376"/>
+  <Bond type1="cd" type2="cg" length="0.1427" k="285482.688"/>
+  <Bond type1="cd" type2="ch" length="0.1426" k="286821.568"/>
+  <Bond type1="cd" type2="cl" length="0.1735" k="159058.944"/>
+  <Bond type1="cd" type2="cx" length="0.1472" k="243115.504"/>
+  <Bond type1="cd" type2="cy" length="0.1505" k="217015.712"/>
+  <Bond type1="cd" type2="h4" length="0.1082" k="337966.784"/>
+  <Bond type1="cd" type2="h5" length="0.1082" k="337799.424"/>
+  <Bond type1="cd" type2="ha" length="0.1084" k="334770.208"/>
+  <Bond type1="cd" type2="n2" length="0.129" k="419019.232"/>
+  <Bond type1="cd" type2="n" length="0.1381" k="296084.944"/>
+  <Bond type1="cd" type2="na" length="0.138" k="296637.232"/>
+  <Bond type1="cd" type2="nc" length="0.1317" k="377154.128"/>
+  <Bond type1="cd" type2="nd" length="0.1369" k="308862.88"/>
+  <Bond type1="cd" type2="ne" length="0.1298" k="405914.944"/>
+  <Bond type1="cd" type2="nh" length="0.1373" k="304151.696"/>
+  <Bond type1="cd" type2="oh" length="0.1347" k="325891.76"/>
+  <Bond type1="cd" type2="os" length="0.1362" k="307858.72"/>
+  <Bond type1="cd" type2="pc" length="0.1733" k="201459.6"/>
+  <Bond type1="cd" type2="ss" length="0.1756" k="194120.864"/>
+  <Bond type1="cd" type2="sy" length="0.1784" k="179117.04"/>
+  <Bond type1="ce" type2="ce" length="0.1457" k="256169.584"/>
+  <Bond type1="ce" type2="cf" length="0.1351" k="378367.488"/>
+  <Bond type1="ce" type2="cg" length="0.1427" k="285482.688"/>
+  <Bond type1="ce" type2="ch" length="0.1431" k="281407.472"/>
+  <Bond type1="ce" type2="cl" length="0.1764" k="146205.696"/>
+  <Bond type1="ce" type2="cx" length="0.1502" k="219099.344"/>
+  <Bond type1="ce" type2="cy" length="0.1516" k="209250.208"/>
+  <Bond type1="ce" type2="h4" length="0.1092" k="322502.72"/>
+  <Bond type1="ce" type2="ha" length="0.1088" k="327556.992"/>
+  <Bond type1="ce" type2="n1" length="0.1311" k="386258.512"/>
+  <Bond type1="ce" type2="n2" length="0.1287" k="424232.496"/>
+  <Bond type1="ce" type2="n" length="0.1424" k="252454.192"/>
+  <Bond type1="ce" type2="na" length="0.1421" k="255475.04"/>
+  <Bond type1="ce" type2="ne" length="0.1394" k="281641.776"/>
+  <Bond type1="ce" type2="nf" length="0.1296" k="409312.352"/>
+  <Bond type1="ce" type2="nh" length="0.139" k="285942.928"/>
+  <Bond type1="ce" type2="oh" length="0.135" k="321942.064"/>
+  <Bond type1="ce" type2="os" length="0.1371" k="297616.288"/>
+  <Bond type1="ce" type2="p2" length="0.1814" k="159301.616"/>
+  <Bond type1="ce" type2="pe" length="0.1818" k="157502.496"/>
+  <Bond type1="ce" type2="px" length="0.1821" k="156180.352"/>
+  <Bond type1="ce" type2="py" length="0.1806" k="163142.528"/>
+  <Bond type1="ce" type2="s" length="0.168" k="243835.152"/>
+  <Bond type1="ce" type2="ss" length="0.1781" k="180414.08"/>
+  <Bond type1="ce" type2="sx" length="0.1819" k="162272.256"/>
+  <Bond type1="ce" type2="sy" length="0.1788" k="176966.464"/>
+  <Bond type1="c" type2="f" length="0.1325" k="324485.936"/>
+  <Bond type1="cf" type2="cf" length="0.1457" k="256169.584"/>
+  <Bond type1="cf" type2="cg" length="0.1431" k="281407.472"/>
+  <Bond type1="cf" type2="ch" length="0.1427" k="285482.688"/>
+  <Bond type1="cf" type2="h4" length="0.1092" k="322502.72"/>
+  <Bond type1="cf" type2="ha" length="0.1088" k="327556.992"/>
+  <Bond type1="cf" type2="n1" length="0.1311" k="386258.512"/>
+  <Bond type1="cf" type2="n2" length="0.1287" k="424232.496"/>
+  <Bond type1="cf" type2="n" length="0.1424" k="252454.192"/>
+  <Bond type1="cf" type2="ne" length="0.1296" k="409312.352"/>
+  <Bond type1="cf" type2="nf" length="0.1394" k="281641.776"/>
+  <Bond type1="cf" type2="nh" length="0.139" k="285942.928"/>
+  <Bond type1="cf" type2="oh" length="0.135" k="321942.064"/>
+  <Bond type1="cf" type2="os" length="0.1371" k="297616.288"/>
+  <Bond type1="cf" type2="p2" length="0.1814" k="159301.616"/>
+  <Bond type1="cf" type2="pf" length="0.1818" k="157502.496"/>
+  <Bond type1="cf" type2="px" length="0.1821" k="156180.352"/>
+  <Bond type1="cf" type2="py" length="0.1806" k="163142.528"/>
+  <Bond type1="cf" type2="s" length="0.168" k="243835.152"/>
+  <Bond type1="cf" type2="sx" length="0.1819" k="162272.256"/>
+  <Bond type1="cf" type2="sy" length="0.1788" k="176966.464"/>
+  <Bond type1="cg" type2="cg" length="0.1369" k="352953.872"/>
+  <Bond type1="cg" type2="ch" length="0.1206" k="679096.672"/>
+  <Bond type1="cg" type2="n1" length="0.1157" k="735814.976"/>
+  <Bond type1="cg" type2="ne" length="0.1326" k="364325.984"/>
+  <Bond type1="cg" type2="pe" length="0.1621" k="284001.552"/>
+  <Bond type1="c" type2="h4" length="0.1112" k="293089.2"/>
+  <Bond type1="c" type2="h5" length="0.1105" k="302754.24"/>
+  <Bond type1="c" type2="ha" length="0.1101" k="308595.104"/>
+  <Bond type1="ch" type2="ch" length="0.1369" k="352953.872"/>
+  <Bond type1="ch" type2="n1" length="0.1157" k="735814.976"/>
+  <Bond type1="ch" type2="nf" length="0.1326" k="364325.984"/>
+  <Bond type1="ch" type2="pf" length="0.1621" k="284001.552"/>
+  <Bond type1="c" type2="i" length="0.2209" k="74918.704"/>
+  <Bond type1="cl" type2="cl" length="0.2267" k="66349.872"/>
+  <Bond type1="cl" type2="cx" length="0.1768" k="144506.992"/>
+  <Bond type1="cl" type2="cy" length="0.1792" k="134833.584"/>
+  <Bond type1="cl" type2="n1" length="0.163" k="182079.312"/>
+  <Bond type1="cl" type2="n2" length="0.1819" k="103604.208"/>
+  <Bond type1="cl" type2="n3" length="0.1777" k="116750.336"/>
+  <Bond type1="cl" type2="n" length="0.1716" k="139753.968"/>
+  <Bond type1="cl" type2="n4" length="0.1753" k="125277.328"/>
+  <Bond type1="cl" type2="na" length="0.1835" k="99043.648"/>
+  <Bond type1="cl" type2="nh" length="0.1763" k="121662.352"/>
+  <Bond type1="cl" type2="no" length="0.184" k="97662.928"/>
+  <Bond type1="cl" type2="o" length="0.1483" k="276980.8"/>
+  <Bond type1="cl" type2="oh" length="0.169" k="141511.248"/>
+  <Bond type1="cl" type2="os" length="0.173" k="125478.16"/>
+  <Bond type1="cl" type2="p2" length="0.207" k="120089.168"/>
+  <Bond type1="cl" type2="p3" length="0.2008" k="140406.672"/>
+  <Bond type1="cl" type2="p4" length="0.2008" k="140406.672"/>
+  <Bond type1="cl" type2="p5" length="0.2008" k="140406.672"/>
+  <Bond type1="cl" type2="pb" length="0.1997" k="144423.312"/>
+  <Bond type1="cl" type2="s" length="0.2072" k="192807.088"/>
+  <Bond type1="cl" type2="s2" length="0.2161" k="155326.816"/>
+  <Bond type1="cl" type2="s4" length="0.2072" k="192807.088"/>
+  <Bond type1="cl" type2="s6" length="0.2072" k="192807.088"/>
+  <Bond type1="cl" type2="sh" length="0.2072" k="192807.088"/>
+  <Bond type1="cl" type2="ss" length="0.2072" k="192807.088"/>
+  <Bond type1="cl" type2="sx" length="0.2072" k="192807.088"/>
+  <Bond type1="cl" type2="sy" length="0.2072" k="192807.088"/>
+  <Bond type1="c" type2="n2" length="0.142" k="256311.84"/>
+  <Bond type1="c" type2="n4" length="0.1546" k="165577.616"/>
+  <Bond type1="c" type2="n" length="0.1379" k="298076.528"/>
+  <Bond type1="c" type2="nc" length="0.1387" k="289557.904"/>
+  <Bond type1="c" type2="nd" length="0.1387" k="289557.904"/>
+  <Bond type1="c" type2="ne" length="0.1391" k="285097.76"/>
+  <Bond type1="c" type2="nf" length="0.1391" k="285097.76"/>
+  <Bond type1="c" type2="no" length="0.154" k="168916.448"/>
+  <Bond type1="c" type2="o" length="0.1218" k="546070.576"/>
+  <Bond type1="c" type2="oh" length="0.1351" k="320603.184"/>
+  <Bond type1="c" type2="os" length="0.1358" k="312076.192"/>
+  <Bond type1="c" type2="p2" length="0.19" k="125553.472"/>
+  <Bond type1="c" type2="p3" length="0.1883" k="131486.384"/>
+  <Bond type1="c" type2="p4" length="0.188" k="132565.856"/>
+  <Bond type1="c" type2="p5" length="0.1882" k="131913.152"/>
+  <Bond type1="cp" type2="cp" length="0.1485" k="232295.68"/>
+  <Bond type1="cp" type2="cq" length="0.1454" k="259073.28"/>
+  <Bond type1="c" type2="pe" length="0.1911" k="121879.92"/>
+  <Bond type1="c" type2="pf" length="0.1911" k="121879.92"/>
+  <Bond type1="cp" type2="na" length="0.1384" k="292478.336"/>
+  <Bond type1="cp" type2="nb" length="0.1339" k="347037.696"/>
+  <Bond type1="c" type2="px" length="0.1904" k="124197.856"/>
+  <Bond type1="c" type2="py" length="0.1867" k="137377.456"/>
+  <Bond type1="cq" type2="cq" length="0.1485" k="232295.68"/>
+  <Bond type1="c" type2="s" length="0.1672" k="249659.28"/>
+  <Bond type1="c" type2="s4" length="0.187" k="140574.032"/>
+  <Bond type1="c" type2="s6" length="0.187" k="140574.032"/>
+  <Bond type1="c" type2="sh" length="0.1797" k="172456.112"/>
+  <Bond type1="c" type2="ss" length="0.18" k="171033.552"/>
+  <Bond type1="c" type2="sx" length="0.1885" k="134917.264"/>
+  <Bond type1="c" type2="sy" length="0.1865" k="142523.776"/>
+  <Bond type1="cu" type2="cu" length="0.1294" k="472038.88"/>
+  <Bond type1="cu" type2="cx" length="0.1485" k="232379.36"/>
+  <Bond type1="cu" type2="ha" length="0.1081" k="339088.096"/>
+  <Bond type1="cv" type2="cv" length="0.1335" k="402107.504"/>
+  <Bond type1="cv" type2="cy" length="0.1515" k="209752.288"/>
+  <Bond type1="cv" type2="ha" length="0.1087" k="329582.048"/>
+  <Bond type1="cx" type2="cv" length="0.1508" k="214948.816"/>
+  <Bond type1="cx" type2="cx" length="0.1504" k="217827.408"/>
+  <Bond type1="cx" type2="cy" length="0.1515" k="209894.544"/>
+  <Bond type1="cx" type2="f" length="0.136" k="283683.568"/>
+  <Bond type1="cx" type2="h1" length="0.1089" k="326477.52"/>
+  <Bond type1="cx" type2="h2" length="0.1086" k="331297.488"/>
+  <Bond type1="cx" type2="hc" length="0.1087" k="329582.048"/>
+  <Bond type1="cx" type2="hx" length="0.1085" k="332711.68"/>
+  <Bond type1="cx" type2="n2" length="0.1482" k="205760.752"/>
+  <Bond type1="cx" type2="n3" length="0.147" k="214471.84"/>
+  <Bond type1="cx" type2="n" length="0.1442" k="237090.544"/>
+  <Bond type1="cx" type2="na" length="0.1461" k="221350.336"/>
+  <Bond type1="cx" type2="nh" length="0.1455" k="226479.92"/>
+  <Bond type1="cx" type2="oh" length="0.1361" k="309030.24"/>
+  <Bond type1="cx" type2="os" length="0.1437" k="233885.6"/>
+  <Bond type1="cx" type2="p3" length="0.1867" k="137377.456"/>
+  <Bond type1="cx" type2="s4" length="0.1822" k="160682.336"/>
+  <Bond type1="cx" type2="s6" length="0.1731" k="209091.216"/>
+  <Bond type1="cx" type2="ss" length="0.1833" k="156004.624"/>
+  <Bond type1="cy" type2="cy" length="0.1556" k="182849.168"/>
+  <Bond type1="cy" type2="f" length="0.1356" k="288553.744"/>
+  <Bond type1="cy" type2="h1" length="0.1095" k="317239.248"/>
+  <Bond type1="cy" type2="h2" length="0.1093" k="320385.616"/>
+  <Bond type1="cy" type2="hc" length="0.1095" k="317540.496"/>
+  <Bond type1="cy" type2="n" length="0.147" k="214773.088"/>
+  <Bond type1="cy" type2="n3" length="0.1479" k="208137.264"/>
+  <Bond type1="cy" type2="oh" length="0.1412" k="255416.464"/>
+  <Bond type1="cy" type2="os" length="0.1439" k="232061.376"/>
+  <Bond type1="cy" type2="s6" length="0.1851" k="148113.6"/>
+  <Bond type1="cy" type2="ss" length="0.1849" k="148858.352"/>
+  <Bond type1="cz" type2="nh" length="0.1339" k="346636.032"/>
+  <Bond type1="f" type2="n1" length="0.141" k="140021.744"/>
+  <Bond type1="f" type2="n2" length="0.1444" k="123879.872"/>
+  <Bond type1="f" type2="n3" length="0.1406" k="142080.272"/>
+  <Bond type1="f" type2="n" length="0.1397" k="146850.032"/>
+  <Bond type1="f" type2="n4" length="0.1308" k="205969.952"/>
+  <Bond type1="f" type2="na" length="0.1411" k="139511.296"/>
+  <Bond type1="f" type2="nh" length="0.1426" k="132130.72"/>
+  <Bond type1="f" type2="no" length="0.1467" k="114214.832"/>
+  <Bond type1="f" type2="o" length="0.133" k="165744.976"/>
+  <Bond type1="f" type2="oh" length="0.1444" k="108608.272"/>
+  <Bond type1="f" type2="os" length="0.1423" k="117101.792"/>
+  <Bond type1="f" type2="p2" length="0.1536" k="437069.008"/>
+  <Bond type1="f" type2="p3" length="0.1578" k="380476.224"/>
+  <Bond type1="f" type2="p4" length="0.159" k="365949.376"/>
+  <Bond type1="f" type2="p5" length="0.1586" k="370476.464"/>
+  <Bond type1="f" type2="s2" length="0.1643" k="304151.696"/>
+  <Bond type1="f" type2="s" length="0.166" k="288470.064"/>
+  <Bond type1="f" type2="s4" length="0.1591" k="358819.84"/>
+  <Bond type1="f" type2="s6" length="0.1612" k="335431.28"/>
+  <Bond type1="f" type2="sh" length="0.1649" k="298503.296"/>
+  <Bond type1="f" type2="ss" length="0.1634" k="312854.416"/>
+  <Bond type1="hn" type2="n1" length="0.0986" k="506724.24"/>
+  <Bond type1="hn" type2="n2" length="0.1023" k="419312.112"/>
+  <Bond type1="hn" type2="n3" length="0.1019" k="427839.104"/>
+  <Bond type1="hn" type2="n" length="0.1013" k="441253.008"/>
+  <Bond type1="hn" type2="n4" length="0.103" k="404065.616"/>
+  <Bond type1="hn" type2="na" length="0.101" k="447805.152"/>
+  <Bond type1="hn" type2="nh" length="0.1012" k="443052.128"/>
+  <Bond type1="hn" type2="no" length="0.1023" k="419312.112"/>
+  <Bond type1="ho" type2="o" length="0.0981" k="452106.304"/>
+  <Bond type1="ho" type2="oh" length="0.0973" k="471545.168"/>
+  <Bond type1="hp" type2="p2" length="0.1336" k="223040.672"/>
+  <Bond type1="hp" type2="p3" length="0.1412" k="167836.976"/>
+  <Bond type1="hp" type2="p4" length="0.1349" k="212212.48"/>
+  <Bond type1="hp" type2="p5" length="0.1418" k="164339.152"/>
+  <Bond type1="hs" type2="s" length="0.1353" k="241224.336"/>
+  <Bond type1="hs" type2="s4" length="0.1375" k="222028.144"/>
+  <Bond type1="hs" type2="s6" length="0.1359" k="235793.504"/>
+  <Bond type1="hs" type2="sh" length="0.1347" k="246512.912"/>
+  <Bond type1="i" type2="i" length="0.2917" k="42065.936"/>
+  <Bond type1="i" type2="n1" length="0.206" k="88290.768"/>
+  <Bond type1="i" type2="n2" length="0.2304" k="49664.08"/>
+  <Bond type1="i" type2="n" length="0.2098" k="80374.64"/>
+  <Bond type1="i" type2="n3" length="0.2185" k="65228.56"/>
+  <Bond type1="i" type2="n4" length="0.2155" k="70031.792"/>
+  <Bond type1="i" type2="na" length="0.2129" k="74533.776"/>
+  <Bond type1="i" type2="nh" length="0.215" k="70868.592"/>
+  <Bond type1="i" type2="no" length="0.2231" k="58601.104"/>
+  <Bond type1="i" type2="o" length="0.198" k="88976.944"/>
+  <Bond type1="i" type2="oh" length="0.2101" k="65588.384"/>
+  <Bond type1="i" type2="os" length="0.2129" k="61278.864"/>
+  <Bond type1="i" type2="p2" length="0.2643" k="55479.84"/>
+  <Bond type1="i" type2="p3" length="0.2566" k="64584.224"/>
+  <Bond type1="i" type2="p4" length="0.2352" k="101043.6"/>
+  <Bond type1="i" type2="p5" length="0.2596" k="60835.36"/>
+  <Bond type1="i" type2="s" length="0.243" k="96876.336"/>
+  <Bond type1="i" type2="s4" length="0.287" k="41178.928"/>
+  <Bond type1="i" type2="s6" length="0.287" k="41178.928"/>
+  <Bond type1="i" type2="sh" length="0.256" k="74107.008"/>
+  <Bond type1="i" type2="ss" length="0.2571" k="72491.984"/>
+  <Bond type1="n1" type2="n1" length="0.1135" k="628420.064"/>
+  <Bond type1="n1" type2="n2" length="0.123" k="414098.848"/>
+  <Bond type1="n1" type2="n3" length="0.135" k="257056.592"/>
+  <Bond type1="n1" type2="n4" length="0.136" k="247483.6"/>
+  <Bond type1="n1" type2="na" length="0.135" k="257056.592"/>
+  <Bond type1="n1" type2="nc" length="0.1216" k="439930.864"/>
+  <Bond type1="n1" type2="nd" length="0.1216" k="439930.864"/>
+  <Bond type1="n1" type2="ne" length="0.1252" k="378668.736"/>
+  <Bond type1="n1" type2="nf" length="0.1252" k="378668.736"/>
+  <Bond type1="n1" type2="nh" length="0.134" k="267073.088"/>
+  <Bond type1="n1" type2="no" length="0.14" k="213225.008"/>
+  <Bond type1="n1" type2="o" length="0.1277" k="249701.12"/>
+  <Bond type1="n1" type2="oh" length="0.13" k="227810.432"/>
+  <Bond type1="n1" type2="os" length="0.131" k="219015.664"/>
+  <Bond type1="n1" type2="p2" length="0.1678" k="225057.36"/>
+  <Bond type1="n1" type2="p3" length="0.166" k="237885.504"/>
+  <Bond type1="n1" type2="p4" length="0.168" k="223685.008"/>
+  <Bond type1="n1" type2="p5" length="0.1571" k="315774.848"/>
+  <Bond type1="n1" type2="s2" length="0.1449" k="569944.48"/>
+  <Bond type1="n1" type2="s" length="0.1659" k="284260.96"/>
+  <Bond type1="n1" type2="s4" length="0.165" k="292319.344"/>
+  <Bond type1="n1" type2="s6" length="0.1416" k="641591.296"/>
+  <Bond type1="n1" type2="sh" length="0.161" k="331615.472"/>
+  <Bond type1="n1" type2="ss" length="0.161" k="331615.472"/>
+  <Bond type1="n2" type2="n2" length="0.1267" k="356468.432"/>
+  <Bond type1="n2" type2="n3" length="0.1329" k="278629.296"/>
+  <Bond type1="n2" type2="n4" length="0.1679" k="83788.784"/>
+  <Bond type1="n2" type2="na" length="0.1368" k="240496.32"/>
+  <Bond type1="n2" type2="nc" length="0.1255" k="374032.864"/>
+  <Bond type1="n2" type2="nd" length="0.1255" k="374032.864"/>
+  <Bond type1="n2" type2="ne" length="0.1271" k="349891.184"/>
+  <Bond type1="n2" type2="nf" length="0.1271" k="349891.184"/>
+  <Bond type1="n2" type2="nh" length="0.1352" k="254721.92"/>
+  <Bond type1="n2" type2="no" length="0.1435" k="188079.168"/>
+  <Bond type1="n2" type2="o" length="0.1217" k="319515.344"/>
+  <Bond type1="n2" type2="oh" length="0.1391" k="160774.384"/>
+  <Bond type1="n2" type2="os" length="0.1401" k="154791.264"/>
+  <Bond type1="n2" type2="p2" length="0.1605" k="282871.872"/>
+  <Bond type1="n2" type2="p3" length="0.1764" k="174071.136"/>
+  <Bond type1="n2" type2="p4" length="0.1724" k="195853.04"/>
+  <Bond type1="n2" type2="p5" length="0.1599" k="288369.648"/>
+  <Bond type1="n2" type2="pe" length="0.154" k="349840.976"/>
+  <Bond type1="n2" type2="pf" length="0.154" k="349840.976"/>
+  <Bond type1="n2" type2="s2" length="0.1544" k="411086.368"/>
+  <Bond type1="n2" type2="s4" length="0.161" k="331615.472"/>
+  <Bond type1="n2" type2="s" length="0.1541" k="415354.048"/>
+  <Bond type1="n2" type2="s6" length="0.1554" k="398065.76"/>
+  <Bond type1="n2" type2="sh" length="0.1738" k="223802.16"/>
+  <Bond type1="n2" type2="ss" length="0.1656" k="286913.616"/>
+  <Bond type1="n3" type2="n3" length="0.1442" k="183501.872"/>
+  <Bond type1="n3" type2="n4" length="0.143" k="191208.8"/>
+  <Bond type1="n3" type2="na" length="0.142" k="198237.92"/>
+  <Bond type1="n3" type2="nh" length="0.1416" k="201426.128"/>
+  <Bond type1="n3" type2="no" length="0.1398" k="214957.184"/>
+  <Bond type1="n3" type2="o" length="0.1303" k="225132.672"/>
+  <Bond type1="n3" type2="oh" length="0.1415" k="147402.32"/>
+  <Bond type1="n3" type2="os" length="0.1441" k="134381.712"/>
+  <Bond type1="n3" type2="p2" length="0.167" k="230655.552"/>
+  <Bond type1="n3" type2="p3" length="0.173" k="192380.32"/>
+  <Bond type1="n3" type2="p4" length="0.1697" k="212404.944"/>
+  <Bond type1="n3" type2="p5" length="0.167" k="230940.064"/>
+  <Bond type1="n3" type2="py" length="0.1694" k="214404.896"/>
+  <Bond type1="n3" type2="s" length="0.1792" k="191233.904"/>
+  <Bond type1="n3" type2="s4" length="0.1754" k="213258.48"/>
+  <Bond type1="n3" type2="s6" length="0.1672" k="272830.272"/>
+  <Bond type1="n3" type2="sh" length="0.1739" k="223141.088"/>
+  <Bond type1="n3" type2="ss" length="0.1724" k="233584.352"/>
+  <Bond type1="n3" type2="sy" length="0.1696" k="253634.08"/>
+  <Bond type1="n4" type2="n4" length="0.1484" k="158038.048"/>
+  <Bond type1="n4" type2="na" length="0.1435" k="187811.392"/>
+  <Bond type1="n4" type2="nh" length="0.1466" k="168272.112"/>
+  <Bond type1="n4" type2="no" length="0.148" k="160247.2"/>
+  <Bond type1="n4" type2="o" length="0.1361" k="179978.944"/>
+  <Bond type1="n4" type2="oh" length="0.14" k="155653.168"/>
+  <Bond type1="n4" type2="os" length="0.1421" k="144180.64"/>
+  <Bond type1="n4" type2="p2" length="0.1942" k="106198.288"/>
+  <Bond type1="n4" type2="p3" length="0.188" k="125478.16"/>
+  <Bond type1="n4" type2="p4" length="0.1938" k="107327.968"/>
+  <Bond type1="n4" type2="p5" length="0.183" k="144122.064"/>
+  <Bond type1="n4" type2="py" length="0.1902" k="118189.632"/>
+  <Bond type1="n4" type2="s" length="0.1832" k="170723.936"/>
+  <Bond type1="n4" type2="s4" length="0.1972" k="116926.064"/>
+  <Bond type1="n4" type2="s6" length="0.1914" k="136314.72"/>
+  <Bond type1="n4" type2="sh" length="0.1811" k="181142.096"/>
+  <Bond type1="n4" type2="ss" length="0.1812" k="180631.648"/>
+  <Bond type1="na" type2="na" length="0.1401" k="212446.784"/>
+  <Bond type1="na" type2="nb" length="0.1347" k="259809.664"/>
+  <Bond type1="na" type2="nc" length="0.1356" k="251450.032"/>
+  <Bond type1="na" type2="nd" length="0.1354" k="253081.792"/>
+  <Bond type1="na" type2="nh" length="0.14" k="213225.008"/>
+  <Bond type1="na" type2="no" length="0.1435" k="188079.168"/>
+  <Bond type1="na" type2="o" length="0.1239" k="291164.56"/>
+  <Bond type1="na" type2="oh" length="0.1393" k="160004.528"/>
+  <Bond type1="na" type2="os" length="0.1444" k="132758.32"/>
+  <Bond type1="na" type2="p2" length="0.1749" k="181878.48"/>
+  <Bond type1="na" type2="p3" length="0.1762" k="175083.664"/>
+  <Bond type1="na" type2="p4" length="0.1564" k="323105.216"/>
+  <Bond type1="na" type2="p5" length="0.1715" k="201191.824"/>
+  <Bond type1="na" type2="pc" length="0.1732" k="191242.272"/>
+  <Bond type1="na" type2="pd" length="0.1732" k="191242.272"/>
+  <Bond type1="na" type2="py" length="0.1712" k="203007.68"/>
+  <Bond type1="na" type2="s" length="0.1765" k="206756.544"/>
+  <Bond type1="na" type2="s4" length="0.1793" k="190689.984"/>
+  <Bond type1="na" type2="s6" length="0.1723" k="234211.952"/>
+  <Bond type1="na" type2="sh" length="0.1721" k="235400.208"/>
+  <Bond type1="na" type2="ss" length="0.1732" k="227484.08"/>
+  <Bond type1="na" type2="sy" length="0.1727" k="231224.576"/>
+  <Bond type1="nb" type2="nb" length="0.1333" k="273826.064"/>
+  <Bond type1="nb" type2="pb" length="0.1587" k="299750.128"/>
+  <Bond type1="nc" type2="nc" length="0.1365" k="243232.656"/>
+  <Bond type1="nc" type2="nd" length="0.1299" k="313574.064"/>
+  <Bond type1="nc" type2="os" length="0.1401" k="154908.416"/>
+  <Bond type1="nc" type2="ss" length="0.1626" k="315180.72"/>
+  <Bond type1="nc" type2="sy" length="0.1555" k="396484.208"/>
+  <Bond type1="nd" type2="nd" length="0.1365" k="243232.656"/>
+  <Bond type1="nd" type2="os" length="0.1401" k="154908.416"/>
+  <Bond type1="nd" type2="ss" length="0.1626" k="315180.72"/>
+  <Bond type1="nd" type2="sy" length="0.1555" k="396484.208"/>
+  <Bond type1="ne" type2="ne" length="0.1422" k="196664.736"/>
+  <Bond type1="ne" type2="nf" length="0.1263" k="361723.536"/>
+  <Bond type1="ne" type2="o" length="0.1231" k="301900.704"/>
+  <Bond type1="ne" type2="p2" length="0.1563" k="324176.32"/>
+  <Bond type1="ne" type2="pe" length="0.1712" k="203007.68"/>
+  <Bond type1="ne" type2="px" length="0.1702" k="209216.736"/>
+  <Bond type1="ne" type2="py" length="0.1605" k="282955.552"/>
+  <Bond type1="ne" type2="s" length="0.1537" k="420943.872"/>
+  <Bond type1="ne" type2="sx" length="0.1838" k="167878.816"/>
+  <Bond type1="ne" type2="sy" length="0.1672" k="272830.272"/>
+  <Bond type1="nf" type2="nf" length="0.1422" k="196664.736"/>
+  <Bond type1="nf" type2="o" length="0.1231" k="301900.704"/>
+  <Bond type1="nf" type2="p2" length="0.1563" k="324176.32"/>
+  <Bond type1="nf" type2="pf" length="0.1712" k="203007.68"/>
+  <Bond type1="nf" type2="px" length="0.1702" k="209216.736"/>
+  <Bond type1="nf" type2="py" length="0.1605" k="282955.552"/>
+  <Bond type1="nf" type2="s" length="0.1537" k="420943.872"/>
+  <Bond type1="nf" type2="sx" length="0.1838" k="167878.816"/>
+  <Bond type1="nf" type2="sy" length="0.1672" k="272830.272"/>
+  <Bond type1="nh" type2="nh" length="0.1402" k="211517.936"/>
+  <Bond type1="nh" type2="no" length="0.1386" k="224203.824"/>
+  <Bond type1="nh" type2="o" length="0.1263" k="264479.008"/>
+  <Bond type1="nh" type2="oh" length="0.1416" k="146716.144"/>
+  <Bond type1="nh" type2="os" length="0.1415" k="147193.12"/>
+  <Bond type1="nh" type2="p2" length="0.1679" k="224371.184"/>
+  <Bond type1="nh" type2="p3" length="0.173" k="192380.32"/>
+  <Bond type1="nh" type2="p4" length="0.1706" k="206706.336"/>
+  <Bond type1="nh" type2="p5" length="0.1671" k="229944.272"/>
+  <Bond type1="nh" type2="s" length="0.1784" k="195685.68"/>
+  <Bond type1="nh" type2="s4" length="0.1749" k="216664.256"/>
+  <Bond type1="nh" type2="s6" length="0.1698" k="252638.288"/>
+  <Bond type1="nh" type2="sh" length="0.1708" k="244755.632"/>
+  <Bond type1="nh" type2="ss" length="0.1709" k="243952.304"/>
+  <Bond type1="nh" type2="sy" length="0.1714" k="240312.224"/>
+  <Bond type1="n" type2="n1" length="0.134" k="267073.088"/>
+  <Bond type1="n" type2="n2" length="0.136" k="247115.408"/>
+  <Bond type1="n" type2="n3" length="0.1404" k="209969.856"/>
+  <Bond type1="n" type2="n4" length="0.1432" k="189844.816"/>
+  <Bond type1="n" type2="n" length="0.1404" k="209894.544"/>
+  <Bond type1="n" type2="na" length="0.1407" k="207752.336"/>
+  <Bond type1="n" type2="nc" length="0.136" k="247584.016"/>
+  <Bond type1="n" type2="nd" length="0.136" k="247584.016"/>
+  <Bond type1="n" type2="nh" length="0.1402" k="211978.176"/>
+  <Bond type1="n" type2="no" length="0.1456" k="174297.072"/>
+  <Bond type1="n" type2="o" length="0.1243" k="286855.04"/>
+  <Bond type1="n" type2="oh" length="0.1406" k="152155.344"/>
+  <Bond type1="no" type2="no" length="0.1824" k="54735.088"/>
+  <Bond type1="no" type2="o" length="0.1226" k="307900.56"/>
+  <Bond type1="no" type2="oh" length="0.1406" k="152264.128"/>
+  <Bond type1="no" type2="os" length="0.1421" k="144130.432"/>
+  <Bond type1="no" type2="p2" length="0.1738" k="187878.336"/>
+  <Bond type1="no" type2="p3" length="0.1844" k="138582.448"/>
+  <Bond type1="no" type2="p4" length="0.187" k="128959.248"/>
+  <Bond type1="no" type2="p5" length="0.1834" k="142515.408"/>
+  <Bond type1="no" type2="s" length="0.1742" k="221174.608"/>
+  <Bond type1="n" type2="os" length="0.1409" k="150657.472"/>
+  <Bond type1="no" type2="s4" length="0.1996" k="109871.84"/>
+  <Bond type1="no" type2="s6" length="0.1976" k="115712.704"/>
+  <Bond type1="no" type2="sh" length="0.1804" k="184782.176"/>
+  <Bond type1="no" type2="ss" length="0.1828" k="172648.576"/>
+  <Bond type1="n" type2="p2" length="0.1733" k="190681.616"/>
+  <Bond type1="n" type2="p3" length="0.177" k="171058.656"/>
+  <Bond type1="n" type2="p4" length="0.1734" k="190112.592"/>
+  <Bond type1="n" type2="p5" length="0.1717" k="199928.256"/>
+  <Bond type1="n" type2="pc" length="0.174" k="186765.392"/>
+  <Bond type1="n" type2="pd" length="0.174" k="186765.392"/>
+  <Bond type1="n" type2="s" length="0.1767" k="205551.552"/>
+  <Bond type1="n" type2="s4" length="0.1768" k="204898.848"/>
+  <Bond type1="n" type2="s6" length="0.1719" k="237098.912"/>
+  <Bond type1="n" type2="sh" length="0.1728" k="230538.4"/>
+  <Bond type1="n" type2="ss" length="0.1726" k="231986.064"/>
+  <Bond type1="n" type2="sy" length="0.1716" k="238730.672"/>
+  <Bond type1="oh" type2="oh" length="0.1469" k="103035.184"/>
+  <Bond type1="oh" type2="os" length="0.1456" k="108047.616"/>
+  <Bond type1="oh" type2="p2" length="0.163" k="276035.216"/>
+  <Bond type1="oh" type2="p3" length="0.1677" k="238513.104"/>
+  <Bond type1="oh" type2="p4" length="0.1641" k="266654.688"/>
+  <Bond type1="oh" type2="p5" length="0.1615" k="289557.904"/>
+  <Bond type1="oh" type2="py" length="0.1616" k="288369.648"/>
+  <Bond type1="oh" type2="s" length="0.1812" k="183920.272"/>
+  <Bond type1="oh" type2="s4" length="0.1696" k="258571.2"/>
+  <Bond type1="oh" type2="s6" length="0.1635" k="312343.968"/>
+  <Bond type1="oh" type2="sh" length="0.1692" k="261575.312"/>
+  <Bond type1="oh" type2="ss" length="0.1688" k="264771.888"/>
+  <Bond type1="oh" type2="sy" length="0.165" k="297925.904"/>
+  <Bond type1="o" type2="o" length="0.143" k="118315.152"/>
+  <Bond type1="o" type2="oh" length="0.1517" k="87336.816"/>
+  <Bond type1="o" type2="os" length="0.1504" k="91294.88"/>
+  <Bond type1="o" type2="p2" length="0.1508" k="411739.072"/>
+  <Bond type1="o" type2="p3" length="0.1515" k="402057.296"/>
+  <Bond type1="o" type2="p4" length="0.1504" k="417546.464"/>
+  <Bond type1="o" type2="p5" length="0.1487" k="443127.44"/>
+  <Bond type1="o" type2="pe" length="0.1521" k="393973.808"/>
+  <Bond type1="o" type2="pf" length="0.1521" k="393973.808"/>
+  <Bond type1="o" type2="px" length="0.1504" k="418115.488"/>
+  <Bond type1="o" type2="py" length="0.1488" k="441755.088"/>
+  <Bond type1="o" type2="s" length="0.1802" k="189225.584"/>
+  <Bond type1="o" type2="s2" length="0.1599" k="349774.032"/>
+  <Bond type1="o" type2="s4" length="0.1504" k="478867.168"/>
+  <Bond type1="o" type2="s6" length="0.1453" k="571559.504"/>
+  <Bond type1="o" type2="sh" length="0.1605" k="343104.736"/>
+  <Bond type1="os" type2="os" length="0.1465" k="104382.432"/>
+  <Bond type1="os" type2="p2" length="0.1573" k="331456.48"/>
+  <Bond type1="os" type2="p3" length="0.1674" k="240421.008"/>
+  <Bond type1="os" type2="p4" length="0.1636" k="270872.16"/>
+  <Bond type1="os" type2="p5" length="0.1615" k="289742.0"/>
+  <Bond type1="os" type2="py" length="0.1619" k="286269.28"/>
+  <Bond type1="os" type2="s" length="0.18" k="190313.424"/>
+  <Bond type1="o" type2="ss" length="0.1507" k="474641.328"/>
+  <Bond type1="os" type2="s4" length="0.1692" k="261416.32"/>
+  <Bond type1="os" type2="s6" length="0.1623" k="324502.672"/>
+  <Bond type1="os" type2="sh" length="0.1671" k="278913.808"/>
+  <Bond type1="os" type2="ss" length="0.1704" k="252236.624"/>
+  <Bond type1="os" type2="sy" length="0.1699" k="256077.536"/>
+  <Bond type1="o" type2="sx" length="0.1513" k="464884.24"/>
+  <Bond type1="o" type2="sy" length="0.1466" k="546564.288"/>
+  <Bond type1="p2" type2="p2" length="0.1786" k="257424.784"/>
+  <Bond type1="p2" type2="p3" length="0.2152" k="98742.4"/>
+  <Bond type1="p2" type2="p4" length="0.2179" k="92617.024"/>
+  <Bond type1="p2" type2="p5" length="0.218" k="92399.456"/>
+  <Bond type1="p2" type2="pe" length="0.1867" k="204949.056"/>
+  <Bond type1="p2" type2="pf" length="0.1867" k="204949.056"/>
+  <Bond type1="p2" type2="s" length="0.1772" k="313841.84"/>
+  <Bond type1="p2" type2="s4" length="0.219" k="105662.736"/>
+  <Bond type1="p2" type2="s6" length="0.218" k="108181.504"/>
+  <Bond type1="p2" type2="sh" length="0.1971" k="181602.336"/>
+  <Bond type1="p2" type2="ss" length="0.1966" k="183987.216"/>
+  <Bond type1="p3" type2="p3" length="0.2214" k="85328.496"/>
+  <Bond type1="p3" type2="p4" length="0.2216" k="84935.2"/>
+  <Bond type1="p3" type2="p5" length="0.2213" k="85529.328"/>
+  <Bond type1="p3" type2="s" length="0.207" k="141168.16"/>
+  <Bond type1="p3" type2="s4" length="0.2087" k="135352.4"/>
+  <Bond type1="p3" type2="s6" length="0.2077" k="138733.072"/>
+  <Bond type1="p3" type2="sh" length="0.2132" k="121294.16"/>
+  <Bond type1="p3" type2="ss" length="0.2121" k="124566.048"/>
+  <Bond type1="p4" type2="p4" length="0.2034" k="131946.624"/>
+  <Bond type1="p4" type2="p5" length="0.2237" k="80918.56"/>
+  <Bond type1="p4" type2="s" length="0.2146" k="117285.888"/>
+  <Bond type1="p4" type2="s4" length="0.2251" k="91746.752"/>
+  <Bond type1="p4" type2="s6" length="0.2269" k="88064.832"/>
+  <Bond type1="p4" type2="sh" length="0.2115" k="126390.272"/>
+  <Bond type1="p4" type2="ss" length="0.2104" k="129821.152"/>
+  <Bond type1="p5" type2="p5" length="0.2054" k="125478.16"/>
+  <Bond type1="p5" type2="s" length="0.1934" k="200129.088"/>
+  <Bond type1="p5" type2="s4" length="0.204" k="152163.712"/>
+  <Bond type1="p5" type2="s6" length="0.204" k="152163.712"/>
+  <Bond type1="p5" type2="sh" length="0.2082" k="137034.368"/>
+  <Bond type1="p5" type2="ss" length="0.2118" k="125595.312"/>
+  <Bond type1="pe" type2="pe" length="0.2092" k="114189.728"/>
+  <Bond type1="pe" type2="pf" length="0.2055" k="125160.176"/>
+  <Bond type1="pe" type2="px" length="0.2005" k="142055.168"/>
+  <Bond type1="pe" type2="py" length="0.2025" k="134992.576"/>
+  <Bond type1="pe" type2="s" length="0.1758" k="326895.92"/>
+  <Bond type1="pe" type2="sx" length="0.2168" k="111294.4"/>
+  <Bond type1="pe" type2="sy" length="0.2213" k="100139.856"/>
+  <Bond type1="pf" type2="pf" length="0.2092" k="114189.728"/>
+  <Bond type1="pf" type2="px" length="0.2005" k="142055.168"/>
+  <Bond type1="pf" type2="py" length="0.2025" k="134992.576"/>
+  <Bond type1="pf" type2="s" length="0.1758" k="326895.92"/>
+  <Bond type1="pf" type2="sx" length="0.2168" k="111294.4"/>
+  <Bond type1="pf" type2="sy" length="0.2213" k="100139.856"/>
+  <Bond type1="px" type2="py" length="0.2199" k="88366.08"/>
+  <Bond type1="px" type2="sx" length="0.2242" k="93654.656"/>
+  <Bond type1="px" type2="sy" length="0.2249" k="92165.152"/>
+  <Bond type1="py" type2="py" length="0.2186" k="91102.416"/>
+  <Bond type1="py" type2="sx" length="0.2259" k="90089.888"/>
+  <Bond type1="py" type2="sy" length="0.2182" k="107671.056"/>
+  <Bond type1="s4" type2="s4" length="0.208" k="203861.216"/>
+  <Bond type1="s4" type2="s6" length="0.208" k="203861.216"/>
+  <Bond type1="s4" type2="sh" length="0.2168" k="164757.552"/>
+  <Bond type1="s4" type2="ss" length="0.2166" k="165544.144"/>
+  <Bond type1="s6" type2="s6" length="0.208" k="203861.216"/>
+  <Bond type1="s6" type2="sh" length="0.2108" k="190321.792"/>
+  <Bond type1="s6" type2="ss" length="0.2118" k="185752.864"/>
+  <Bond type1="sh" type2="sh" length="0.2058" k="215317.008"/>
+  <Bond type1="sh" type2="ss" length="0.2067" k="210538.88"/>
+  <Bond type1="s" type2="s" length="0.203" k="231023.744"/>
+  <Bond type1="s" type2="s2" length="0.1897" k="327280.848"/>
+  <Bond type1="s" type2="s4" length="0.2076" k="205894.64"/>
+  <Bond type1="s" type2="s6" length="0.2038" k="226404.608"/>
+  <Bond type1="s" type2="sh" length="0.211" k="189401.312"/>
+  <Bond type1="s" type2="ss" length="0.2089" k="199392.704"/>
+  <Bond type1="ss" type2="ss" length="0.2073" k="207534.768"/>
+  <Bond type1="sx" type2="sx" length="0.2391" k="99604.304"/>
+  <Bond type1="sx" type2="sy" length="0.2255" k="134590.912"/>
+  <Bond type1="sy" type2="sy" length="0.225" k="136138.992"/>
+  <Bond type1="br" type2="cd" length="0.1885" k="144373.104"/>
+  <Bond type1="c1" type2="cf" length="0.1315" k="434039.792"/>
+  <Bond type1="cd" type2="f" length="0.1341" k="305423.632"/>
+  <Bond type1="cd" type2="n4" length="0.1493" k="198087.296"/>
+  <Bond type1="cd" type2="nf" length="0.1379" k="298411.248"/>
+  <Bond type1="cd" type2="no" length="0.1429" k="248211.616"/>
+  <Bond type1="cd" type2="sh" length="0.1769" k="186840.704"/>
+  <Bond type1="cd" type2="sx" length="0.1811" k="165903.968"/>
+  <Bond type1="cc" type2="cy" length="0.1505" k="217015.712"/>
+  <Bond type1="cf" type2="cl" length="0.1764" k="146205.696"/>
+  <Bond type1="cf" type2="cx" length="0.1502" k="219099.344"/>
+  <Bond type1="cf" type2="cy" length="0.1516" k="209250.208"/>
+  <Bond type1="cf" type2="na" length="0.1421" k="255475.04"/>
+  <Bond type1="cf" type2="ss" length="0.1781" k="180414.08"/>
+  <Bond type1="cq" type2="na" length="0.1384" k="292478.336"/>
+  <Bond type1="cq" type2="nb" length="0.1339" k="347037.696"/>
+  <Bond type1="cl" type2="py" length="0.2045" k="127829.568"/>
+  <Bond type1="f" type2="py" length="0.1577" k="381714.688"/>
+  <Bond type1="py" type2="s" length="0.1973" k="180656.752"/>
+  <Bond type1="cy" type2="nh" length="0.1476" k="210103.744"/>
+  <Bond type1="cy" type2="hx" length="0.1091" k="323414.832"/>
+  <Bond type1="br" type2="ce" length="0.1905" k="136749.856"/>
+  <Bond type1="cc" type2="i" length="0.212" k="92550.08"/>
+  <Bond type1="cy" type2="n4" length="0.1522" k="179443.392"/>
+  <Bond type1="cy" type2="p3" length="0.1908" k="122867.344"/>
+  <Bond type1="cy" type2="na" length="0.1446" k="233492.304"/>
+  <Bond type1="cx" type2="n4" length="0.1496" k="196053.872"/>
+  <Bond type1="ne" type2="s4" length="0.166" k="283382.32"/>
+  <Bond type1="cv" type2="ss" length="0.1761" k="191418.0"/>
+  <Bond type1="cy" type2="no" length="0.1519" k="181267.616"/>
+  <Bond type1="ce" type2="cv" length="0.136" k="365530.976"/>
+  <Bond type1="cd" type2="i" length="0.2115" k="93679.76"/>
+  <Bond type1="cy" type2="s4" length="0.1913" k="125076.496"/>
+  <Bond type1="n2" type2="sy" length="0.1544" k="411220.256"/>
+  <Bond type1="cc" type2="s6" length="0.1814" k="164355.888"/>
+  <Bond type1="i" type2="s2" length="0.2883" k="40233.344"/>
+  <Bond type1="br" type2="cy" length="0.1951" k="120967.808"/>
+  <Bond type1="br" type2="cf" length="0.1905" k="136749.856"/>
+  <Bond type1="nf" type2="s4" length="0.166" k="283382.32"/>
+  <Bond type1="cf" type2="cv" length="0.136" k="365530.976"/>
+  <Bond type1="cd" type2="s6" length="0.1814" k="164355.888"/>
+  <Bond type1="ss" type2="sy" length="0.2212" k="148414.848"/>
+  <Bond type1="h5" type2="ce" length="0.1089" k="326787.136"/>
+  <Bond type1="h5" type2="cf" length="0.1089" k="326787.136"/>
+  <Bond type1="ce" type2="s4" length="0.1764" k="189744.4"/>
+  <Bond type1="cf" type2="s4" length="0.1764" k="189694.192"/>
+  <Bond type1="cy" type2="py" length="0.1937" k="113821.536"/>
+  <Bond type1="cd" type2="o" length="0.1219" k="543543.44"/>
+  <Bond type1="ne" type2="s6" length="0.1598" k="344954.064"/>
+  <Bond type1="nf" type2="s6" length="0.1598" k="344954.064"/>
+  <Bond type1="ce" type2="no" length="0.1463" k="219793.888"/>
+  <Bond type1="cf" type2="no" length="0.1463" k="219793.888"/>
+ </HarmonicBondForce>
+ <HarmonicAngleForce>
+  <Angle type1="hw" type2="ow" type3="hw" angle="1.82421813418" k="362.133568"/>
+  <Angle type1="hw" type2="hw" type3="ow" angle="2.2294835865" k="0.0"/>
+  <Angle type1="br" type2="c1" type3="br" angle="3.14159265359" k="488.958976"/>
+  <Angle type1="br" type2="c1" type3="c1" angle="3.14159265359" k="469.654"/>
+  <Angle type1="c1" type2="c1" type3="c1" angle="3.14159265359" k="548.346672"/>
+  <Angle type1="c1" type2="c1" type3="c2" angle="3.14159265359" k="522.589968"/>
+  <Angle type1="c1" type2="c1" type3="c3" angle="3.11558724774" k="485.1348"/>
+  <Angle type1="c1" type2="c1" type3="ca" angle="3.14159265359" k="489.82088"/>
+  <Angle type1="c1" type2="c1" type3="cl" angle="3.14159265359" k="535.108496"/>
+  <Angle type1="c1" type2="c1" type3="f" angle="3.14159265359" k="675.180448"/>
+  <Angle type1="c1" type2="c1" type3="ha" angle="3.12605922325" k="374.735776"/>
+  <Angle type1="c1" type2="c1" type3="hc" angle="3.14159265359" k="374.652096"/>
+  <Angle type1="c1" type2="c1" type3="i" angle="3.14159265359" k="443.386848"/>
+  <Angle type1="c1" type2="c1" type3="n1" angle="3.14159265359" k="699.246816"/>
+  <Angle type1="c1" type2="c1" type3="n2" angle="3.14159265359" k="687.0128"/>
+  <Angle type1="c1" type2="c1" type3="n3" angle="3.14159265359" k="642.001328"/>
+  <Angle type1="c1" type2="c1" type3="n4" angle="3.13391320488" k="621.273792"/>
+  <Angle type1="c1" type2="c1" type3="n" angle="3.09237436868" k="652.511536"/>
+  <Angle type1="c1" type2="c1" type3="na" angle="3.0848694529" k="643.365312"/>
+  <Angle type1="c1" type2="c1" type3="nh" angle="3.12885175005" k="644.913392"/>
+  <Angle type1="c1" type2="c1" type3="no" angle="3.14159265359" k="624.227696"/>
+  <Angle type1="c1" type2="c1" type3="o" angle="3.14159265359" k="694.008448"/>
+  <Angle type1="c1" type2="c1" type3="oh" angle="3.08312412365" k="654.729056"/>
+  <Angle type1="c1" type2="c1" type3="os" angle="3.08801104555" k="656.645328"/>
+  <Angle type1="c1" type2="c1" type3="p2" angle="3.14159265359" k="570.32104"/>
+  <Angle type1="c1" type2="c1" type3="p3" angle="2.96060201016" k="581.107392"/>
+  <Angle type1="c1" type2="c1" type3="p4" angle="3.14159265359" k="564.120352"/>
+  <Angle type1="c1" type2="c1" type3="p5" angle="3.07474654324" k="581.86888"/>
+  <Angle type1="c1" type2="c1" type3="s4" angle="2.92290289831" k="466.80888"/>
+  <Angle type1="c1" type2="c1" type3="s6" angle="3.04350514963" k="463.486784"/>
+  <Angle type1="c1" type2="c1" type3="s" angle="3.14106905481" k="486.423472"/>
+  <Angle type1="c1" type2="c1" type3="sh" angle="3.14159265359" k="466.708464"/>
+  <Angle type1="c1" type2="c1" type3="ss" angle="3.0647981665" k="470.022192"/>
+  <Angle type1="c2" type2="c1" type3="c2" angle="3.1305970793" k="503.62808"/>
+  <Angle type1="c2" type2="c1" type3="ce" angle="3.1250120257" k="502.473296"/>
+  <Angle type1="c2" type2="c1" type3="n1" angle="3.14159265359" k="663.649344"/>
+  <Angle type1="c2" type2="c1" type3="o" angle="3.13286600733" k="660.762384"/>
+  <Angle type1="c2" type2="c1" type3="s2" angle="3.0190705401" k="489.661888"/>
+  <Angle type1="c3" type2="c1" type3="c3" angle="3.14159265359" k="447.880464"/>
+  <Angle type1="c3" type2="c1" type3="cg" angle="3.11419098433" k="483.41936"/>
+  <Angle type1="c3" type2="c1" type3="n1" angle="3.11680897821" k="612.671488"/>
+  <Angle type1="ca" type2="c1" type3="ca" angle="3.14159265359" k="456.30704"/>
+  <Angle type1="c" type2="c1" type3="c1" angle="3.14159265359" k="484.875392"/>
+  <Angle type1="cg" type2="c1" type3="ha" angle="3.12117230134" k="371.472256"/>
+  <Angle type1="ch" type2="c1" type3="ha" angle="3.12117230134" k="370.760976"/>
+  <Angle type1="cl" type2="c1" type3="cl" angle="3.14159265359" k="587.123984"/>
+  <Angle type1="f" type2="c1" type3="f" angle="3.14159265359" k="834.858624"/>
+  <Angle type1="i" type2="c1" type3="i" angle="3.14159265359" k="488.666096"/>
+  <Angle type1="n1" type2="c1" type3="n1" angle="1.78041036996" k="1186.599136"/>
+  <Angle type1="n1" type2="c1" type3="n3" angle="3.07195401644" k="823.310784"/>
+  <Angle type1="n1" type2="c1" type3="nh" angle="3.10057741617" k="821.69576"/>
+  <Angle type1="n1" type2="c1" type3="os" angle="3.11698351114" k="829.6872"/>
+  <Angle type1="n1" type2="c1" type3="p3" angle="2.98800367941" k="724.350816"/>
+  <Angle type1="n1" type2="c1" type3="ss" angle="3.09743582351" k="586.881312"/>
+  <Angle type1="n2" type2="c1" type3="n2" angle="3.14159265359" k="860.749216"/>
+  <Angle type1="n2" type2="c1" type3="o" angle="3.01470721697" k="887.643968"/>
+  <Angle type1="n2" type2="c1" type3="s" angle="3.07020868718" k="616.202784"/>
+  <Angle type1="n3" type2="c1" type3="n3" angle="3.14159265359" k="764.676208"/>
+  <Angle type1="n4" type2="c1" type3="n4" angle="3.14159265359" k="727.170832"/>
+  <Angle type1="na" type2="c1" type3="na" angle="3.14159265359" k="756.534144"/>
+  <Angle type1="ne" type2="c1" type3="o" angle="3.00772589996" k="886.639808"/>
+  <Angle type1="ne" type2="c1" type3="s" angle="3.06863789086" k="615.96848"/>
+  <Angle type1="nf" type2="c1" type3="o" angle="3.00772589996" k="886.639808"/>
+  <Angle type1="nh" type2="c1" type3="nh" angle="3.14159265359" k="767.63848"/>
+  <Angle type1="n" type2="c1" type3="n" angle="3.14159265359" k="774.734544"/>
+  <Angle type1="no" type2="c1" type3="no" angle="3.14159265359" k="733.379888"/>
+  <Angle type1="oh" type2="c1" type3="oh" angle="3.14159265359" k="777.077584"/>
+  <Angle type1="o" type2="c1" type3="o" angle="3.14159265359" k="878.882672"/>
+  <Angle type1="os" type2="c1" type3="os" angle="3.14159265359" k="781.730192"/>
+  <Angle type1="p2" type2="c1" type3="p2" angle="3.14159265359" k="714.568624"/>
+  <Angle type1="p3" type2="c1" type3="p3" angle="3.14159265359" k="706.585552"/>
+  <Angle type1="p4" type2="c1" type3="p4" angle="3.14159265359" k="706.585552"/>
+  <Angle type1="p5" type2="c1" type3="p5" angle="3.14159265359" k="721.497328"/>
+  <Angle type1="s2" type2="c1" type3="s2" angle="3.14159265359" k="481.477984"/>
+  <Angle type1="s4" type2="c1" type3="s4" angle="3.14159265359" k="439.838816"/>
+  <Angle type1="s6" type2="c1" type3="s6" angle="3.14159265359" k="445.97256"/>
+  <Angle type1="sh" type2="c1" type3="sh" angle="3.14159265359" k="457.118736"/>
+  <Angle type1="s" type2="c1" type3="s" angle="3.14159265359" k="479.017792"/>
+  <Angle type1="ss" type2="c1" type3="ss" angle="3.14159265359" k="454.46608"/>
+  <Angle type1="br" type2="c2" type3="br" angle="2.00817583734" k="577.383632"/>
+  <Angle type1="br" type2="c2" type3="c2" angle="2.11237199369" k="539.384544"/>
+  <Angle type1="br" type2="c2" type3="c3" angle="2.0127136934" k="542.530912"/>
+  <Angle type1="br" type2="c2" type3="ce" angle="2.12109863995" k="537.886672"/>
+  <Angle type1="br" type2="c2" type3="h4" angle="1.98496295829" k="358.535328"/>
+  <Angle type1="br" type2="c2" type3="ha" angle="1.97710897666" k="359.296816"/>
+  <Angle type1="c1" type2="c2" type3="c1" angle="2.03802096755" k="624.194224"/>
+  <Angle type1="c1" type2="c2" type3="c2" angle="2.12266943628" k="605.165392"/>
+  <Angle type1="c1" type2="c2" type3="c3" angle="2.17991623574" k="554.38"/>
+  <Angle type1="c1" type2="c2" type3="f" angle="2.17991623574" k="757.312368"/>
+  <Angle type1="c1" type2="c2" type3="ha" angle="2.10172548525" k="427.947888"/>
+  <Angle type1="c2" type2="c2" type3="c2" angle="2.12598556185" k="598.638352"/>
+  <Angle type1="c2" type2="c2" type3="c3" angle="2.15775055424" k="553.392576"/>
+  <Angle type1="c2" type2="c2" type3="ca" angle="2.04203522483" k="599.10696"/>
+  <Angle type1="c2" type2="c2" type3="cc" angle="2.04570041626" k="604.50432"/>
+  <Angle type1="c2" type2="c2" type3="cd" angle="2.04570041626" k="604.50432"/>
+  <Angle type1="c2" type2="c2" type3="cl" angle="2.14867484213" k="605.265808"/>
+  <Angle type1="c2" type2="c2" type3="cx" angle="2.18078890037" k="556.379952"/>
+  <Angle type1="c2" type2="c2" type3="cy" angle="2.04517681749" k="568.513552"/>
+  <Angle type1="c2" type2="c2" type3="f" angle="2.14448605193" k="755.948384"/>
+  <Angle type1="c2" type2="c2" type3="h4" angle="2.14099539342" k="417.680352"/>
+  <Angle type1="c2" type2="c2" type3="ha" angle="2.10190001818" k="421.437584"/>
+  <Angle type1="c2" type2="c2" type3="hc" angle="2.08915911464" k="422.809936"/>
+  <Angle type1="c2" type2="c2" type3="hx" angle="2.20696883915" k="411.739072"/>
+  <Angle type1="c2" type2="c2" type3="i" angle="2.11237199369" k="496.398128"/>
+  <Angle type1="c2" type2="c2" type3="n1" angle="2.1464059141" k="753.898224"/>
+  <Angle type1="c2" type2="c2" type3="n2" angle="2.19928939044" k="751.262304"/>
+  <Angle type1="c2" type2="c2" type3="n3" angle="2.17380758336" k="739.764672"/>
+  <Angle type1="c2" type2="c2" type3="n4" angle="2.12092410702" k="698.066928"/>
+  <Angle type1="c2" type2="c2" type3="n" angle="2.15844868594" k="725.447024"/>
+  <Angle type1="c2" type2="c2" type3="na" angle="2.12825448988" k="729.957376"/>
+  <Angle type1="c2" type2="c2" type3="nh" angle="2.18148703207" k="725.112304"/>
+  <Angle type1="c2" type2="c2" type3="no" angle="2.15478349451" k="711.78208"/>
+  <Angle type1="c2" type2="c2" type3="o" angle="2.28446145794" k="751.387824"/>
+  <Angle type1="c2" type2="c2" type3="oh" angle="2.13226874716" k="747.362816"/>
+  <Angle type1="c2" type2="c2" type3="os" angle="2.12703275941" k="742.291808"/>
+  <Angle type1="c2" type2="c2" type3="p2" angle="2.00887396905" k="740.701888"/>
+  <Angle type1="c2" type2="c2" type3="p3" angle="2.17869450526" k="657.498864"/>
+  <Angle type1="c2" type2="c2" type3="p4" angle="2.09020631219" k="675.17208"/>
+  <Angle type1="c2" type2="c2" type3="p5" angle="2.19859125874" k="645.515888"/>
+  <Angle type1="c2" type2="c2" type3="s4" angle="2.09160257559" k="541.802896"/>
+  <Angle type1="c2" type2="c2" type3="s6" angle="2.09456963532" k="541.426336"/>
+  <Angle type1="c2" type2="c2" type3="s" angle="2.25793245331" k="527.953856"/>
+  <Angle type1="c2" type2="c2" type3="sh" angle="2.19387886976" k="523.493712"/>
+  <Angle type1="c2" type2="c2" type3="ss" angle="2.13541033982" k="542.37192"/>
+  <Angle type1="c3" type2="c2" type3="c3" angle="2.01847327993" k="543.066464"/>
+  <Angle type1="c3" type2="c2" type3="cc" angle="2.18497769057" k="546.288144"/>
+  <Angle type1="c3" type2="c2" type3="cd" angle="2.18497769057" k="546.288144"/>
+  <Angle type1="c3" type2="c2" type3="ce" angle="2.14937297383" k="552.756608"/>
+  <Angle type1="c3" type2="c2" type3="cf" angle="2.14937297383" k="552.756608"/>
+  <Angle type1="c3" type2="c2" type3="h4" angle="2.07729087572" k="382.91968"/>
+  <Angle type1="c3" type2="c2" type3="ha" angle="2.01899687871" k="388.367248"/>
+  <Angle type1="c3" type2="c2" type3="hc" angle="2.09439510239" k="381.346496"/>
+  <Angle type1="c3" type2="c2" type3="n2" angle="2.15425989574" k="702.57728"/>
+  <Angle type1="c3" type2="c2" type3="n" angle="2.00363798129" k="706.376352"/>
+  <Angle type1="c3" type2="c2" type3="na" angle="2.04552588334" k="698.68616"/>
+  <Angle type1="c3" type2="c2" type3="ne" angle="2.10678694008" k="708.819808"/>
+  <Angle type1="c3" type2="c2" type3="nf" angle="2.10678694008" k="708.819808"/>
+  <Angle type1="c3" type2="c2" type3="nh" angle="2.02824712374" k="704.54376"/>
+  <Angle type1="c3" type2="c2" type3="o" angle="2.1436133873" k="713.003808"/>
+  <Angle type1="c3" type2="c2" type3="oh" angle="2.0099211666" k="717.229648"/>
+  <Angle type1="c3" type2="c2" type3="os" angle="1.96873139625" k="720.627056"/>
+  <Angle type1="c3" type2="c2" type3="p2" angle="2.1422171239" k="691.272112"/>
+  <Angle type1="c3" type2="c2" type3="s" angle="2.0148080885" k="541.74432"/>
+  <Angle type1="c3" type2="c2" type3="ss" angle="2.08846098294" k="531.694352"/>
+  <Angle type1="ca" type2="c2" type3="ca" angle="2.05739412225" k="586.42944"/>
+  <Angle type1="ca" type2="c2" type3="hc" angle="2.15199096771" k="404.802"/>
+  <Angle type1="c" type2="c2" type3="c2" angle="2.10661240716" k="584.847888"/>
+  <Angle type1="c" type2="c2" type3="c3" angle="2.08915911464" k="551.359152"/>
+  <Angle type1="c" type2="c2" type3="c" angle="2.07484741477" k="575.065696"/>
+  <Angle type1="cc" type2="c2" type3="h4" angle="2.09177710852" k="416.609248"/>
+  <Angle type1="cc" type2="c2" type3="ha" angle="2.07257848674" k="418.433472"/>
+  <Angle type1="cc" type2="c2" type3="nh" angle="2.14884937506" k="724.350816"/>
+  <Angle type1="cc" type2="c2" type3="o" angle="2.15705242254" k="764.433536"/>
+  <Angle type1="cd" type2="c2" type3="ha" angle="2.07257848674" k="418.433472"/>
+  <Angle type1="ce" type2="c2" type3="cl" angle="2.15495802744" k="603.391376"/>
+  <Angle type1="ce" type2="c2" type3="h4" angle="2.13471220811" k="415.504672"/>
+  <Angle type1="ce" type2="c2" type3="ha" angle="2.10224908403" k="418.600832"/>
+  <Angle type1="ce" type2="c2" type3="na" angle="2.1671753322" k="720.551744"/>
+  <Angle type1="ce" type2="c2" type3="nh" angle="2.10678694008" k="734.894496"/>
+  <Angle type1="ce" type2="c2" type3="no" angle="2.08828645001" k="720.459696"/>
+  <Angle type1="ce" type2="c2" type3="o" angle="2.15321269819" k="769.789056"/>
+  <Angle type1="ce" type2="c2" type3="oh" angle="2.14902390798" k="741.162128"/>
+  <Angle type1="ce" type2="c2" type3="os" angle="2.14326432145" k="736.34216"/>
+  <Angle type1="cf" type2="c2" type3="ha" angle="2.10224908403" k="418.600832"/>
+  <Angle type1="c" type2="c2" type3="ha" angle="2.11760798144" k="403.00288"/>
+  <Angle type1="c" type2="c2" type3="hc" angle="2.08915911464" k="405.797792"/>
+  <Angle type1="cl" type2="c2" type3="cl" angle="1.99560946673" k="694.184176"/>
+  <Angle type1="cl" type2="c2" type3="h4" angle="1.98164683271" k="414.241104"/>
+  <Angle type1="cl" type2="c2" type3="ha" angle="1.97571271326" k="414.877072"/>
+  <Angle type1="cx" type2="c2" type3="ha" angle="2.02719992619" k="393.346208"/>
+  <Angle type1="f" type2="c2" type3="f" angle="1.94848557693" k="1005.825232"/>
+  <Angle type1="f" type2="c2" type3="ha" angle="1.91986217719" k="558.81504"/>
+  <Angle type1="h4" type2="c2" type3="n2" angle="2.11167386199" k="542.33008"/>
+  <Angle type1="h4" type2="c2" type3="n" angle="1.97990150346" k="524.012528"/>
+  <Angle type1="h4" type2="c2" type3="na" angle="1.97169845598" k="524.4644"/>
+  <Angle type1="h4" type2="c2" type3="ne" angle="2.08584298906" k="542.731744"/>
+  <Angle type1="h4" type2="c2" type3="nh" angle="2.0085249032" k="523.945584"/>
+  <Angle type1="h4" type2="c2" type3="no" angle="1.97885430591" k="509.468944"/>
+  <Angle type1="h4" type2="c2" type3="os" angle="1.98496295829" k="535.459952"/>
+  <Angle type1="h4" type2="c2" type3="ss" angle="2.0362756383" k="364.80296"/>
+  <Angle type1="h5" type2="c2" type3="n2" angle="2.12406569968" k="540.095824"/>
+  <Angle type1="h5" type2="c2" type3="na" angle="2.2059216416" k="495.452544"/>
+  <Angle type1="h5" type2="c2" type3="ne" angle="2.09177710852" k="541.334288"/>
+  <Angle type1="h5" type2="c2" type3="nh" angle="1.98810455095" k="526.196576"/>
+  <Angle type1="ha" type2="c2" type3="ha" angle="2.04028989558" k="315.339712"/>
+  <Angle type1="ha" type2="c2" type3="n1" angle="2.10765960471" k="535.443216"/>
+  <Angle type1="ha" type2="c2" type3="n2" angle="2.10381988035" k="543.175248"/>
+  <Angle type1="ha" type2="c2" type3="n3" angle="1.98164683271" k="541.777792"/>
+  <Angle type1="ha" type2="c2" type3="n" angle="1.97920337176" k="524.00416"/>
+  <Angle type1="ha" type2="c2" type3="na" angle="1.96209914509" k="525.644288"/>
+  <Angle type1="ha" type2="c2" type3="ne" angle="2.11498998757" k="538.823888"/>
+  <Angle type1="ha" type2="c2" type3="nf" angle="2.11498998757" k="538.823888"/>
+  <Angle type1="ha" type2="c2" type3="nh" angle="2.03645017123" k="520.230192"/>
+  <Angle type1="ha" type2="c2" type3="no" angle="1.95721222319" k="512.196912"/>
+  <Angle type1="ha" type2="c2" type3="o" angle="2.04604948211" k="567.978"/>
+  <Angle type1="ha" type2="c2" type3="oh" angle="2.02772352497" k="536.037344"/>
+  <Angle type1="ha" type2="c2" type3="os" angle="1.96681153407" k="537.802992"/>
+  <Angle type1="ha" type2="c2" type3="p2" angle="2.12022597532" k="477.904848"/>
+  <Angle type1="ha" type2="c2" type3="p3" angle="1.99508586795" k="445.813568"/>
+  <Angle type1="ha" type2="c2" type3="p4" angle="2.0570450564" k="442.240432"/>
+  <Angle type1="ha" type2="c2" type3="p5" angle="2.02458193231" k="435.002112"/>
+  <Angle type1="ha" type2="c2" type3="pe" angle="2.11882971192" k="472.315024"/>
+  <Angle type1="ha" type2="c2" type3="pf" angle="2.11882971192" k="472.315024"/>
+  <Angle type1="ha" type2="c2" type3="s2" angle="2.07240395382" k="390.216576"/>
+  <Angle type1="ha" type2="c2" type3="s4" angle="2.01236462755" k="361.690064"/>
+  <Angle type1="ha" type2="c2" type3="s" angle="2.01934594456" k="366.786176"/>
+  <Angle type1="ha" type2="c2" type3="s6" angle="2.03505390783" k="359.673376"/>
+  <Angle type1="ha" type2="c2" type3="sh" angle="1.95023090618" k="362.560336"/>
+  <Angle type1="ha" type2="c2" type3="ss" angle="2.03714830293" k="364.744384"/>
+  <Angle type1="hc" type2="c2" type3="hc" angle="2.07554554647" k="312.912992"/>
+  <Angle type1="hc" type2="c2" type3="n2" angle="2.1013764194" k="543.62712"/>
+  <Angle type1="hc" type2="c2" type3="n" angle="1.99037347897" k="522.615072"/>
+  <Angle type1="hc" type2="c2" type3="na" angle="2.07868713913" k="510.765984"/>
+  <Angle type1="hc" type2="c2" type3="nh" angle="1.97850524006" k="527.886912"/>
+  <Angle type1="hc" type2="c2" type3="no" angle="1.95686315734" k="512.305696"/>
+  <Angle type1="hc" type2="c2" type3="oh" angle="2.02842165667" k="536.05408"/>
+  <Angle type1="hc" type2="c2" type3="os" angle="2.02650179449" k="529.920336"/>
+  <Angle type1="hc" type2="c2" type3="p3" angle="2.04535135041" k="440.265584"/>
+  <Angle type1="hc" type2="c2" type3="p5" angle="2.08706471953" k="428.39976"/>
+  <Angle type1="hc" type2="c2" type3="s4" angle="2.02667632742" k="360.393024"/>
+  <Angle type1="hc" type2="c2" type3="s6" angle="2.01498262143" k="361.439024"/>
+  <Angle type1="hc" type2="c2" type3="sh" angle="2.01812421408" k="356.384752"/>
+  <Angle type1="hc" type2="c2" type3="ss" angle="2.01794968116" k="366.459824"/>
+  <Angle type1="hx" type2="c2" type3="n4" angle="1.97274565353" k="491.343856"/>
+  <Angle type1="i" type2="c2" type3="i" angle="2.0584413198" k="553.308896"/>
+  <Angle type1="n1" type2="c2" type3="n1" angle="2.16682626635" k="950.002304"/>
+  <Angle type1="n2" type2="c2" type3="n2" angle="1.98653375462" k="1010.988288"/>
+  <Angle type1="n2" type2="c2" type3="n4" angle="1.97169845598" k="918.34616"/>
+  <Angle type1="n2" type2="c2" type3="na" angle="2.15757602132" k="923.090816"/>
+  <Angle type1="n2" type2="c2" type3="nh" angle="2.16892066145" k="926.404544"/>
+  <Angle type1="n2" type2="c2" type3="oh" angle="2.13069795083" k="954.127728"/>
+  <Angle type1="n2" type2="c2" type3="os" angle="2.09055537804" k="954.7888"/>
+  <Angle type1="n2" type2="c2" type3="ss" angle="2.26491377031" k="663.574032"/>
+  <Angle type1="n3" type2="c2" type3="n3" angle="2.06769156484" k="947.834992"/>
+  <Angle type1="n4" type2="c2" type3="n4" angle="1.9884536168" k="856.305808"/>
+  <Angle type1="n4" type2="c2" type3="ss" angle="2.02929432129" k="675.013088"/>
+  <Angle type1="na" type2="c2" type3="na" angle="1.90816847121" k="943.36648"/>
+  <Angle type1="ne" type2="c2" type3="nh" angle="2.15478349451" k="926.571904"/>
+  <Angle type1="ne" type2="c2" type3="os" angle="2.07275301967" k="955.734384"/>
+  <Angle type1="ne" type2="c2" type3="ss" angle="2.10329628158" k="687.89144"/>
+  <Angle type1="nf" type2="c2" type3="nh" angle="2.15478349451" k="926.571904"/>
+  <Angle type1="nh" type2="c2" type3="nh" angle="1.9690804621" k="938.236896"/>
+  <Angle type1="nh" type2="c2" type3="oh" angle="2.04395508701" k="936.747392"/>
+  <Angle type1="nh" type2="c2" type3="os" angle="1.99491133503" k="941.31632"/>
+  <Angle type1="nh" type2="c2" type3="ss" angle="1.9469147806" k="705.782224"/>
+  <Angle type1="n" type2="c2" type3="n2" angle="2.1436133873" k="926.940096"/>
+  <Angle type1="n" type2="c2" type3="n" angle="1.97623631203" k="928.371024"/>
+  <Angle type1="n" type2="c2" type3="na" angle="1.83992609745" k="961.424624"/>
+  <Angle type1="n" type2="c2" type3="ne" angle="2.18759568445" k="914.814864"/>
+  <Angle type1="n" type2="c2" type3="nh" angle="1.90851753706" k="948.797312"/>
+  <Angle type1="no" type2="c2" type3="no" angle="1.98793001802" k="894.505728"/>
+  <Angle type1="n" type2="c2" type3="ss" angle="1.94063159529" k="705.50608"/>
+  <Angle type1="oh" type2="c2" type3="oh" angle="1.99543493381" k="965.926608"/>
+  <Angle type1="o" type2="c2" type3="o" angle="2.12389116675" k="1023.255776"/>
+  <Angle type1="o" type2="c2" type3="oh" angle="2.11586265219" k="975.825952"/>
+  <Angle type1="o" type2="c2" type3="s" angle="2.22843638895" k="672.887616"/>
+  <Angle type1="os" type2="c2" type3="os" angle="2.00800130442" k="947.960512"/>
+  <Angle type1="p2" type2="c2" type3="p2" angle="2.26543736909" k="892.61456"/>
+  <Angle type1="p3" type2="c2" type3="p3" angle="2.01655341775" k="860.77432"/>
+  <Angle type1="p5" type2="c2" type3="p5" angle="2.12668369356" k="825.319104"/>
+  <Angle type1="s4" type2="c2" type3="s4" angle="2.099980156" k="533.694304"/>
+  <Angle type1="s4" type2="c2" type3="s6" angle="2.09352243777" k="534.522736"/>
+  <Angle type1="s6" type2="c2" type3="s6" angle="2.09387150362" k="534.472528"/>
+  <Angle type1="sh" type2="c2" type3="sh" angle="1.9282397576" k="550.078848"/>
+  <Angle type1="sh" type2="c2" type3="ss" angle="2.0563469247" k="539.451488"/>
+  <Angle type1="s" type2="c2" type3="s" angle="2.1235421009" k="538.681632"/>
+  <Angle type1="ss" type2="c2" type3="ss" angle="2.03156324932" k="550.11232"/>
+  <Angle type1="br" type2="c3" type3="br" angle="1.91532432114" k="565.777216"/>
+  <Angle type1="br" type2="c3" type3="c1" angle="1.95127810373" k="534.162912"/>
+  <Angle type1="br" type2="c3" type3="c3" angle="1.92003671012" k="534.38048"/>
+  <Angle type1="br" type2="c3" type3="c" angle="1.90101262127" k="537.928512"/>
+  <Angle type1="br" type2="c3" type3="h1" angle="1.83381744507" k="355.079344"/>
+  <Angle type1="br" type2="c3" type3="h2" angle="1.86401164113" k="352.142176"/>
+  <Angle type1="br" type2="c3" type3="hc" angle="1.85877565337" k="352.686096"/>
+  <Angle type1="c1" type2="c3" type3="c1" angle="1.92178203937" k="572.647344"/>
+  <Angle type1="c1" type2="c3" type3="c2" angle="1.93591920631" k="562.195712"/>
+  <Angle type1="c1" type2="c3" type3="c3" angle="1.9497073074" k="554.597568"/>
+  <Angle type1="c1" type2="c3" type3="ca" angle="1.93539560754" k="561.049296"/>
+  <Angle type1="c1" type2="c3" type3="cc" angle="1.99299147285" k="555.660304"/>
+  <Angle type1="c1" type2="c3" type3="cd" angle="1.99299147285" k="555.660304"/>
+  <Angle type1="c1" type2="c3" type3="cl" angle="1.93085775148" k="605.533584"/>
+  <Angle type1="c1" type2="c3" type3="h1" angle="1.90659767488" k="409.337456"/>
+  <Angle type1="c1" type2="c3" type3="hc" angle="1.90956473461" k="409.019472"/>
+  <Angle type1="c1" type2="c3" type3="hx" angle="1.95546689393" k="404.500752"/>
+  <Angle type1="c1" type2="c3" type3="n3" angle="1.96750966577" k="709.296784"/>
+  <Angle type1="c1" type2="c3" type3="n4" angle="1.95581595978" k="700.050144"/>
+  <Angle type1="c1" type2="c3" type3="n" angle="1.96140101339" k="711.0708"/>
+  <Angle type1="c1" type2="c3" type3="nh" angle="1.96471713897" k="709.966224"/>
+  <Angle type1="c1" type2="c3" type3="oh" angle="1.91008833338" k="729.85696"/>
+  <Angle type1="c1" type2="c3" type3="os" angle="1.90240888467" k="729.346512"/>
+  <Angle type1="c2" type2="c3" type3="c2" angle="1.95476876223" k="551.844496"/>
+  <Angle type1="c2" type2="c3" type3="c3" angle="1.94708931352" k="547.760912"/>
+  <Angle type1="c2" type2="c3" type3="ca" angle="1.96332087557" k="549.52656"/>
+  <Angle type1="c2" type2="c3" type3="cc" angle="1.95319796591" k="553.526464"/>
+  <Angle type1="c2" type2="c3" type3="cd" angle="1.95319796591" k="553.526464"/>
+  <Angle type1="c2" type2="c3" type3="ce" angle="1.95145263665" k="551.141584"/>
+  <Angle type1="c2" type2="c3" type3="cf" angle="1.95145263665" k="551.175056"/>
+  <Angle type1="c2" type2="c3" type3="cl" angle="1.92876335638" k="601.357952"/>
+  <Angle type1="c2" type2="c3" type3="cx" angle="1.95948115121" k="549.551664"/>
+  <Angle type1="c2" type2="c3" type3="cy" angle="1.7737781188" k="574.990384"/>
+  <Angle type1="c2" type2="c3" type3="f" angle="1.93312667951" k="739.664256"/>
+  <Angle type1="c2" type2="c3" type3="h1" angle="1.91916404549" k="397.990448"/>
+  <Angle type1="c2" type2="c3" type3="h2" angle="1.94935824155" k="394.92776"/>
+  <Angle type1="c2" type2="c3" type3="hc" angle="1.9261453625" k="397.2708"/>
+  <Angle type1="c2" type2="c3" type3="hx" angle="1.94324958917" k="395.747824"/>
+  <Angle type1="c2" type2="c3" type3="n2" angle="1.89752196277" k="711.32184"/>
+  <Angle type1="c2" type2="c3" type3="n3" angle="1.94464585257" k="702.962208"/>
+  <Angle type1="c2" type2="c3" type3="n" angle="1.94237692454" k="703.991472"/>
+  <Angle type1="c2" type2="c3" type3="na" angle="1.97693444373" k="697.59832"/>
+  <Angle type1="c2" type2="c3" type3="nh" angle="1.92701802713" k="706.326144"/>
+  <Angle type1="c2" type2="c3" type3="oh" angle="1.92597082958" k="715.42216"/>
+  <Angle type1="c2" type2="c3" type3="os" angle="1.89472943597" k="719.497376"/>
+  <Angle type1="c2" type2="c3" type3="s4" angle="1.91794231502" k="534.439056"/>
+  <Angle type1="c2" type2="c3" type3="ss" angle="1.83207211582" k="544.899056"/>
+  <Angle type1="c3" type2="c3" type3="c3" angle="1.9462166489" k="542.982784"/>
+  <Angle type1="c3" type2="c3" type3="ca" angle="1.95599049271" k="545.451344"/>
+  <Angle type1="c3" type2="c3" type3="cc" angle="1.95354703176" k="548.22952"/>
+  <Angle type1="c3" type2="c3" type3="cd" angle="1.95354703176" k="548.22952"/>
+  <Angle type1="c3" type2="c3" type3="ce" angle="1.93591920631" k="548.221152"/>
+  <Angle type1="c3" type2="c3" type3="cf" angle="1.93591920631" k="548.254624"/>
+  <Angle type1="c3" type2="c3" type3="cl" angle="1.92701802713" k="598.43752"/>
+  <Angle type1="c3" type2="c3" type3="cx" angle="1.95162716958" k="545.576864"/>
+  <Angle type1="c3" type2="c3" type3="cy" angle="1.96157554632" k="541.836368"/>
+  <Angle type1="c3" type2="c3" type3="f" angle="1.90659767488" k="735.940496"/>
+  <Angle type1="c3" type2="c3" type3="h1" angle="1.91218272848" k="392.191424"/>
+  <Angle type1="c3" type2="c3" type3="h2" angle="1.92370190155" k="391.03664"/>
+  <Angle type1="c3" type2="c3" type3="hc" angle="1.91637151869" k="391.756288"/>
+  <Angle type1="c3" type2="c3" type3="hx" angle="1.929636021" k="390.593136"/>
+  <Angle type1="c3" type2="c3" type3="i" angle="1.93993346359" k="508.531728"/>
+  <Angle type1="c3" type2="c3" type3="n1" angle="1.90205981882" k="710.234"/>
+  <Angle type1="c3" type2="c3" type3="n2" angle="1.89891822617" k="703.941264"/>
+  <Angle type1="c3" type2="c3" type3="n3" angle="1.93801360141" k="697.09624"/>
+  <Angle type1="c3" type2="c3" type3="n4" angle="1.9933405387" k="677.607168"/>
+  <Angle type1="c3" type2="c3" type3="n" angle="1.94796197815" k="695.891248"/>
+  <Angle type1="c3" type2="c3" type3="na" angle="1.97012765965" k="691.765824"/>
+  <Angle type1="c3" type2="c3" type3="nh" angle="1.92789069175" k="699.071088"/>
+  <Angle type1="c3" type2="c3" type3="no" angle="1.90956473461" k="687.364256"/>
+  <Angle type1="c3" type2="c3" type3="o" angle="1.97239658768" k="719.053872"/>
+  <Angle type1="c3" type2="c3" type3="oh" angle="1.92317830277" k="708.284256"/>
+  <Angle type1="c3" type2="c3" type3="os" angle="1.88443199338" k="713.840608"/>
+  <Angle type1="c3" type2="c3" type3="p3" angle="1.97850524006" k="664.6284"/>
+  <Angle type1="c3" type2="c3" type3="p5" angle="1.95511782808" k="673.54032"/>
+  <Angle type1="c3" type2="c3" type3="s4" angle="1.9219565723" k="531.209008"/>
+  <Angle type1="c3" type2="c3" type3="s6" angle="1.92370190155" k="535.752832"/>
+  <Angle type1="c3" type2="c3" type3="sh" angle="1.97449098278" k="521.435184"/>
+  <Angle type1="c3" type2="c3" type3="ss" angle="1.92457456617" k="529.041696"/>
+  <Angle type1="c3" type2="c3" type3="sy" angle="1.91846591379" k="536.229808"/>
+  <Angle type1="ca" type2="c3" type3="ca" angle="1.95895755244" k="549.032848"/>
+  <Angle type1="ca" type2="c3" type3="cc" angle="1.97012765965" k="550.011904"/>
+  <Angle type1="ca" type2="c3" type3="cd" angle="1.97012765965" k="550.011904"/>
+  <Angle type1="ca" type2="c3" type3="ce" angle="1.95843395366" k="549.057952"/>
+  <Angle type1="ca" type2="c3" type3="cl" angle="1.93696640386" k="599.408208"/>
+  <Angle type1="ca" type2="c3" type3="cx" angle="1.96366994142" k="547.869696"/>
+  <Angle type1="ca" type2="c3" type3="f" angle="1.95075450495" k="734.41752"/>
+  <Angle type1="ca" type2="c3" type3="h1" angle="1.91218272848" k="397.287536"/>
+  <Angle type1="ca" type2="c3" type3="h2" angle="1.91462618944" k="397.069968"/>
+  <Angle type1="ca" type2="c3" type3="hc" angle="1.92806522468" k="395.647408"/>
+  <Angle type1="ca" type2="c3" type3="hx" angle="1.94516945135" k="394.124432"/>
+  <Angle type1="ca" type2="c3" type3="n2" angle="1.96157554632" k="698.092032"/>
+  <Angle type1="ca" type2="c3" type3="n3" angle="1.95756128904" k="699.112928"/>
+  <Angle type1="ca" type2="c3" type3="n4" angle="1.98618468877" k="683.841328"/>
+  <Angle type1="ca" type2="c3" type3="n" angle="1.96140101339" k="699.037616"/>
+  <Angle type1="ca" type2="c3" type3="na" angle="1.96995312673" k="697.30544"/>
+  <Angle type1="ca" type2="c3" type3="nc" angle="1.8589501863" k="719.363488"/>
+  <Angle type1="ca" type2="c3" type3="nd" angle="1.8589501863" k="719.363488"/>
+  <Angle type1="ca" type2="c3" type3="nh" angle="1.9441222538" k="701.681904"/>
+  <Angle type1="ca" type2="c3" type3="oh" angle="1.93068321856" k="712.886656"/>
+  <Angle type1="ca" type2="c3" type3="os" angle="1.90153622005" k="716.560208"/>
+  <Angle type1="ca" type2="c3" type3="p5" angle="1.98269403027" k="671.423216"/>
+  <Angle type1="ca" type2="c3" type3="s6" angle="1.94674024767" k="534.790512"/>
+  <Angle type1="ca" type2="c3" type3="ss" angle="1.93766453556" k="529.292736"/>
+  <Angle type1="ca" type2="c3" type3="sx" angle="1.93347574536" k="529.31784"/>
+  <Angle type1="c" type2="c3" type3="c1" angle="1.96140101339" k="555.626832"/>
+  <Angle type1="c" type2="c3" type3="c2" angle="1.94307505625" k="550.815232"/>
+  <Angle type1="c" type2="c3" type3="c3" angle="1.93801360141" k="546.488976"/>
+  <Angle type1="c" type2="c3" type3="c" angle="1.948311044" k="547.468032"/>
+  <Angle type1="c" type2="c3" type3="ca" angle="1.93749000264" k="550.513984"/>
+  <Angle type1="c" type2="c3" type3="cc" angle="1.97518911448" k="547.72744"/>
+  <Angle type1="cc" type2="c3" type3="cc" angle="1.96157554632" k="553.819344"/>
+  <Angle type1="cc" type2="c3" type3="cd" angle="1.97030219258" k="552.597616"/>
+  <Angle type1="cc" type2="c3" type3="cx" angle="1.95651409149" k="551.400992"/>
+  <Angle type1="c" type2="c3" type3="cd" angle="1.97518911448" k="547.72744"/>
+  <Angle type1="c" type2="c3" type3="ce" angle="1.95284890006" k="548.296464"/>
+  <Angle type1="cc" type2="c3" type3="f" angle="1.94272599039" k="740.333696"/>
+  <Angle type1="cc" type2="c3" type3="h1" angle="1.91357899189" k="400.45064"/>
+  <Angle type1="cc" type2="c3" type3="hc" angle="1.92841429053" k="398.910928"/>
+  <Angle type1="cc" type2="c3" type3="hx" angle="1.93749000264" k="398.216384"/>
+  <Angle type1="c" type2="c3" type3="cl" angle="1.92701802713" k="599.9856"/>
+  <Angle type1="cc" type2="c3" type3="n2" angle="1.92527269787" k="708.18384"/>
+  <Angle type1="cc" type2="c3" type3="n3" angle="1.93888626604" k="706.00816"/>
+  <Angle type1="cc" type2="c3" type3="n4" angle="2.01725154946" k="681.715856"/>
+  <Angle type1="cc" type2="c3" type3="n" angle="1.95057997203" k="704.518656"/>
+  <Angle type1="cc" type2="c3" type3="na" angle="1.97484004863" k="699.958096"/>
+  <Angle type1="cc" type2="c3" type3="nc" angle="1.86820043133" k="721.23792"/>
+  <Angle type1="cc" type2="c3" type3="nh" angle="1.96070288169" k="702.225824"/>
+  <Angle type1="cc" type2="c3" type3="oh" angle="1.94010799652" k="714.970288"/>
+  <Angle type1="cc" type2="c3" type3="os" angle="1.90066355542" k="720.518272"/>
+  <Angle type1="cc" type2="c3" type3="p5" angle="2.02859618959" k="665.364784"/>
+  <Angle type1="cc" type2="c3" type3="sh" angle="1.99002441312" k="522.615072"/>
+  <Angle type1="cc" type2="c3" type3="ss" angle="1.94010799652" k="530.221584"/>
+  <Angle type1="c" type2="c3" type3="cx" angle="1.93993346359" k="549.668816"/>
+  <Angle type1="cd" type2="c3" type3="cd" angle="1.96157554632" k="553.819344"/>
+  <Angle type1="cd" type2="c3" type3="f" angle="1.94272599039" k="740.333696"/>
+  <Angle type1="cd" type2="c3" type3="h1" angle="1.91357899189" k="400.45064"/>
+  <Angle type1="cd" type2="c3" type3="hc" angle="1.92841429053" k="398.910928"/>
+  <Angle type1="cd" type2="c3" type3="n3" angle="1.93888626604" k="706.00816"/>
+  <Angle type1="cd" type2="c3" type3="n" angle="1.95057997203" k="704.518656"/>
+  <Angle type1="cd" type2="c3" type3="nd" angle="1.86820043133" k="721.23792"/>
+  <Angle type1="cd" type2="c3" type3="nh" angle="1.96070288169" k="702.225824"/>
+  <Angle type1="cd" type2="c3" type3="oh" angle="1.94010799652" k="714.970288"/>
+  <Angle type1="cd" type2="c3" type3="os" angle="1.90066355542" k="720.518272"/>
+  <Angle type1="cd" type2="c3" type3="sh" angle="1.99002441312" k="522.615072"/>
+  <Angle type1="cd" type2="c3" type3="ss" angle="1.94010799652" k="530.221584"/>
+  <Angle type1="ce" type2="c3" type3="ce" angle="1.9455185172" k="550.8236"/>
+  <Angle type1="ce" type2="c3" type3="cy" angle="1.7952456686" k="570.371248"/>
+  <Angle type1="ce" type2="c3" type3="h1" angle="1.91183366263" k="397.254064"/>
+  <Angle type1="ce" type2="c3" type3="hc" angle="1.93015961978" k="395.362896"/>
+  <Angle type1="ce" type2="c3" type3="n3" angle="1.95057997203" k="700.292816"/>
+  <Angle type1="ce" type2="c3" type3="n" angle="1.92370190155" k="705.782224"/>
+  <Angle type1="ce" type2="c3" type3="oh" angle="1.94063159529" k="710.978752"/>
+  <Angle type1="ce" type2="c3" type3="os" angle="1.91113553093" k="714.677408"/>
+  <Angle type1="ce" type2="c3" type3="ss" angle="1.93242854781" k="529.98728"/>
+  <Angle type1="c" type2="c3" type3="f" angle="1.91986217719" k="737.622464"/>
+  <Angle type1="cf" type2="c3" type3="cy" angle="1.7952456686" k="570.40472"/>
+  <Angle type1="cf" type2="c3" type3="h1" angle="1.91183366263" k="397.304272"/>
+  <Angle type1="cf" type2="c3" type3="hc" angle="1.93015961978" k="395.413104"/>
+  <Angle type1="cf" type2="c3" type3="n3" angle="1.95057997203" k="700.343024"/>
+  <Angle type1="c" type2="c3" type3="h1" angle="1.88879531651" k="397.739408"/>
+  <Angle type1="c" type2="c3" type3="h2" angle="1.91445165651" k="395.09512"/>
+  <Angle type1="c" type2="c3" type3="hc" angle="1.89839462739" k="396.735248"/>
+  <Angle type1="c" type2="c3" type3="hx" angle="1.8997908908" k="396.802192"/>
+  <Angle type1="cl" type2="c3" type3="cl" angle="1.90816847121" k="680.920896"/>
+  <Angle type1="cl" type2="c3" type3="f" angle="1.90432874685" k="787.202864"/>
+  <Angle type1="cl" type2="c3" type3="h1" angle="1.86366257528" k="408.852112"/>
+  <Angle type1="cl" type2="c3" type3="h2" angle="1.86732776671" k="408.425344"/>
+  <Angle type1="cl" type2="c3" type3="hc" angle="1.87884693977" k="407.195248"/>
+  <Angle type1="cl" type2="c3" type3="os" angle="1.93487200876" k="761.764144"/>
+  <Angle type1="cl" type2="c3" type3="ss" angle="1.96401900727" k="595.21584"/>
+  <Angle type1="c" type2="c3" type3="n2" angle="1.91410259066" k="704.54376"/>
+  <Angle type1="c" type2="c3" type3="n3" angle="1.93975893067" k="700.175664"/>
+  <Angle type1="c" type2="c3" type3="n4" angle="1.93260308073" k="691.288848"/>
+  <Angle type1="c" type2="c3" type3="n" angle="1.90345608223" k="707.43072"/>
+  <Angle type1="c" type2="c3" type3="na" angle="1.94604211597" k="699.430912"/>
+  <Angle type1="c" type2="c3" type3="nh" angle="1.90851753706" k="706.033264"/>
+  <Angle type1="c" type2="c3" type3="oh" angle="1.89874369324" k="716.526736"/>
+  <Angle type1="c" type2="c3" type3="os" angle="1.9060740761" k="713.405472"/>
+  <Angle type1="c" type2="c3" type3="p5" angle="1.93469747584" k="678.703376"/>
+  <Angle type1="c" type2="c3" type3="s6" angle="1.93155588318" k="536.037344"/>
+  <Angle type1="c" type2="c3" type3="sh" angle="1.89752196277" k="533.158752"/>
+  <Angle type1="c" type2="c3" type3="ss" angle="1.89961635787" k="533.777984"/>
+  <Angle type1="cx" type2="c3" type3="cx" angle="1.98251949734" k="544.7568"/>
+  <Angle type1="cx" type2="c3" type3="h1" angle="1.91427712359" k="396.417264"/>
+  <Angle type1="cx" type2="c3" type3="hc" angle="1.92300376985" k="395.51352"/>
+  <Angle type1="cx" type2="c3" type3="hx" angle="1.9676841987" k="391.212368"/>
+  <Angle type1="cx" type2="c3" type3="n3" angle="1.97536364741" k="695.263648"/>
+  <Angle type1="cx" type2="c3" type3="n4" angle="1.77081105907" k="723.555856"/>
+  <Angle type1="cx" type2="c3" type3="n" angle="1.96227367802" k="698.18408"/>
+  <Angle type1="cx" type2="c3" type3="oh" angle="1.91951311134" k="714.200432"/>
+  <Angle type1="cx" type2="c3" type3="os" angle="1.88268666413" k="719.380224"/>
+  <Angle type1="cy" type2="c3" type3="h1" angle="1.88984251406" k="395.8064"/>
+  <Angle type1="cy" type2="c3" type3="hc" angle="1.93295214658" k="391.37136"/>
+  <Angle type1="cy" type2="c3" type3="n3" angle="1.97937790469" k="691.180064"/>
+  <Angle type1="cy" type2="c3" type3="oh" angle="1.94586758305" k="705.67344"/>
+  <Angle type1="cy" type2="c3" type3="os" angle="1.86872403011" k="718.367696"/>
+  <Angle type1="f" type2="c3" type3="f" angle="1.87378548494" k="1017.17224"/>
+  <Angle type1="f" type2="c3" type3="h1" angle="1.8832102629" k="559.559792"/>
+  <Angle type1="f" type2="c3" type3="h2" angle="1.89874369324" k="557.367376"/>
+  <Angle type1="f" type2="c3" type3="h3" angle="1.9212584406" k="554.237744"/>
+  <Angle type1="f" type2="c3" type3="hc" angle="1.90101262127" k="556.93224"/>
+  <Angle type1="f" type2="c3" type3="n2" angle="1.9268434942" k="944.730464"/>
+  <Angle type1="f" type2="c3" type3="os" angle="1.92998508686" k="957.274096"/>
+  <Angle type1="f" type2="c3" type3="p5" angle="1.87814880807" k="895.96176"/>
+  <Angle type1="f" type2="c3" type3="s6" angle="1.91427712359" k="702.125408"/>
+  <Angle type1="f" type2="c3" type3="ss" angle="1.9504054391" k="685.196944"/>
+  <Angle type1="h1" type2="c3" type3="h1" angle="1.89298410671" k="324.695136"/>
+  <Angle type1="h1" type2="c3" type3="n1" angle="1.88478105923" k="525.853488"/>
+  <Angle type1="h1" type2="c3" type3="n2" angle="1.91654605161" k="511.560944"/>
+  <Angle type1="h1" type2="c3" type3="n3" angle="1.91776778209" k="511.811984"/>
+  <Angle type1="h1" type2="c3" type3="n" angle="1.90031448957" k="515.000192"/>
+  <Angle type1="h1" type2="c3" type3="na" angle="1.89856916032" k="514.933248"/>
+  <Angle type1="h1" type2="c3" type3="nc" angle="1.89490396889" k="517.510592"/>
+  <Angle type1="h1" type2="c3" type3="nd" angle="1.89490396889" k="517.510592"/>
+  <Angle type1="h1" type2="c3" type3="nh" angle="1.91619698576" k="512.230384"/>
+  <Angle type1="h1" type2="c3" type3="no" angle="1.84079876208" k="501.762016"/>
+  <Angle type1="h1" type2="c3" type3="o" angle="2.03243591395" k="540.882416"/>
+  <Angle type1="h1" type2="c3" type3="oh" angle="1.92440003325" k="523.33472"/>
+  <Angle type1="h1" type2="c3" type3="os" angle="1.91602245284" k="521.970736"/>
+  <Angle type1="h1" type2="c3" type3="p5" angle="1.88966798113" k="456.959744"/>
+  <Angle type1="h1" type2="c3" type3="s4" angle="1.88355932875" k="358.5688"/>
+  <Angle type1="h1" type2="c3" type3="s" angle="1.96122648047" k="348.368208"/>
+  <Angle type1="h1" type2="c3" type3="s6" angle="1.87012029351" k="364.8448"/>
+  <Angle type1="h1" type2="c3" type3="sh" angle="1.89228597501" k="354.97056"/>
+  <Angle type1="h1" type2="c3" type3="ss" angle="1.89822009447" k="355.330384"/>
+  <Angle type1="h1" type2="c3" type3="sx" angle="1.8797196044" k="356.51864"/>
+  <Angle type1="h1" type2="c3" type3="sy" angle="1.88286119705" k="363.346928"/>
+  <Angle type1="h2" type2="c3" type3="h2" angle="1.9233528357" k="322.360464"/>
+  <Angle type1="h2" type2="c3" type3="i" angle="1.83242118167" k="326.887552"/>
+  <Angle type1="h2" type2="c3" type3="n2" angle="1.9233528357" k="510.707408"/>
+  <Angle type1="h2" type2="c3" type3="n3" angle="1.90851753706" k="513.109024"/>
+  <Angle type1="h2" type2="c3" type3="n" angle="1.87238922154" k="518.882944"/>
+  <Angle type1="h2" type2="c3" type3="na" angle="1.87291282032" k="518.506384"/>
+  <Angle type1="h2" type2="c3" type3="nc" angle="1.91061193216" k="515.435328"/>
+  <Angle type1="h2" type2="c3" type3="nd" angle="1.91061193216" k="515.435328"/>
+  <Angle type1="h2" type2="c3" type3="nh" angle="1.92003671012" k="511.778512"/>
+  <Angle type1="h2" type2="c3" type3="no" angle="1.88966798113" k="495.268448"/>
+  <Angle type1="h2" type2="c3" type3="o" angle="1.9018852859" k="559.250176"/>
+  <Angle type1="h2" type2="c3" type3="oh" angle="1.90991380046" k="525.38488"/>
+  <Angle type1="h2" type2="c3" type3="os" angle="1.91253179434" k="522.514656"/>
+  <Angle type1="h2" type2="c3" type3="s4" angle="1.87291282032" k="359.564592"/>
+  <Angle type1="h2" type2="c3" type3="s" angle="1.8631389765" k="357.388912"/>
+  <Angle type1="h2" type2="c3" type3="s6" angle="1.8589501863" k="365.915904"/>
+  <Angle type1="h2" type2="c3" type3="sh" angle="1.88268666413" k="355.8492"/>
+  <Angle type1="h2" type2="c3" type3="ss" angle="1.89071517869" k="356.008192"/>
+  <Angle type1="h3" type2="c3" type3="n3" angle="1.89769649569" k="514.648736"/>
+  <Angle type1="h3" type2="c3" type3="nc" angle="1.90886660291" k="515.753312"/>
+  <Angle type1="h3" type2="c3" type3="nd" angle="1.90886660291" k="515.753312"/>
+  <Angle type1="h3" type2="c3" type3="nh" angle="1.9233528357" k="511.418688"/>
+  <Angle type1="h3" type2="c3" type3="os" angle="1.9462166489" k="518.071248"/>
+  <Angle type1="h3" type2="c3" type3="ss" angle="1.903979681" k="354.727888"/>
+  <Angle type1="hc" type2="c3" type3="hc" angle="1.8776252093" k="326.01728"/>
+  <Angle type1="hc" type2="c3" type3="i" angle="1.83242118167" k="326.946128"/>
+  <Angle type1="hc" type2="c3" type3="n2" angle="1.91113553093" k="512.28896"/>
+  <Angle type1="hc" type2="c3" type3="n3" angle="1.91637151869" k="512.004448"/>
+  <Angle type1="hc" type2="c3" type3="n4" angle="1.8832102629" k="502.674128"/>
+  <Angle type1="hc" type2="c3" type3="n" angle="1.91113553093" k="513.535792"/>
+  <Angle type1="hc" type2="c3" type3="na" angle="1.91113553093" k="513.242912"/>
+  <Angle type1="hc" type2="c3" type3="nh" angle="1.94674024767" k="508.197008"/>
+  <Angle type1="hc" type2="c3" type3="no" angle="1.87099295814" k="497.703536"/>
+  <Angle type1="hc" type2="c3" type3="oh" angle="1.91113553093" k="525.142208"/>
+  <Angle type1="hc" type2="c3" type3="os" angle="1.89717289692" k="524.556448"/>
+  <Angle type1="hc" type2="c3" type3="p2" angle="1.92300376985" k="448.800944"/>
+  <Angle type1="hc" type2="c3" type3="p3" angle="1.91794231502" k="448.533168"/>
+  <Angle type1="hc" type2="c3" type3="p4" angle="1.91026286631" k="454.708752"/>
+  <Angle type1="hc" type2="c3" type3="p5" angle="1.89246050794" k="456.616656"/>
+  <Angle type1="hc" type2="c3" type3="px" angle="1.91462618944" k="456.943008"/>
+  <Angle type1="hc" type2="c3" type3="py" angle="1.90555047733" k="454.993264"/>
+  <Angle type1="hc" type2="c3" type3="s4" angle="1.87622894589" k="359.271712"/>
+  <Angle type1="hc" type2="c3" type3="s6" angle="1.88844625066" k="363.070784"/>
+  <Angle type1="hc" type2="c3" type3="sh" angle="1.88268666413" k="355.882672"/>
+  <Angle type1="hc" type2="c3" type3="ss" angle="1.89822009447" k="355.330384"/>
+  <Angle type1="hx" type2="c3" type3="hx" angle="1.91549885406" k="324.527776"/>
+  <Angle type1="hx" type2="c3" type3="n4" angle="1.88513012508" k="502.715968"/>
+  <Angle type1="i" type2="c3" type3="i" angle="1.97431644986" k="554.354896"/>
+  <Angle type1="n1" type2="c3" type3="n1" angle="1.83381744507" k="941.14896"/>
+  <Angle type1="n2" type2="c3" type3="n2" angle="1.91427712359" k="900.35496"/>
+  <Angle type1="n2" type2="c3" type3="nh" angle="1.94202785869" k="894.5392"/>
+  <Angle type1="n2" type2="c3" type3="oh" angle="1.95284890006" k="904.229344"/>
+  <Angle type1="n2" type2="c3" type3="os" angle="1.93801360141" k="905.225136"/>
+  <Angle type1="n3" type2="c3" type3="n3" angle="1.94132972699" k="894.91576"/>
+  <Angle type1="n3" type2="c3" type3="nc" angle="1.97728350958" k="889.367776"/>
+  <Angle type1="n3" type2="c3" type3="nd" angle="1.97728350958" k="889.367776"/>
+  <Angle type1="n3" type2="c3" type3="nh" angle="1.93050868563" k="897.63536"/>
+  <Angle type1="n3" type2="c3" type3="oh" angle="1.93207948196" k="909.543024"/>
+  <Angle type1="n3" type2="c3" type3="os" angle="1.89385677134" k="916.178848"/>
+  <Angle type1="n3" type2="c3" type3="p5" angle="1.90956473461" k="863.7868"/>
+  <Angle type1="n3" type2="c3" type3="ss" angle="1.87413455079" k="679.498336"/>
+  <Angle type1="n4" type2="c3" type3="n4" angle="1.97780710836" k="859.460544"/>
+  <Angle type1="na" type2="c3" type3="na" angle="1.98077416809" k="887.04984"/>
+  <Angle type1="na" type2="c3" type3="os" angle="1.90293248345" k="914.588928"/>
+  <Angle type1="nc" type2="c3" type3="nc" angle="1.93050868563" k="902.78168"/>
+  <Angle type1="nc" type2="c3" type3="nh" angle="1.96227367802" k="892.982752"/>
+  <Angle type1="nc" type2="c3" type3="os" angle="2.01428448973" k="891.15016"/>
+  <Angle type1="nd" type2="c3" type3="nd" angle="1.93050868563" k="902.78168"/>
+  <Angle type1="nd" type2="c3" type3="nh" angle="1.96227367802" k="892.982752"/>
+  <Angle type1="nd" type2="c3" type3="os" angle="2.01428448973" k="891.15016"/>
+  <Angle type1="nh" type2="c3" type3="nh" angle="1.84778007909" k="917.735296"/>
+  <Angle type1="nh" type2="c3" type3="oh" angle="1.95948115121" k="903.392544"/>
+  <Angle type1="nh" type2="c3" type3="os" angle="1.9046778127" k="913.802336"/>
+  <Angle type1="nh" type2="c3" type3="p5" angle="1.96349540849" k="851.937712"/>
+  <Angle type1="nh" type2="c3" type3="ss" angle="1.9025834176" k="674.477536"/>
+  <Angle type1="n" type2="c3" type3="n2" angle="1.94272599039" k="895.024544"/>
+  <Angle type1="n" type2="c3" type3="n3" angle="1.93923533189" k="896.25464"/>
+  <Angle type1="n" type2="c3" type3="n" angle="1.96611340237" k="890.966064"/>
+  <Angle type1="n" type2="c3" type3="nh" angle="1.89647476522" k="906.522176"/>
+  <Angle type1="n" type2="c3" type3="oh" angle="1.96454260604" k="902.923936"/>
+  <Angle type1="no" type2="c3" type3="no" angle="1.83573730725" k="879.066768"/>
+  <Angle type1="n" type2="c3" type3="os" angle="1.9046778127" k="914.49688"/>
+  <Angle type1="n" type2="c3" type3="p5" angle="1.9289378893" k="859.803632"/>
+  <Angle type1="oh" type2="c3" type3="oh" angle="1.91811684794" k="926.50496"/>
+  <Angle type1="oh" type2="c3" type3="os" angle="1.90904113583" k="925.986144"/>
+  <Angle type1="oh" type2="c3" type3="p5" angle="1.89682383107" k="871.728032"/>
+  <Angle type1="oh" type2="c3" type3="sh" angle="2.01515715435" k="657.858688"/>
+  <Angle type1="o" type2="c3" type3="o" angle="2.13453767519" k="949.533696"/>
+  <Angle type1="os" type2="c3" type3="os" angle="1.89001704698" k="927.952624"/>
+  <Angle type1="os" type2="c3" type3="p5" angle="1.88478105923" k="873.552256"/>
+  <Angle type1="os" type2="c3" type3="ss" angle="1.89525303474" k="678.89584"/>
+  <Angle type1="p2" type2="c3" type3="p2" angle="1.9282397576" k="870.297104"/>
+  <Angle type1="p3" type2="c3" type3="p3" angle="1.922654704" k="870.0628"/>
+  <Angle type1="p5" type2="c3" type3="p5" angle="1.92213110522" k="879.024928"/>
+  <Angle type1="p5" type2="c3" type3="ss" angle="1.94569305012" k="680.853952"/>
+  <Angle type1="s4" type2="c3" type3="s4" angle="1.95983021706" k="531.175536"/>
+  <Angle type1="s4" type2="c3" type3="s6" angle="1.98129776686" k="531.585568"/>
+  <Angle type1="s6" type2="c3" type3="s6" angle="1.94115519407" k="540.514224"/>
+  <Angle type1="sh" type2="c3" type3="sh" angle="2.02911978837" k="518.347392"/>
+  <Angle type1="sh" type2="c3" type3="ss" angle="1.93260308073" k="531.74456"/>
+  <Angle type1="s" type2="c3" type3="s" angle="2.15286363234" k="502.816384"/>
+  <Angle type1="ss" type2="c3" type3="ss" angle="1.94499491842" k="530.673456"/>
+  <Angle type1="br" type2="ca" type3="br" angle="2.05250720035" k="566.59728"/>
+  <Angle type1="br" type2="ca" type3="ca" angle="2.08217779763" k="536.89088"/>
+  <Angle type1="c1" type2="ca" type3="c1" angle="2.09439510239" k="558.865248"/>
+  <Angle type1="c1" type2="ca" type3="ca" angle="2.09439510239" k="566.814848"/>
+  <Angle type1="c2" type2="ca" type3="c2" angle="2.09439510239" k="581.224544"/>
+  <Angle type1="c2" type2="ca" type3="ca" angle="2.10486707791" k="576.873184"/>
+  <Angle type1="c3" type2="ca" type3="c2" angle="2.09439510239" k="552.714768"/>
+  <Angle type1="c3" type2="ca" type3="c3" angle="2.03854456633" k="538.213024"/>
+  <Angle type1="c3" type2="ca" type3="ca" angle="2.10783413763" k="548.798544"/>
+  <Angle type1="c3" type2="ca" type3="cp" angle="2.10539067668" k="547.953376"/>
+  <Angle type1="c3" type2="ca" type3="cq" angle="2.10539067668" k="547.953376"/>
+  <Angle type1="c3" type2="ca" type3="na" angle="2.07205488797" k="695.974928"/>
+  <Angle type1="c3" type2="ca" type3="nb" angle="2.03645017123" k="710.577088"/>
+  <Angle type1="ca" type2="ca" type3="ca" angle="2.09474416824" k="575.442256"/>
+  <Angle type1="ca" type2="ca" type3="cc" angle="2.10818320348" k="561.676896"/>
+  <Angle type1="ca" type2="ca" type3="cd" angle="2.10818320348" k="561.676896"/>
+  <Angle type1="ca" type2="ca" type3="ce" angle="2.10870680226" k="557.174912"/>
+  <Angle type1="ca" type2="ca" type3="cf" angle="2.10870680226" k="557.174912"/>
+  <Angle type1="ca" type2="ca" type3="cg" angle="2.09910749137" k="567.693488"/>
+  <Angle type1="ca" type2="ca" type3="ch" angle="2.09910749137" k="567.693488"/>
+  <Angle type1="ca" type2="ca" type3="cl" angle="2.08374859396" k="603.433216"/>
+  <Angle type1="ca" type2="ca" type3="cp" angle="2.10643787423" k="572.320992"/>
+  <Angle type1="ca" type2="ca" type3="cq" angle="2.10643787423" k="572.320992"/>
+  <Angle type1="ca" type2="ca" type3="cx" angle="2.10888133518" k="554.187536"/>
+  <Angle type1="ca" type2="ca" type3="cy" angle="2.10940493396" k="548.639552"/>
+  <Angle type1="ca" type2="ca" type3="f" angle="2.07624367817" k="746.936048"/>
+  <Angle type1="ca" type2="ca" type3="h4" angle="2.10032922185" k="406.358448"/>
+  <Angle type1="ca" type2="ca" type3="ha" angle="2.09230070729" k="407.35424"/>
+  <Angle type1="ca" type2="ca" type3="i" angle="2.07886167205" k="511.268064"/>
+  <Angle type1="ca" type2="ca" type3="n1" angle="2.09055537804" k="737.254272"/>
+  <Angle type1="ca" type2="ca" type3="n2" angle="2.08689018661" k="745.5888"/>
+  <Angle type1="ca" type2="ca" type3="n4" angle="2.08235233055" k="699.9832"/>
+  <Angle type1="ca" type2="ca" type3="n" angle="2.09771122797" k="716.543472"/>
+  <Angle type1="ca" type2="ca" type3="na" angle="2.06542263681" k="729.413456"/>
+  <Angle type1="ca" type2="ca" type3="nb" angle="2.1457077824" k="726.752432"/>
+  <Angle type1="ca" type2="ca" type3="nc" angle="2.08950818049" k="733.32968"/>
+  <Angle type1="ca" type2="ca" type3="nd" angle="2.08950818049" k="733.32968"/>
+  <Angle type1="ca" type2="ca" type3="ne" angle="2.10504161083" k="716.38448"/>
+  <Angle type1="ca" type2="ca" type3="nf" angle="2.10504161083" k="716.38448"/>
+  <Angle type1="ca" type2="ca" type3="nh" angle="2.11097573029" k="721.011984"/>
+  <Angle type1="ca" type2="ca" type3="no" angle="2.0771163428" k="705.004"/>
+  <Angle type1="ca" type2="ca" type3="o" angle="2.15129283601" k="749.220512"/>
+  <Angle type1="ca" type2="ca" type3="oh" angle="2.09264977314" k="729.781648"/>
+  <Angle type1="ca" type2="ca" type3="os" angle="2.08043246838" k="730.434352"/>
+  <Angle type1="ca" type2="ca" type3="p2" angle="1.99595853258" k="680.561072"/>
+  <Angle type1="ca" type2="ca" type3="p3" angle="2.09456963532" k="668.670144"/>
+  <Angle type1="ca" type2="ca" type3="p4" angle="2.09963109015" k="673.8332"/>
+  <Angle type1="ca" type2="ca" type3="p5" angle="2.0985838926" k="677.289184"/>
+  <Angle type1="ca" type2="ca" type3="pe" angle="2.10224908403" k="666.452624"/>
+  <Angle type1="ca" type2="ca" type3="pf" angle="2.10224908403" k="666.452624"/>
+  <Angle type1="ca" type2="ca" type3="px" angle="2.10364534743" k="667.440048"/>
+  <Angle type1="ca" type2="ca" type3="py" angle="2.09875842552" k="670.879296"/>
+  <Angle type1="ca" type2="ca" type3="s4" angle="2.07955980375" k="531.878448"/>
+  <Angle type1="ca" type2="ca" type3="s6" angle="2.10190001818" k="534.062496"/>
+  <Angle type1="ca" type2="ca" type3="s" angle="2.13890099832" k="536.020608"/>
+  <Angle type1="ca" type2="ca" type3="sh" angle="2.12546196308" k="527.786496"/>
+  <Angle type1="ca" type2="ca" type3="ss" angle="2.09544229994" k="531.61904"/>
+  <Angle type1="ca" type2="ca" type3="sx" angle="2.08182873178" k="522.774064"/>
+  <Angle type1="ca" type2="ca" type3="sy" angle="2.08427219273" k="530.589776"/>
+  <Angle type1="c" type2="ca" type3="c3" angle="2.0605357149" k="539.710896"/>
+  <Angle type1="c" type2="ca" type3="c" angle="2.09439510239" k="539.894992"/>
+  <Angle type1="c" type2="ca" type3="ca" angle="2.10015468892" k="555.225168"/>
+  <Angle type1="cc" type2="ca" type3="cp" angle="2.16944426023" k="552.37168"/>
+  <Angle type1="cc" type2="ca" type3="nb" angle="2.05512519422" k="725.580912"/>
+  <Angle type1="cd" type2="ca" type3="nb" angle="2.05512519422" k="725.580912"/>
+  <Angle type1="ce" type2="ca" type3="na" angle="2.09299883899" k="703.430816"/>
+  <Angle type1="ce" type2="ca" type3="nb" angle="2.05180906864" k="719.882304"/>
+  <Angle type1="cf" type2="ca" type3="nb" angle="2.05180906864" k="719.882304"/>
+  <Angle type1="cg" type2="ca" type3="cp" angle="2.12109863995" k="563.33376"/>
+  <Angle type1="c" type2="ca" type3="ha" angle="2.02283660306" k="392.4592"/>
+  <Angle type1="cl" type2="ca" type3="cl" angle="2.07205488797" k="673.70768"/>
+  <Angle type1="cl" type2="ca" type3="cp" angle="2.10120188648" k="600.203168"/>
+  <Angle type1="cl" type2="ca" type3="nb" angle="2.02772352497" k="772.609072"/>
+  <Angle type1="c" type2="ca" type3="nb" angle="2.055648793" k="714.869872"/>
+  <Angle type1="c" type2="ca" type3="nc" angle="2.28289066161" k="675.975408"/>
+  <Angle type1="c" type2="ca" type3="nd" angle="2.28289066161" k="675.975408"/>
+  <Angle type1="cp" type2="ca" type3="f" angle="2.08427219273" k="743.337808"/>
+  <Angle type1="cp" type2="ca" type3="h4" angle="2.09596589872" k="405.044672"/>
+  <Angle type1="cp" type2="ca" type3="ha" angle="2.09195164144" k="405.6388"/>
+  <Angle type1="cp" type2="ca" type3="na" angle="1.89874369324" k="758.68472"/>
+  <Angle type1="cp" type2="ca" type3="nb" angle="2.15687788961" k="722.735792"/>
+  <Angle type1="cp" type2="ca" type3="nh" angle="2.12162223872" k="717.254752"/>
+  <Angle type1="cp" type2="ca" type3="oh" angle="2.10923040104" k="724.861264"/>
+  <Angle type1="cp" type2="ca" type3="ss" angle="1.94028252944" k="551.8696"/>
+  <Angle type1="cp" type2="ca" type3="sy" angle="1.94045706237" k="549.325728"/>
+  <Angle type1="cq" type2="ca" type3="ha" angle="2.09195164144" k="405.6388"/>
+  <Angle type1="cq" type2="ca" type3="sy" angle="1.94045706237" k="549.325728"/>
+  <Angle type1="f" type2="ca" type3="f" angle="2.05076187109" k="972.796736"/>
+  <Angle type1="f" type2="ca" type3="nb" angle="2.00136905326" k="974.344816"/>
+  <Angle type1="h4" type2="ca" type3="n" angle="2.02493099816" k="514.163392"/>
+  <Angle type1="h4" type2="ca" type3="na" angle="2.03016698592" k="521.887056"/>
+  <Angle type1="h4" type2="ca" type3="nb" angle="2.02510553109" k="536.104288"/>
+  <Angle type1="h4" type2="ca" type3="nc" angle="2.06577170266" k="526.999904"/>
+  <Angle type1="h4" type2="ca" type3="nd" angle="2.06577170266" k="526.999904"/>
+  <Angle type1="h4" type2="ca" type3="os" angle="1.93993346359" k="538.31344"/>
+  <Angle type1="h4" type2="ca" type3="ss" angle="2.02789805789" k="355.874304"/>
+  <Angle type1="h5" type2="ca" type3="nb" angle="2.02144033966" k="536.731888"/>
+  <Angle type1="h5" type2="ca" type3="nc" angle="2.13122154961" k="518.974992"/>
+  <Angle type1="h5" type2="ca" type3="nd" angle="2.13122154961" k="518.974992"/>
+  <Angle type1="ha" type2="ca" type3="n2" angle="2.02458193231" k="547.493136"/>
+  <Angle type1="ha" type2="ca" type3="p2" angle="2.13907553124" k="428.910208"/>
+  <Angle type1="i" type2="ca" type3="i" angle="2.08182873178" k="560.873568"/>
+  <Angle type1="n1" type2="ca" type3="n1" angle="2.04255882361" k="957.223888"/>
+  <Angle type1="n2" type2="ca" type3="n2" angle="2.09439510239" k="968.520688"/>
+  <Angle type1="n2" type2="ca" type3="na" angle="2.08741378539" k="939.18248"/>
+  <Angle type1="n4" type2="ca" type3="n4" angle="2.03889363218" k="861.770112"/>
+  <Angle type1="na" type2="ca" type3="na" angle="1.878323341" k="962.855552"/>
+  <Angle type1="na" type2="ca" type3="nb" angle="2.21813894636" k="900.1876"/>
+  <Angle type1="na" type2="ca" type3="nh" angle="2.07100769042" k="916.33784"/>
+  <Angle type1="nb" type2="ca" type3="nb" angle="2.22110600609" k="915.199792"/>
+  <Angle type1="nb" type2="ca" type3="nc" angle="2.20784150377" k="913.5764"/>
+  <Angle type1="nb" type2="ca" type3="nd" angle="2.20784150377" k="913.5764"/>
+  <Angle type1="nb" type2="ca" type3="nh" angle="2.04098802728" k="937.743184"/>
+  <Angle type1="nb" type2="ca" type3="oh" angle="2.05390346375" k="942.872768"/>
+  <Angle type1="nb" type2="ca" type3="os" angle="2.08950818049" k="932.680544"/>
+  <Angle type1="nb" type2="ca" type3="sh" angle="2.05268173327" k="677.72432"/>
+  <Angle type1="nb" type2="ca" type3="ss" angle="2.07345115137" k="674.41896"/>
+  <Angle type1="nc" type2="ca" type3="nc" angle="2.24693687902" k="901.375856"/>
+  <Angle type1="nc" type2="ca" type3="nh" angle="2.07449834892" k="926.08656"/>
+  <Angle type1="nd" type2="ca" type3="nd" angle="2.24693687902" k="901.375856"/>
+  <Angle type1="nd" type2="ca" type3="nh" angle="2.07449834892" k="926.08656"/>
+  <Angle type1="nh" type2="ca" type3="nh" angle="2.11149932906" k="906.890368"/>
+  <Angle type1="n" type2="ca" type3="nc" angle="2.16176481152" k="898.020288"/>
+  <Angle type1="n" type2="ca" type3="nd" angle="2.16176481152" k="898.020288"/>
+  <Angle type1="n" type2="ca" type3="nh" angle="2.02737445912" k="916.689296"/>
+  <Angle type1="no" type2="ca" type3="no" angle="2.04447868579" k="869.56072"/>
+  <Angle type1="oh" type2="ca" type3="oh" angle="2.09439510239" k="925.408752"/>
+  <Angle type1="o" type2="ca" type3="o" angle="2.21342655738" k="993.348544"/>
+  <Angle type1="os" type2="ca" type3="os" angle="1.98496295829" k="946.479376"/>
+  <Angle type1="p2" type2="ca" type3="p2" angle="2.11533905342" k="837.695376"/>
+  <Angle type1="p3" type2="ca" type3="p3" angle="2.11987690947" k="843.352144"/>
+  <Angle type1="p5" type2="ca" type3="p5" angle="2.09439510239" k="862.883056"/>
+  <Angle type1="s4" type2="ca" type3="s4" angle="1.84673288154" k="560.204128"/>
+  <Angle type1="s6" type2="ca" type3="s6" angle="1.84673288154" k="566.89016"/>
+  <Angle type1="sh" type2="ca" type3="sh" angle="2.0985838926" k="527.610768"/>
+  <Angle type1="s" type2="ca" type3="s" angle="2.18410502595" k="529.635824"/>
+  <Angle type1="ss" type2="ca" type3="ss" angle="2.00974663367" k="539.23392"/>
+  <Angle type1="br" type2="c" type3="br" angle="1.97396738401" k="566.446656"/>
+  <Angle type1="br" type2="c" type3="c3" angle="1.93277761366" k="540.556064"/>
+  <Angle type1="br" type2="c" type3="o" angle="2.11987690947" k="656.80432"/>
+  <Angle type1="c1" type2="c" type3="c1" angle="2.0127136934" k="562.279392"/>
+  <Angle type1="c1" type2="c" type3="o" angle="2.13523580689" k="733.271104"/>
+  <Angle type1="c2" type2="c" type3="c2" angle="2.03819550048" k="580.212016"/>
+  <Angle type1="c2" type2="c" type3="ha" angle="2.02370926769" k="411.295568"/>
+  <Angle type1="c2" type2="c" type3="o" angle="2.07903620498" k="763.010976"/>
+  <Angle type1="c2" type2="c" type3="s" angle="2.07973433668" k="558.81504"/>
+  <Angle type1="c3" type2="c" type3="c3" angle="2.03330857857" k="535.895088"/>
+  <Angle type1="c3" type2="c" type3="ca" angle="2.06646983436" k="537.359488"/>
+  <Angle type1="c3" type2="c" type3="cc" angle="2.04709667966" k="543.786112"/>
+  <Angle type1="c3" type2="c" type3="cd" angle="2.04709667966" k="543.786112"/>
+  <Angle type1="c3" type2="c" type3="ce" angle="2.03226138102" k="543.242192"/>
+  <Angle type1="c3" type2="c" type3="cf" angle="2.03226138102" k="543.242192"/>
+  <Angle type1="c3" type2="c" type3="cg" angle="2.00712863979" k="551.936544"/>
+  <Angle type1="c3" type2="c" type3="ch" angle="2.00712863979" k="551.936544"/>
+  <Angle type1="c3" type2="c" type3="cl" angle="1.95459422931" k="596.111216"/>
+  <Angle type1="c3" type2="c" type3="f" angle="1.93207948196" k="739.881824"/>
+  <Angle type1="c3" type2="c" type3="h4" angle="2.00084545449" k="385.865216"/>
+  <Angle type1="c3" type2="c" type3="ha" angle="2.01096836415" k="385.321296"/>
+  <Angle type1="c3" type2="c" type3="i" angle="1.9711748572" k="505.326784"/>
+  <Angle type1="c3" type2="c" type3="n2" angle="1.99892559231" k="699.012512"/>
+  <Angle type1="c3" type2="c" type3="n4" angle="1.95930661829" k="678.695008"/>
+  <Angle type1="c3" type2="c" type3="n" angle="2.01027023245" k="705.137888"/>
+  <Angle type1="c3" type2="c" type3="ne" angle="1.96541527067" k="710.786288"/>
+  <Angle type1="c3" type2="c" type3="nf" angle="1.96541527067" k="710.786288"/>
+  <Angle type1="c3" type2="c" type3="o" angle="2.15024563846" k="707.531136"/>
+  <Angle type1="c3" type2="c" type3="oh" angle="1.96750966577" k="717.999504"/>
+  <Angle type1="c3" type2="c" type3="os" angle="1.93242854781" k="723.154192"/>
+  <Angle type1="c3" type2="c" type3="p3" angle="2.03191231517" k="650.804464"/>
+  <Angle type1="c3" type2="c" type3="p5" angle="2.07519648062" k="644.29416"/>
+  <Angle type1="c3" type2="c" type3="pe" angle="2.00451064592" k="647.833824"/>
+  <Angle type1="c3" type2="c" type3="pf" angle="2.00451064592" k="647.833824"/>
+  <Angle type1="c3" type2="c" type3="px" angle="2.01760061531" k="647.574416"/>
+  <Angle type1="c3" type2="c" type3="py" angle="2.06228104416" k="650.176864"/>
+  <Angle type1="c3" type2="c" type3="s4" angle="2.00346344836" k="513.393536"/>
+  <Angle type1="c3" type2="c" type3="s6" angle="2.00224171789" k="513.552528"/>
+  <Angle type1="c3" type2="c" type3="s" angle="2.14937297383" k="535.058288"/>
+  <Angle type1="c3" type2="c" type3="sh" angle="1.96611340237" k="533.476736"/>
+  <Angle type1="c3" type2="c" type3="ss" angle="1.98112323394" k="530.849184"/>
+  <Angle type1="c3" type2="c" type3="sx" angle="1.9891517485" k="512.129968"/>
+  <Angle type1="c3" type2="c" type3="sy" angle="1.99456226918" k="515.569216"/>
+  <Angle type1="ca" type2="c" type3="ca" angle="2.06140837953" k="544.196144"/>
+  <Angle type1="ca" type2="c" type3="cc" angle="2.02458193231" k="553.325632"/>
+  <Angle type1="ca" type2="c" type3="cd" angle="2.02458193231" k="553.325632"/>
+  <Angle type1="ca" type2="c" type3="ce" angle="2.07729087572" k="543.576912"/>
+  <Angle type1="ca" type2="c" type3="cf" angle="2.07729087572" k="543.576912"/>
+  <Angle type1="ca" type2="c" type3="h4" angle="2.00957210075" k="392.551248"/>
+  <Angle type1="ca" type2="c" type3="ha" angle="1.99176974238" k="394.835712"/>
+  <Angle type1="ca" type2="c" type3="n" angle="2.01149196292" k="714.560256"/>
+  <Angle type1="ca" type2="c" type3="ne" angle="2.00206718496" k="713.70672"/>
+  <Angle type1="ca" type2="c" type3="o" angle="2.13977366295" k="721.380176"/>
+  <Angle type1="ca" type2="c" type3="oh" angle="1.98007603639" k="725.907264"/>
+  <Angle type1="ca" type2="c" type3="os" angle="1.96244821094" k="727.706384"/>
+  <Angle type1="ca" type2="c" type3="s" angle="2.14116992635" k="540.514224"/>
+  <Angle type1="ca" type2="c" type3="sh" angle="2.07048409164" k="523.12552"/>
+  <Angle type1="ca" type2="c" type3="ss" angle="2.00800130442" k="530.581408"/>
+  <Angle type1="br" type2="cc" type3="c" angle="2.02946885422" k="545.225408"/>
+  <Angle type1="br" type2="cc" type3="cc" angle="2.1650809371" k="530.439152"/>
+  <Angle type1="br" type2="cc" type3="cd" angle="2.16822252975" k="532.924448"/>
+  <Angle type1="br" type2="cc" type3="na" angle="2.12197130457" k="674.16792"/>
+  <Angle type1="c2" type2="cc" type3="c3" angle="2.20103471969" k="546.112416"/>
+  <Angle type1="c2" type2="cc" type3="ca" angle="2.17153865533" k="560.254336"/>
+  <Angle type1="c2" type2="cc" type3="cc" angle="2.13261781301" k="571.601344"/>
+  <Angle type1="c2" type2="cc" type3="cd" angle="2.04238429068" k="596.521248"/>
+  <Angle type1="c2" type2="cc" type3="ha" angle="2.14186805805" k="411.965008"/>
+  <Angle type1="c2" type2="cc" type3="n" angle="2.18009076867" k="720.9032"/>
+  <Angle type1="c2" type2="cc" type3="os" angle="2.11917877777" k="736.308688"/>
+  <Angle type1="c" type2="c" type3="c3" angle="2.02754899204" k="532.380528"/>
+  <Angle type1="c3" type2="cc" type3="ca" angle="2.20819056962" k="529.845024"/>
+  <Angle type1="c3" type2="cc" type3="cc" angle="2.02405833354" k="558.220912"/>
+  <Angle type1="c3" type2="cc" type3="cd" angle="2.08479579151" k="558.999136"/>
+  <Angle type1="c3" type2="cc" type3="cf" angle="2.05669599055" k="563.96136"/>
+  <Angle type1="c3" type2="cc" type3="ha" angle="2.12092410702" k="380.886256"/>
+  <Angle type1="c3" type2="cc" type3="n2" angle="2.19370433683" k="697.355648"/>
+  <Angle type1="c3" type2="cc" type3="n" angle="2.08025793545" k="699.213344"/>
+  <Angle type1="c3" type2="cc" type3="na" angle="2.14204259097" k="689.155008"/>
+  <Angle type1="c3" type2="cc" type3="nc" angle="2.11097573029" k="696.34312"/>
+  <Angle type1="c3" type2="cc" type3="nd" angle="2.13645753737" k="701.958048"/>
+  <Angle type1="c3" type2="cc" type3="os" angle="2.03854456633" k="710.06664"/>
+  <Angle type1="c3" type2="cc" type3="ss" angle="2.12109863995" k="524.305408"/>
+  <Angle type1="c" type2="c" type3="c" angle="1.94918370863" k="538.823888"/>
+  <Angle type1="c" type2="c" type3="ca" angle="2.06996049287" k="532.397264"/>
+  <Angle type1="ca" type2="cc" type3="cc" angle="1.93801360141" k="580.203648"/>
+  <Angle type1="ca" type2="cc" type3="cd" angle="1.98112323394" k="584.103136"/>
+  <Angle type1="ca" type2="cc" type3="ce" angle="2.21674268296" k="537.710944"/>
+  <Angle type1="ca" type2="cc" type3="h4" angle="2.2558380582" k="379.639424"/>
+  <Angle type1="ca" type2="cc" type3="ha" angle="2.16490640417" k="387.4384"/>
+  <Angle type1="ca" type2="cc" type3="n" angle="2.05372893082" k="716.652256"/>
+  <Angle type1="ca" type2="cc" type3="nc" angle="2.10469254498" k="710.418096"/>
+  <Angle type1="ca" type2="cc" type3="nd" angle="2.15094377016" k="713.740192"/>
+  <Angle type1="ca" type2="cc" type3="nh" angle="2.13157061546" k="705.029104"/>
+  <Angle type1="ca" type2="cc" type3="oh" angle="2.05163453572" k="724.476336"/>
+  <Angle type1="ca" type2="cc" type3="os" angle="2.00276531666" k="729.932272"/>
+  <Angle type1="ca" type2="cc" type3="ss" angle="2.10835773641" k="530.598144"/>
+  <Angle type1="c" type2="cc" type3="c2" angle="2.11481545464" k="564.948784"/>
+  <Angle type1="c" type2="cc" type3="c3" angle="2.05529972715" k="547.083104"/>
+  <Angle type1="c" type2="cc" type3="c" angle="2.11307012539" k="545.92832"/>
+  <Angle type1="c" type2="c" type3="cc" angle="1.9490091757" k="552.45536"/>
+  <Angle type1="c" type2="cc" type3="ca" angle="2.14588231533" k="543.96184"/>
+  <Angle type1="c" type2="cc" type3="cc" angle="2.14134445927" k="549.560032"/>
+  <Angle type1="cc" type2="c" type3="cc" angle="2.02178940551" k="558.112128"/>
+  <Angle type1="cc" type2="cc" type3="cc" angle="1.93207948196" k="586.839472"/>
+  <Angle type1="cc" type2="cc" type3="cd" angle="1.99299147285" k="588.672064"/>
+  <Angle type1="cc" type2="cc" type3="ce" angle="2.21761534758" k="542.689904"/>
+  <Angle type1="cc" type2="cc" type3="cf" angle="2.14186805805" k="569.208096"/>
+  <Angle type1="cc" type2="cc" type3="cg" angle="2.19754406119" k="550.65624"/>
+  <Angle type1="c" type2="cc" type3="cd" angle="2.1179570473" k="562.220816"/>
+  <Angle type1="cc" type2="c" type3="cd" angle="1.96855686332" k="565.609856"/>
+  <Angle type1="c" type2="cc" type3="ce" angle="2.12179677165" k="547.317408"/>
+  <Angle type1="cc" type2="c" type3="ce" angle="2.01707701653" k="555.911344"/>
+  <Angle type1="cc" type2="cc" type3="f" angle="2.08025793545" k="739.538736"/>
+  <Angle type1="c" type2="cc" type3="cg" angle="2.05739412225" k="561.040928"/>
+  <Angle type1="cc" type2="cc" type3="h4" angle="2.23332331085" k="387.840064"/>
+  <Angle type1="cc" type2="cc" type3="ha" angle="2.11307012539" k="398.601312"/>
+  <Angle type1="c" type2="cc" type3="cl" angle="2.03121418347" k="607.441488"/>
+  <Angle type1="cc" type2="cc" type3="n2" angle="2.13296687886" k="730.995008"/>
+  <Angle type1="cc" type2="cc" type3="n" angle="2.09247524022" k="717.581104"/>
+  <Angle type1="cc" type2="cc" type3="na" angle="2.05547426007" k="724.133248"/>
+  <Angle type1="cc" type2="cc" type3="nc" angle="2.12895262158" k="714.058176"/>
+  <Angle type1="cc" type2="cc" type3="nd" angle="1.96454260604" k="755.680608"/>
+  <Angle type1="cc" type2="cc" type3="nh" angle="2.08950818049" k="719.798624"/>
+  <Angle type1="cc" type2="cc" type3="oh" angle="2.11656078389" k="721.329968"/>
+  <Angle type1="cc" type2="cc" type3="os" angle="2.04796934429" k="729.798384"/>
+  <Angle type1="cc" type2="cc" type3="pd" angle="2.0134118251" k="707.238256"/>
+  <Angle type1="cc" type2="cc" type3="ss" angle="2.09806029382" k="534.522736"/>
+  <Angle type1="cc" type2="cc" type3="sy" angle="2.23838476568" k="511.335008"/>
+  <Angle type1="c" type2="c" type3="cd" angle="1.9490091757" k="552.45536"/>
+  <Angle type1="cd" type2="cc" type3="cd" angle="2.09579136579" k="585.985936"/>
+  <Angle type1="cd" type2="cc" type3="ce" angle="2.23489410718" k="550.271312"/>
+  <Angle type1="cd" type2="cc" type3="cl" angle="2.15391082989" k="599.876816"/>
+  <Angle type1="cd" type2="cc" type3="f" angle="2.11516452049" k="749.52176"/>
+  <Angle type1="cd" type2="cc" type3="h4" angle="2.24239902296" k="399.647312"/>
+  <Angle type1="cd" type2="cc" type3="ha" angle="2.12511289723" k="410.36672"/>
+  <Angle type1="cd" type2="cc" type3="n" angle="2.11760798144" k="727.93232"/>
+  <Angle type1="cd" type2="cc" type3="na" angle="1.86732776671" k="775.320304"/>
+  <Angle type1="cd" type2="cc" type3="nc" angle="1.94866010985" k="761.964976"/>
+  <Angle type1="cd" type2="cc" type3="nh" angle="2.16141574567" k="722.417808"/>
+  <Angle type1="cd" type2="cc" type3="no" angle="2.24606421439" k="694.100496"/>
+  <Angle type1="cd" type2="cc" type3="oh" angle="2.16036854812" k="729.497136"/>
+  <Angle type1="cd" type2="cc" type3="os" angle="2.09963109015" k="736.024176"/>
+  <Angle type1="cd" type2="cc" type3="ss" angle="1.9469147806" k="559.710416"/>
+  <Angle type1="cd" type2="cc" type3="sy" angle="2.17380758336" k="523.008368"/>
+  <Angle type1="ce" type2="cc" type3="na" angle="2.17031692485" k="697.648528"/>
+  <Angle type1="ce" type2="cc" type3="nc" angle="2.11359372417" k="709.346992"/>
+  <Angle type1="ce" type2="cc" type3="nd" angle="2.12406569968" k="718.702416"/>
+  <Angle type1="ce" type2="cc" type3="os" angle="2.07275301967" k="717.940928"/>
+  <Angle type1="ce" type2="cc" type3="ss" angle="2.12197130457" k="529.041696"/>
+  <Angle type1="c" type2="cc" type3="f" angle="2.04168615898" k="734.367312"/>
+  <Angle type1="cg" type2="cc" type3="na" angle="2.13994819587" k="710.259104"/>
+  <Angle type1="cg" type2="cc" type3="ss" angle="2.10713600593" k="533.560416"/>
+  <Angle type1="cc" type2="c" type3="h4" angle="2.00416158007" k="398.300064"/>
+  <Angle type1="c" type2="cc" type3="ha" angle="2.03575203953" k="396.68504"/>
+  <Angle type1="cl" type2="cc" type3="na" angle="2.11394279002" k="757.396048"/>
+  <Angle type1="cl" type2="cc" type3="nd" angle="2.13052341791" k="761.178384"/>
+  <Angle type1="cl" type2="cc" type3="ss" angle="2.09177710852" k="601.943712"/>
+  <Angle type1="c" type2="cc" type3="n2" angle="2.162986542" k="713.187904"/>
+  <Angle type1="c" type2="cc" type3="n" angle="2.03103965055" k="717.246384"/>
+  <Angle type1="cc" type2="c" type3="n" angle="1.966986067" k="729.22936"/>
+  <Angle type1="c" type2="cc" type3="nc" angle="2.15234003356" k="699.138032"/>
+  <Angle type1="cc" type2="c" type3="nd" angle="2.02877072252" k="716.317536"/>
+  <Angle type1="c" type2="cc" type3="nd" angle="2.12720729233" k="713.982864"/>
+  <Angle type1="c" type2="cc" type3="ne" angle="2.09230070729" k="707.121104"/>
+  <Angle type1="cc" type2="c" type3="o" angle="2.162986542" k="725.806848"/>
+  <Angle type1="c" type2="cc" type3="oh" angle="1.98374122782" k="733.103744"/>
+  <Angle type1="cc" type2="c" type3="oh" angle="1.96942952795" k="734.83592"/>
+  <Angle type1="c" type2="cc" type3="os" angle="2.08147966593" k="712.526832"/>
+  <Angle type1="cc" type2="c" type3="os" angle="1.99316600578" k="728.919744"/>
+  <Angle type1="cc" type2="c" type3="s" angle="2.20400177942" k="535.644048"/>
+  <Angle type1="cc" type2="c" type3="ss" angle="1.96175007924" k="538.949408"/>
+  <Angle type1="cx" type2="cc" type3="nd" angle="2.2308798499" k="695.774096"/>
+  <Angle type1="cx" type2="cc" type3="os" angle="2.06071024783" k="714.744352"/>
+  <Angle type1="cd" type2="c" type3="cd" angle="2.02178940551" k="558.112128"/>
+  <Angle type1="cd" type2="c" type3="cx" angle="2.04954014062" k="548.547504"/>
+  <Angle type1="cd" type2="c" type3="n" angle="1.966986067" k="729.22936"/>
+  <Angle type1="cd" type2="c" type3="nc" angle="2.02877072252" k="716.317536"/>
+  <Angle type1="cd" type2="c" type3="nd" angle="1.98531202414" k="724.116512"/>
+  <Angle type1="cd" type2="c" type3="o" angle="2.162986542" k="725.806848"/>
+  <Angle type1="cd" type2="c" type3="oh" angle="1.96942952795" k="734.83592"/>
+  <Angle type1="cd" type2="c" type3="os" angle="1.99316600578" k="728.919744"/>
+  <Angle type1="ce" type2="c" type3="ce" angle="2.02144033966" k="552.555776"/>
+  <Angle type1="ce" type2="c" type3="cf" angle="2.03103965055" k="551.242"/>
+  <Angle type1="ce" type2="c" type3="cx" angle="2.04884200892" k="545.978528"/>
+  <Angle type1="ce" type2="c" type3="h4" angle="2.00520877762" k="394.810608"/>
+  <Angle type1="ce" type2="c" type3="ha" angle="2.01096836415" k="394.810608"/>
+  <Angle type1="ce" type2="c" type3="n" angle="2.01096836415" k="716.97024"/>
+  <Angle type1="ce" type2="c" type3="o" angle="2.15024563846" k="722.560064"/>
+  <Angle type1="ce" type2="c" type3="oh" angle="1.98304309612" k="727.815168"/>
+  <Angle type1="ce" type2="c" type3="os" angle="1.93609373924" k="735.095328"/>
+  <Angle type1="ce" type2="c" type3="s" angle="2.14029726172" k="541.669008"/>
+  <Angle type1="ce" type2="c" type3="ss" angle="1.92841429053" k="542.196192"/>
+  <Angle type1="cf" type2="c" type3="cf" angle="2.02144033966" k="552.555776"/>
+  <Angle type1="cf" type2="c" type3="ha" angle="2.01096836415" k="394.810608"/>
+  <Angle type1="cf" type2="c" type3="n" angle="2.01096836415" k="716.97024"/>
+  <Angle type1="cf" type2="c" type3="o" angle="2.15024563846" k="722.560064"/>
+  <Angle type1="cf" type2="c" type3="oh" angle="1.98304309612" k="727.815168"/>
+  <Angle type1="cf" type2="c" type3="os" angle="1.93609373924" k="735.095328"/>
+  <Angle type1="cf" type2="c" type3="s" angle="2.14029726172" k="541.669008"/>
+  <Angle type1="cg" type2="c" type3="cg" angle="2.01376089095" k="565.542912"/>
+  <Angle type1="cg" type2="c" type3="ha" angle="1.98793001802" k="404.358496"/>
+  <Angle type1="cg" type2="c" type3="o" angle="2.12546196308" k="738.166384"/>
+  <Angle type1="c" type2="c" type3="h4" angle="2.02109127381" k="378.593424"/>
+  <Angle type1="h4" type2="cc" type3="n" angle="2.01917141163" k="525.025056"/>
+  <Angle type1="h4" type2="cc" type3="na" angle="2.10364534743" k="514.523216"/>
+  <Angle type1="h4" type2="cc" type3="nc" angle="2.11429185587" k="516.439488"/>
+  <Angle type1="h4" type2="cc" type3="nd" angle="2.06769156484" k="538.028928"/>
+  <Angle type1="h4" type2="cc" type3="os" angle="2.00538331054" k="532.53952"/>
+  <Angle type1="h4" type2="cc" type3="ss" angle="2.09387150362" k="355.271808"/>
+  <Angle type1="h5" type2="cc" type3="n" angle="2.01934594456" k="524.983216"/>
+  <Angle type1="h5" type2="cc" type3="na" angle="2.1214477058" k="512.339168"/>
+  <Angle type1="h5" type2="cc" type3="nc" angle="2.14535871655" k="512.66552"/>
+  <Angle type1="h5" type2="cc" type3="nd" angle="2.1907372771" k="522.673648"/>
+  <Angle type1="h5" type2="cc" type3="os" angle="2.0390681651" k="528.10448"/>
+  <Angle type1="h5" type2="cc" type3="ss" angle="2.11219746076" k="353.732096"/>
+  <Angle type1="c" type2="c" type3="ha" angle="2.01463355558" k="379.555744"/>
+  <Angle type1="ha" type2="cc" type3="na" angle="2.12057504117" k="512.272224"/>
+  <Angle type1="ha" type2="cc" type3="nc" angle="2.03400671027" k="526.330464"/>
+  <Angle type1="ha" type2="cc" type3="nd" angle="2.07484741477" k="536.840672"/>
+  <Angle type1="ha" type2="cc" type3="os" angle="1.93487200876" k="541.945152"/>
+  <Angle type1="ha" type2="cc" type3="pd" angle="2.12511289723" k="459.035008"/>
+  <Angle type1="ha" type2="cc" type3="ss" angle="2.12301850213" k="352.861824"/>
+  <Angle type1="ch" type2="c" type3="ch" angle="2.01376089095" k="565.542912"/>
+  <Angle type1="ch" type2="c" type3="ha" angle="1.98793001802" k="404.358496"/>
+  <Angle type1="ch" type2="c" type3="o" angle="2.12546196308" k="738.166384"/>
+  <Angle type1="cl" type2="c" type3="cl" angle="1.94255145747" k="675.46496"/>
+  <Angle type1="cl" type2="c" type3="f" angle="1.95476876223" k="779.52104"/>
+  <Angle type1="cl" type2="c" type3="ha" angle="1.91811684794" k="403.513328"/>
+  <Angle type1="cl" type2="c" type3="o" angle="2.10643787423" k="745.120192"/>
+  <Angle type1="cl" type2="c" type3="s" angle="2.22704012554" k="584.521536"/>
+  <Angle type1="c" type2="c" type3="n" angle="1.9676841987" k="705.665072"/>
+  <Angle type1="na" type2="cc" type3="nc" angle="2.12842902281" k="910.538816"/>
+  <Angle type1="na" type2="cc" type3="nd" angle="1.95860848659" k="966.537472"/>
+  <Angle type1="na" type2="cc" type3="no" angle="2.17450571506" k="881.259184"/>
+  <Angle type1="na" type2="cc" type3="oh" angle="2.05041280524" k="935.073792"/>
+  <Angle type1="na" type2="cc" type3="sx" angle="2.04238429068" k="666.787344"/>
+  <Angle type1="na" type2="cc" type3="sy" angle="2.10242361695" k="665.314576"/>
+  <Angle type1="nc" type2="cc" type3="nd" angle="2.02161487259" k="955.50008"/>
+  <Angle type1="nc" type2="cc" type3="nh" angle="2.04604948211" k="930.98184"/>
+  <Angle type1="nc" type2="cc" type3="no" angle="2.12458929845" k="894.723296"/>
+  <Angle type1="nc" type2="cc" type3="ss" angle="2.14047179465" k="668.787296"/>
+  <Angle type1="nd" type2="cc" type3="nd" angle="2.23524317303" k="927.400336"/>
+  <Angle type1="nd" type2="cc" type3="ne" angle="2.251649268" k="902.036928"/>
+  <Angle type1="nd" type2="cc" type3="nh" angle="2.10573974253" k="934.680496"/>
+  <Angle type1="nd" type2="cc" type3="no" angle="2.14239165682" k="905.75232"/>
+  <Angle type1="nd" type2="cc" type3="oh" angle="2.11394279002" k="942.73888"/>
+  <Angle type1="nd" type2="cc" type3="os" angle="2.03749736878" k="954.587968"/>
+  <Angle type1="nd" type2="cc" type3="sh" angle="2.18113796622" k="662.728864"/>
+  <Angle type1="nd" type2="cc" type3="ss" angle="1.99857652646" k="696.753152"/>
+  <Angle type1="nd" type2="cc" type3="sx" angle="2.2294835865" k="642.394624"/>
+  <Angle type1="nd" type2="cc" type3="sy" angle="2.14727857873" k="663.20584"/>
+  <Angle type1="ne" type2="cc" type3="ss" angle="2.04255882361" k="683.724176"/>
+  <Angle type1="nh" type2="cc" type3="nh" angle="2.02388380061" k="934.672128"/>
+  <Angle type1="nh" type2="cc" type3="os" angle="2.03645017123" k="935.66792"/>
+  <Angle type1="nh" type2="cc" type3="ss" angle="2.12598556185" k="670.670096"/>
+  <Angle type1="n" type2="cc" type3="n2" angle="2.08427219273" k="945.014976"/>
+  <Angle type1="n" type2="cc" type3="na" angle="2.13139608254" k="906.21256"/>
+  <Angle type1="n" type2="cc" type3="nc" angle="2.20312911479" k="894.806976"/>
+  <Angle type1="n" type2="cc" type3="nd" angle="2.14675497995" k="923.023872"/>
+  <Angle type1="n" type2="cc" type3="nh" angle="2.04098802728" k="928.30408"/>
+  <Angle type1="no" type2="cc" type3="os" angle="2.05163453572" k="912.681024"/>
+  <Angle type1="no" type2="cc" type3="ss" angle="2.11289559246" k="666.871024"/>
+  <Angle type1="n" type2="cc" type3="ss" angle="2.14466058485" k="667.038384"/>
+  <Angle type1="c" type2="c" type3="o" angle="2.10923040104" k="705.6316"/>
+  <Angle type1="c" type2="c" type3="oh" angle="1.95599049271" k="712.70256"/>
+  <Angle type1="c" type2="c" type3="os" angle="1.94447131965" k="713.556096"/>
+  <Angle type1="os" type2="cc" type3="ss" angle="2.08182873178" k="678.845632"/>
+  <Angle type1="ss" type2="cc" type3="ss" angle="2.11830611315" k="532.531152"/>
+  <Angle type1="ss" type2="cc" type3="sy" angle="2.12406569968" k="527.585664"/>
+  <Angle type1="cx" type2="c" type3="cx" angle="1.12748269679" k="732.250208"/>
+  <Angle type1="cx" type2="c" type3="n" angle="1.99892559231" k="714.702512"/>
+  <Angle type1="cx" type2="c" type3="o" angle="2.14239165682" k="718.300752"/>
+  <Angle type1="cx" type2="c" type3="oh" angle="1.96384447434" k="726.67712"/>
+  <Angle type1="cx" type2="c" type3="os" angle="1.9441222538" k="728.928112"/>
+  <Angle type1="cy" type2="c" type3="cy" angle="1.60413211551" k="592.91464"/>
+  <Angle type1="cy" type2="c" type3="n" angle="1.59802346313" k="782.165328"/>
+  <Angle type1="cy" type2="c" type3="o" angle="2.358987017" k="666.302"/>
+  <Angle type1="cy" type2="c" type3="oh" angle="1.95791035489" k="711.522672"/>
+  <Angle type1="cy" type2="c" type3="os" angle="1.65439759797" k="772.692752"/>
+  <Angle type1="c2" type2="cd" type3="c3" angle="2.20103471969" k="546.112416"/>
+  <Angle type1="c2" type2="cd" type3="ca" angle="2.17153865533" k="560.254336"/>
+  <Angle type1="c2" type2="cd" type3="cc" angle="2.04238429068" k="596.521248"/>
+  <Angle type1="c2" type2="cd" type3="cd" angle="2.13261781301" k="571.601344"/>
+  <Angle type1="c2" type2="cd" type3="ha" angle="2.14186805805" k="411.965008"/>
+  <Angle type1="c2" type2="cd" type3="n" angle="2.18009076867" k="720.9032"/>
+  <Angle type1="c2" type2="cd" type3="os" angle="2.11917877777" k="736.308688"/>
+  <Angle type1="c3" type2="cd" type3="ca" angle="2.20819056962" k="529.845024"/>
+  <Angle type1="c3" type2="cd" type3="cc" angle="2.08479579151" k="558.999136"/>
+  <Angle type1="c3" type2="cd" type3="cd" angle="2.02405833354" k="558.220912"/>
+  <Angle type1="c3" type2="cd" type3="ce" angle="2.05669599055" k="563.96136"/>
+  <Angle type1="c3" type2="cd" type3="ha" angle="2.12092410702" k="380.886256"/>
+  <Angle type1="c3" type2="cd" type3="n2" angle="2.19370433683" k="697.355648"/>
+  <Angle type1="c3" type2="cd" type3="n" angle="2.08025793545" k="699.213344"/>
+  <Angle type1="c3" type2="cd" type3="na" angle="2.14204259097" k="689.155008"/>
+  <Angle type1="c3" type2="cd" type3="nc" angle="2.13645753737" k="701.958048"/>
+  <Angle type1="c3" type2="cd" type3="nd" angle="2.11097573029" k="696.34312"/>
+  <Angle type1="c3" type2="cd" type3="os" angle="2.03854456633" k="710.06664"/>
+  <Angle type1="c3" type2="cd" type3="ss" angle="2.12109863995" k="524.305408"/>
+  <Angle type1="ca" type2="cd" type3="cc" angle="1.98112323394" k="584.103136"/>
+  <Angle type1="ca" type2="cd" type3="cd" angle="1.93801360141" k="580.203648"/>
+  <Angle type1="ca" type2="cd" type3="ce" angle="2.17991623574" k="558.095392"/>
+  <Angle type1="ca" type2="cd" type3="h4" angle="2.2558380582" k="379.639424"/>
+  <Angle type1="ca" type2="cd" type3="ha" angle="2.16490640417" k="387.4384"/>
+  <Angle type1="ca" type2="cd" type3="n" angle="2.05372893082" k="716.652256"/>
+  <Angle type1="ca" type2="cd" type3="na" angle="2.15460896159" k="699.782368"/>
+  <Angle type1="ca" type2="cd" type3="nc" angle="2.15094377016" k="713.740192"/>
+  <Angle type1="ca" type2="cd" type3="nd" angle="2.10469254498" k="710.418096"/>
+  <Angle type1="ca" type2="cd" type3="oh" angle="2.05163453572" k="724.476336"/>
+  <Angle type1="ca" type2="cd" type3="os" angle="2.00276531666" k="729.932272"/>
+  <Angle type1="ca" type2="cd" type3="ss" angle="2.10835773641" k="530.598144"/>
+  <Angle type1="c" type2="cd" type3="c2" angle="2.11481545464" k="564.948784"/>
+  <Angle type1="c" type2="cd" type3="c3" angle="2.05529972715" k="547.083104"/>
+  <Angle type1="c" type2="cd" type3="c" angle="2.11307012539" k="545.92832"/>
+  <Angle type1="c" type2="cd" type3="ca" angle="2.14588231533" k="543.96184"/>
+  <Angle type1="c" type2="cd" type3="cc" angle="2.1179570473" k="562.220816"/>
+  <Angle type1="cc" type2="cd" type3="cc" angle="2.09579136579" k="585.985936"/>
+  <Angle type1="cc" type2="cd" type3="cd" angle="1.99299147285" k="588.672064"/>
+  <Angle type1="cc" type2="cd" type3="cf" angle="2.23489410718" k="550.271312"/>
+  <Angle type1="cc" type2="cd" type3="ch" angle="2.19544966608" k="561.32544"/>
+  <Angle type1="cc" type2="cd" type3="cl" angle="2.15391082989" k="599.876816"/>
+  <Angle type1="cc" type2="cd" type3="cy" angle="2.13017435206" k="552.179216"/>
+  <Angle type1="c" type2="cd" type3="cd" angle="2.14134445927" k="549.560032"/>
+  <Angle type1="c" type2="cd" type3="cf" angle="2.12179677165" k="547.317408"/>
+  <Angle type1="cc" type2="cd" type3="h4" angle="2.24239902296" k="399.647312"/>
+  <Angle type1="cc" type2="cd" type3="ha" angle="2.12511289723" k="410.36672"/>
+  <Angle type1="c" type2="cd" type3="cl" angle="2.03121418347" k="607.441488"/>
+  <Angle type1="cc" type2="cd" type3="n" angle="2.11760798144" k="727.93232"/>
+  <Angle type1="cc" type2="cd" type3="na" angle="1.86732776671" k="775.320304"/>
+  <Angle type1="cc" type2="cd" type3="nc" angle="2.16106667982" k="736.961392"/>
+  <Angle type1="cc" type2="cd" type3="nd" angle="1.94866010985" k="761.964976"/>
+  <Angle type1="cc" type2="cd" type3="nh" angle="2.16141574567" k="722.417808"/>
+  <Angle type1="cc" type2="cd" type3="oh" angle="2.16036854812" k="729.497136"/>
+  <Angle type1="cc" type2="cd" type3="os" angle="2.09963109015" k="736.024176"/>
+  <Angle type1="cc" type2="cd" type3="ss" angle="1.9469147806" k="559.710416"/>
+  <Angle type1="cc" type2="cd" type3="sy" angle="2.17380758336" k="523.008368"/>
+  <Angle type1="cd" type2="cd" type3="cd" angle="1.93207948196" k="586.839472"/>
+  <Angle type1="cd" type2="cd" type3="ce" angle="2.14186805805" k="569.208096"/>
+  <Angle type1="cd" type2="cd" type3="cf" angle="2.21761534758" k="542.689904"/>
+  <Angle type1="cd" type2="cd" type3="ch" angle="2.19754406119" k="550.65624"/>
+  <Angle type1="cd" type2="cd" type3="cy" angle="2.12999981913" k="543.401184"/>
+  <Angle type1="cd" type2="cd" type3="h4" angle="2.23332331085" k="387.840064"/>
+  <Angle type1="cd" type2="cd" type3="ha" angle="2.11307012539" k="398.601312"/>
+  <Angle type1="cd" type2="cd" type3="n2" angle="2.13296687886" k="730.995008"/>
+  <Angle type1="cd" type2="cd" type3="n" angle="2.09247524022" k="717.581104"/>
+  <Angle type1="cd" type2="cd" type3="na" angle="2.05547426007" k="724.133248"/>
+  <Angle type1="cd" type2="cd" type3="nc" angle="1.96454260604" k="755.680608"/>
+  <Angle type1="cd" type2="cd" type3="nd" angle="2.12895262158" k="714.058176"/>
+  <Angle type1="cd" type2="cd" type3="nh" angle="2.08950818049" k="719.798624"/>
+  <Angle type1="cd" type2="cd" type3="oh" angle="2.11656078389" k="721.329968"/>
+  <Angle type1="cd" type2="cd" type3="os" angle="2.04796934429" k="729.798384"/>
+  <Angle type1="cd" type2="cd" type3="pc" angle="2.0134118251" k="707.238256"/>
+  <Angle type1="cd" type2="cd" type3="ss" angle="2.09806029382" k="534.522736"/>
+  <Angle type1="ce" type2="cd" type3="nd" angle="2.16385920662" k="725.011888"/>
+  <Angle type1="cf" type2="cd" type3="na" angle="2.17031692485" k="697.648528"/>
+  <Angle type1="cf" type2="cd" type3="nc" angle="2.12406569968" k="718.702416"/>
+  <Angle type1="cf" type2="cd" type3="nd" angle="2.11359372417" k="709.346992"/>
+  <Angle type1="cf" type2="cd" type3="os" angle="2.07275301967" k="717.940928"/>
+  <Angle type1="cf" type2="cd" type3="ss" angle="2.12197130457" k="529.041696"/>
+  <Angle type1="c" type2="cd" type3="h4" angle="2.06280464293" k="394.17464"/>
+  <Angle type1="c" type2="cd" type3="ha" angle="2.03575203953" k="396.68504"/>
+  <Angle type1="cl" type2="cd" type3="nc" angle="2.13052341791" k="761.178384"/>
+  <Angle type1="c" type2="cd" type3="n2" angle="2.162986542" k="713.187904"/>
+  <Angle type1="c" type2="cd" type3="n" angle="2.03103965055" k="717.246384"/>
+  <Angle type1="c" type2="cd" type3="nc" angle="2.12720729233" k="713.982864"/>
+  <Angle type1="c" type2="cd" type3="nd" angle="2.15234003356" k="699.138032"/>
+  <Angle type1="c" type2="cd" type3="oh" angle="1.98374122782" k="733.103744"/>
+  <Angle type1="c" type2="cd" type3="os" angle="2.08147966593" k="712.526832"/>
+  <Angle type1="h4" type2="cd" type3="n" angle="2.01917141163" k="525.025056"/>
+  <Angle type1="h4" type2="cd" type3="na" angle="2.10364534743" k="514.523216"/>
+  <Angle type1="h4" type2="cd" type3="nc" angle="2.06769156484" k="538.028928"/>
+  <Angle type1="h4" type2="cd" type3="nd" angle="2.11429185587" k="516.439488"/>
+  <Angle type1="h4" type2="cd" type3="os" angle="2.00538331054" k="532.53952"/>
+  <Angle type1="h4" type2="cd" type3="ss" angle="2.09387150362" k="355.271808"/>
+  <Angle type1="h5" type2="cd" type3="n" angle="2.01934594456" k="524.991584"/>
+  <Angle type1="h5" type2="cd" type3="na" angle="2.1214477058" k="512.347536"/>
+  <Angle type1="h5" type2="cd" type3="nc" angle="2.1907372771" k="522.682016"/>
+  <Angle type1="h5" type2="cd" type3="nd" angle="2.14535871655" k="512.673888"/>
+  <Angle type1="h5" type2="cd" type3="os" angle="2.0390681651" k="528.112848"/>
+  <Angle type1="h5" type2="cd" type3="ss" angle="2.11219746076" k="353.723728"/>
+  <Angle type1="ha" type2="cd" type3="na" angle="2.12057504117" k="512.272224"/>
+  <Angle type1="ha" type2="cd" type3="nc" angle="2.07484741477" k="536.840672"/>
+  <Angle type1="ha" type2="cd" type3="nd" angle="2.03400671027" k="526.330464"/>
+  <Angle type1="ha" type2="cd" type3="os" angle="1.93487200876" k="541.945152"/>
+  <Angle type1="ha" type2="cd" type3="pc" angle="2.12511289723" k="459.035008"/>
+  <Angle type1="ha" type2="cd" type3="ss" angle="2.12301850213" k="352.861824"/>
+  <Angle type1="na" type2="cd" type3="nc" angle="1.95860848659" k="966.537472"/>
+  <Angle type1="na" type2="cd" type3="nd" angle="2.12842902281" k="910.538816"/>
+  <Angle type1="na" type2="cd" type3="nh" angle="2.04692214674" k="927.124192"/>
+  <Angle type1="na" type2="cd" type3="ss" angle="1.94534398427" k="700.426704"/>
+  <Angle type1="nc" type2="cd" type3="nd" angle="2.02161487259" k="955.50008"/>
+  <Angle type1="nc" type2="cd" type3="nh" angle="2.10573974253" k="934.680496"/>
+  <Angle type1="nc" type2="cd" type3="oh" angle="2.11394279002" k="942.73888"/>
+  <Angle type1="nc" type2="cd" type3="os" angle="2.03749736878" k="954.587968"/>
+  <Angle type1="nc" type2="cd" type3="ss" angle="1.99857652646" k="696.753152"/>
+  <Angle type1="nd" type2="cd" type3="nd" angle="2.19387886976" k="900.421904"/>
+  <Angle type1="nd" type2="cd" type3="nh" angle="2.04604948211" k="930.98184"/>
+  <Angle type1="nd" type2="cd" type3="ss" angle="2.14047179465" k="668.787296"/>
+  <Angle type1="nh" type2="cd" type3="nh" angle="2.02388380061" k="934.672128"/>
+  <Angle type1="nh" type2="cd" type3="os" angle="2.03645017123" k="935.66792"/>
+  <Angle type1="nh" type2="cd" type3="ss" angle="2.12598556185" k="670.670096"/>
+  <Angle type1="n" type2="cd" type3="na" angle="2.13139608254" k="906.21256"/>
+  <Angle type1="n" type2="cd" type3="nc" angle="2.14675497995" k="923.023872"/>
+  <Angle type1="n" type2="cd" type3="nd" angle="2.20312911479" k="894.806976"/>
+  <Angle type1="n" type2="cd" type3="nh" angle="2.04098802728" k="928.30408"/>
+  <Angle type1="n" type2="cd" type3="ss" angle="2.14466058485" k="667.038384"/>
+  <Angle type1="oh" type2="cd" type3="os" angle="1.94796197815" k="966.018656"/>
+  <Angle type1="os" type2="cd" type3="ss" angle="2.08182873178" k="678.845632"/>
+  <Angle type1="ss" type2="cd" type3="ss" angle="2.11830611315" k="532.531152"/>
+  <Angle type1="ss" type2="cd" type3="sy" angle="2.12406569968" k="527.585664"/>
+  <Angle type1="c2" type2="ce" type3="c3" angle="2.13855193247" k="552.639456"/>
+  <Angle type1="c2" type2="ce" type3="ca" angle="2.12546196308" k="563.685216"/>
+  <Angle type1="c2" type2="ce" type3="cc" angle="2.15234003356" k="565.34208"/>
+  <Angle type1="c2" type2="ce" type3="ce" angle="2.15129283601" k="564.689376"/>
+  <Angle type1="c2" type2="ce" type3="cg" angle="2.13087248376" k="574.438096"/>
+  <Angle type1="c2" type2="ce" type3="cl" angle="2.09020631219" k="603.16544"/>
+  <Angle type1="c2" type2="ce" type3="h4" angle="2.17380758336" k="411.320672"/>
+  <Angle type1="c2" type2="ce" type3="ha" angle="2.09334790484" k="419.454368"/>
+  <Angle type1="c2" type2="ce" type3="n1" angle="2.06350277463" k="763.906352"/>
+  <Angle type1="c2" type2="ce" type3="n2" angle="2.24623874732" k="738.291904"/>
+  <Angle type1="c2" type2="ce" type3="na" angle="2.08025793545" k="729.823488"/>
+  <Angle type1="c2" type2="ce" type3="ne" angle="2.06507357096" k="740.266752"/>
+  <Angle type1="c2" type2="ce" type3="oh" angle="2.15897228472" k="736.250112"/>
+  <Angle type1="c2" type2="ce" type3="p2" angle="2.06367730756" k="681.339296"/>
+  <Angle type1="c2" type2="ce" type3="pe" angle="2.07275301967" k="678.552752"/>
+  <Angle type1="c2" type2="ce" type3="px" angle="2.08950818049" k="674.854096"/>
+  <Angle type1="c2" type2="ce" type3="py" angle="2.13244328009" k="672.946192"/>
+  <Angle type1="c2" type2="ce" type3="sx" angle="2.0806070013" k="527.619136"/>
+  <Angle type1="c2" type2="ce" type3="sy" angle="2.0978857609" k="533.08344"/>
+  <Angle type1="c3" type2="ce" type3="ca" angle="2.08113060008" k="539.434752"/>
+  <Angle type1="c3" type2="ce" type3="cc" angle="2.06001211613" k="545.978528"/>
+  <Angle type1="c3" type2="ce" type3="ce" angle="2.04412961994" k="547.51824"/>
+  <Angle type1="c3" type2="ce" type3="cf" angle="2.13593393859" k="552.279632"/>
+  <Angle type1="c3" type2="ce" type3="cg" angle="2.04587494919" k="552.354944"/>
+  <Angle type1="c3" type2="ce" type3="n2" angle="2.14204259097" k="701.564752"/>
+  <Angle type1="c3" type2="ce" type3="nf" angle="2.10626334131" k="706.00816"/>
+  <Angle type1="c3" type2="ce" type3="nh" angle="2.08671565368" k="692.251168"/>
+  <Angle type1="ca" type2="ce" type3="ca" angle="2.05652145762" k="550.120688"/>
+  <Angle type1="ca" type2="ce" type3="cc" angle="2.06175744538" k="553.534832"/>
+  <Angle type1="ca" type2="ce" type3="ce" angle="2.08636658783" k="549.643712"/>
+  <Angle type1="ca" type2="ce" type3="cf" angle="2.22564386214" k="550.095584"/>
+  <Angle type1="ca" type2="ce" type3="cl" angle="1.99997278986" k="604.010608"/>
+  <Angle type1="ca" type2="ce" type3="h4" angle="2.04186069191" k="393.689296"/>
+  <Angle type1="ca" type2="ce" type3="ha" angle="2.00939756782" k="397.011392"/>
+  <Angle type1="ca" type2="ce" type3="n2" angle="2.10696147301" k="720.350912"/>
+  <Angle type1="ca" type2="ce" type3="nf" angle="2.1242402326" k="715.748512"/>
+  <Angle type1="ca" type2="ce" type3="nh" angle="2.01725154946" k="715.179488"/>
+  <Angle type1="ca" type2="ce" type3="oh" angle="2.02632726157" k="722.083088"/>
+  <Angle type1="ca" type2="ce" type3="os" angle="2.02301113599" k="718.292384"/>
+  <Angle type1="ca" type2="ce" type3="ss" angle="2.05111093694" k="530.347104"/>
+  <Angle type1="c" type2="ce" type3="c2" angle="2.10172548525" k="565.392288"/>
+  <Angle type1="c" type2="ce" type3="c3" angle="2.04587494919" k="542.991152"/>
+  <Angle type1="c" type2="ce" type3="c" angle="2.13331594471" k="537.869936"/>
+  <Angle type1="c" type2="ce" type3="ca" angle="2.06437543926" k="547.919904"/>
+  <Angle type1="cc" type2="ce" type3="cd" angle="2.27957453603" k="546.087312"/>
+  <Angle type1="cc" type2="ce" type3="cf" angle="2.20155831847" k="558.179072"/>
+  <Angle type1="c" type2="ce" type3="cd" angle="2.10783413763" k="561.425856"/>
+  <Angle type1="c" type2="ce" type3="ce" angle="2.11149932906" k="545.1752"/>
+  <Angle type1="c" type2="ce" type3="cf" angle="2.20627070745" k="551.083008"/>
+  <Angle type1="c" type2="ce" type3="cg" angle="2.06681890021" k="556.472"/>
+  <Angle type1="cc" type2="ce" type3="h4" angle="2.01899687871" k="401.12008"/>
+  <Angle type1="cc" type2="ce" type3="ha" angle="2.0148080885" k="401.714208"/>
+  <Angle type1="c" type2="ce" type3="cl" angle="2.01533168728" k="600.998128"/>
+  <Angle type1="cc" type2="ce" type3="n2" angle="2.11115026321" k="726.911424"/>
+  <Angle type1="cc" type2="ce" type3="nh" angle="2.06036118198" k="713.782032"/>
+  <Angle type1="c" type2="ce" type3="cy" angle="1.54356919046" k="625.123072"/>
+  <Angle type1="cd" type2="ce" type3="ce" angle="2.17031692485" k="558.907088"/>
+  <Angle type1="cd" type2="ce" type3="ha" angle="2.00625597517" k="423.738784"/>
+  <Angle type1="ce" type2="ce" type3="ce" angle="2.13122154961" k="547.401088"/>
+  <Angle type1="ce" type2="ce" type3="cf" angle="2.16839706268" k="561.651792"/>
+  <Angle type1="ce" type2="ce" type3="cl" angle="2.04587494919" k="599.291056"/>
+  <Angle type1="ce" type2="ce" type3="h4" angle="2.06175744538" k="396.149488"/>
+  <Angle type1="ce" type2="ce" type3="ha" angle="2.03592657245" k="398.835616"/>
+  <Angle type1="ce" type2="ce" type3="n1" angle="2.21918614391" k="703.322032"/>
+  <Angle type1="ce" type2="ce" type3="n2" angle="2.0757200794" k="731.965696"/>
+  <Angle type1="ce" type2="ce" type3="oh" angle="2.03941723096" k="725.38008"/>
+  <Angle type1="cf" type2="ce" type3="cg" angle="2.14902390798" k="571.132736"/>
+  <Angle type1="cf" type2="ce" type3="cy" angle="2.40122398489" k="520.882896"/>
+  <Angle type1="cf" type2="ce" type3="h4" angle="2.14588231533" k="412.868752"/>
+  <Angle type1="cf" type2="ce" type3="ha" angle="2.06332824171" k="421.345536"/>
+  <Angle type1="cf" type2="ce" type3="n1" angle="2.09334790484" k="757.002752"/>
+  <Angle type1="cf" type2="ce" type3="n" angle="1.89176237624" k="763.136496"/>
+  <Angle type1="cf" type2="ce" type3="nh" angle="2.11848064607" k="730.836016"/>
+  <Angle type1="cf" type2="ce" type3="oh" angle="2.12389116675" k="740.994768"/>
+  <Angle type1="cg" type2="ce" type3="cg" angle="2.03365764442" k="572.312624"/>
+  <Angle type1="cg" type2="ce" type3="ha" angle="2.03261044687" k="406.324976"/>
+  <Angle type1="cg" type2="ce" type3="n1" angle="2.08566845613" k="735.00328"/>
+  <Angle type1="cg" type2="ce" type3="n2" angle="2.11429185587" k="735.137168"/>
+  <Angle type1="c" type2="ce" type3="ha" angle="2.03261044687" k="393.296"/>
+  <Angle type1="c" type2="ce" type3="n" angle="2.06734249899" k="697.372384"/>
+  <Angle type1="c" type2="ce" type3="nh" angle="2.0134118251" k="714.133488"/>
+  <Angle type1="c" type2="ce" type3="oh" angle="2.02039314211" k="721.288128"/>
+  <Angle type1="c" type2="ce" type3="os" angle="2.00136905326" k="720.367648"/>
+  <Angle type1="h4" type2="ce" type3="n1" angle="2.03575203953" k="542.773584"/>
+  <Angle type1="h4" type2="ce" type3="n2" angle="2.12022597532" k="538.840624"/>
+  <Angle type1="h4" type2="ce" type3="ne" angle="2.01847327993" k="520.096304"/>
+  <Angle type1="ha" type2="ce" type3="n1" angle="2.02388380061" k="544.807008"/>
+  <Angle type1="ha" type2="ce" type3="n2" angle="2.08584298906" k="543.744272"/>
+  <Angle type1="ha" type2="ce" type3="ne" angle="2.06978595994" k="513.912352"/>
+  <Angle type1="ha" type2="ce" type3="nh" angle="2.00695410687" k="523.133888"/>
+  <Angle type1="ha" type2="ce" type3="p2" angle="2.09631496457" k="440.207008"/>
+  <Angle type1="ha" type2="ce" type3="pe" angle="2.0827013964" k="440.583568"/>
+  <Angle type1="ha" type2="ce" type3="px" angle="2.0577431881" k="442.441264"/>
+  <Angle type1="ha" type2="ce" type3="py" angle="2.05931398443" k="446.399328"/>
+  <Angle type1="ha" type2="ce" type3="sx" angle="2.01498262143" k="348.928864"/>
+  <Angle type1="ha" type2="ce" type3="sy" angle="2.00468517884" k="356.292704"/>
+  <Angle type1="n2" type2="ce" type3="nh" angle="2.18323236132" k="920.56368"/>
+  <Angle type1="n2" type2="ce" type3="os" angle="2.05861585273" k="955.75112"/>
+  <Angle type1="n2" type2="ce" type3="ss" angle="2.04604948211" k="682.092416"/>
+  <Angle type1="ne" type2="ce" type3="ne" angle="2.16193934445" k="890.915856"/>
+  <Angle type1="ne" type2="ce" type3="nh" angle="1.98339216197" k="931.517392"/>
+  <Angle type1="nf" type2="ce" type3="nh" angle="2.08165419885" k="940.077856"/>
+  <Angle type1="pe" type2="ce" type3="pe" angle="2.26526283616" k="819.294144"/>
+  <Angle type1="py" type2="ce" type3="py" angle="1.88600278971" k="904.070352"/>
+  <Angle type1="sx" type2="ce" type3="sx" angle="2.099980156" k="516.531536"/>
+  <Angle type1="sy" type2="ce" type3="sy" angle="2.09387150362" k="526.071056"/>
+  <Angle type1="c2" type2="cf" type3="c3" angle="2.13855193247" k="552.689664"/>
+  <Angle type1="c2" type2="cf" type3="ca" angle="2.12546196308" k="563.685216"/>
+  <Angle type1="c2" type2="cf" type3="cd" angle="2.15234003356" k="565.34208"/>
+  <Angle type1="c2" type2="cf" type3="cf" angle="2.15129283601" k="564.689376"/>
+  <Angle type1="c2" type2="cf" type3="ch" angle="2.13087248376" k="574.438096"/>
+  <Angle type1="c2" type2="cf" type3="ha" angle="2.09334790484" k="419.454368"/>
+  <Angle type1="c2" type2="cf" type3="n2" angle="2.24623874732" k="738.291904"/>
+  <Angle type1="c2" type2="cf" type3="nf" angle="2.06507357096" k="740.266752"/>
+  <Angle type1="c2" type2="cf" type3="p2" angle="2.06367730756" k="681.339296"/>
+  <Angle type1="c2" type2="cf" type3="pf" angle="2.07275301967" k="678.552752"/>
+  <Angle type1="c2" type2="cf" type3="px" angle="2.08950818049" k="674.854096"/>
+  <Angle type1="c2" type2="cf" type3="py" angle="2.13244328009" k="672.946192"/>
+  <Angle type1="c2" type2="cf" type3="sx" angle="2.0806070013" k="527.619136"/>
+  <Angle type1="c2" type2="cf" type3="sy" angle="2.0978857609" k="533.08344"/>
+  <Angle type1="c3" type2="cf" type3="ca" angle="2.08113060008" k="539.468224"/>
+  <Angle type1="c3" type2="cf" type3="cd" angle="2.06001211613" k="546.020368"/>
+  <Angle type1="c3" type2="cf" type3="ce" angle="2.13593393859" k="552.32984"/>
+  <Angle type1="c3" type2="cf" type3="cf" angle="2.04412961994" k="547.56008"/>
+  <Angle type1="c3" type2="cf" type3="n2" angle="2.14204259097" k="701.623328"/>
+  <Angle type1="ca" type2="cf" type3="ca" angle="2.05652145762" k="550.120688"/>
+  <Angle type1="ca" type2="cf" type3="cc" angle="2.28428692501" k="540.664848"/>
+  <Angle type1="ca" type2="cf" type3="cd" angle="2.06175744538" k="553.534832"/>
+  <Angle type1="ca" type2="cf" type3="ce" angle="2.22564386214" k="550.095584"/>
+  <Angle type1="ca" type2="cf" type3="ha" angle="2.00939756782" k="397.011392"/>
+  <Angle type1="ca" type2="cf" type3="n2" angle="2.10696147301" k="720.350912"/>
+  <Angle type1="ca" type2="cf" type3="ne" angle="2.1242402326" k="715.748512"/>
+  <Angle type1="ca" type2="cf" type3="oh" angle="2.02632726157" k="722.083088"/>
+  <Angle type1="c" type2="cf" type3="c2" angle="2.10172548525" k="565.392288"/>
+  <Angle type1="c" type2="cf" type3="c3" angle="2.04587494919" k="543.024624"/>
+  <Angle type1="c" type2="cf" type3="c" angle="2.13331594471" k="537.869936"/>
+  <Angle type1="c" type2="cf" type3="cc" angle="2.10783413763" k="561.425856"/>
+  <Angle type1="cc" type2="cf" type3="cf" angle="2.17031692485" k="558.907088"/>
+  <Angle type1="c" type2="cf" type3="cd" angle="2.0563469247" k="553.057856"/>
+  <Angle type1="c" type2="cf" type3="ce" angle="2.20627070745" k="551.083008"/>
+  <Angle type1="cc" type2="cf" type3="ha" angle="2.00625597517" k="423.738784"/>
+  <Angle type1="cd" type2="cf" type3="ce" angle="2.20155831847" k="558.179072"/>
+  <Angle type1="cd" type2="cf" type3="ha" angle="2.0148080885" k="401.714208"/>
+  <Angle type1="cd" type2="cf" type3="n2" angle="2.11115026321" k="726.911424"/>
+  <Angle type1="ce" type2="cf" type3="cf" angle="2.16839706268" k="561.651792"/>
+  <Angle type1="ce" type2="cf" type3="ch" angle="2.14902390798" k="571.132736"/>
+  <Angle type1="ce" type2="cf" type3="ha" angle="2.06332824171" k="421.345536"/>
+  <Angle type1="ce" type2="cf" type3="n" angle="1.89176237624" k="763.136496"/>
+  <Angle type1="ce" type2="cf" type3="oh" angle="2.12389116675" k="740.994768"/>
+  <Angle type1="cf" type2="cf" type3="cf" angle="2.13122154961" k="547.401088"/>
+  <Angle type1="cf" type2="cf" type3="h4" angle="2.06175744538" k="396.149488"/>
+  <Angle type1="cf" type2="cf" type3="ha" angle="2.03592657245" k="398.835616"/>
+  <Angle type1="cf" type2="cf" type3="n1" angle="2.21918614391" k="703.322032"/>
+  <Angle type1="cf" type2="cf" type3="n2" angle="2.0757200794" k="731.965696"/>
+  <Angle type1="c" type2="cf" type3="ha" angle="2.03261044687" k="393.296"/>
+  <Angle type1="ch" type2="cf" type3="ch" angle="2.03365764442" k="572.312624"/>
+  <Angle type1="ch" type2="cf" type3="ha" angle="2.03261044687" k="406.324976"/>
+  <Angle type1="ch" type2="cf" type3="n1" angle="2.08566845613" k="735.00328"/>
+  <Angle type1="c" type2="cf" type3="n2" angle="1.99683119721" k="737.865136"/>
+  <Angle type1="c" type2="cf" type3="n" angle="2.06734249899" k="697.372384"/>
+  <Angle type1="c" type2="cf" type3="nh" angle="2.0134118251" k="714.133488"/>
+  <Angle type1="f" type2="c" type3="f" angle="1.87361095202" k="1036.175968"/>
+  <Angle type1="h4" type2="cf" type3="n2" angle="2.12022597532" k="538.840624"/>
+  <Angle type1="h4" type2="cf" type3="ne" angle="2.1041689462" k="538.22976"/>
+  <Angle type1="ha" type2="cf" type3="n1" angle="2.02388380061" k="544.807008"/>
+  <Angle type1="ha" type2="cf" type3="n2" angle="2.08584298906" k="543.744272"/>
+  <Angle type1="ha" type2="cf" type3="nf" angle="2.06978595994" k="513.912352"/>
+  <Angle type1="ha" type2="cf" type3="nh" angle="2.00695410687" k="523.133888"/>
+  <Angle type1="ha" type2="cf" type3="p2" angle="2.09631496457" k="440.207008"/>
+  <Angle type1="ha" type2="cf" type3="pf" angle="2.0827013964" k="440.583568"/>
+  <Angle type1="ha" type2="cf" type3="px" angle="2.0577431881" k="442.441264"/>
+  <Angle type1="ha" type2="cf" type3="py" angle="2.05931398443" k="446.399328"/>
+  <Angle type1="ha" type2="cf" type3="sx" angle="2.01498262143" k="348.928864"/>
+  <Angle type1="ha" type2="cf" type3="sy" angle="2.00468517884" k="356.292704"/>
+  <Angle type1="n2" type2="cf" type3="nh" angle="2.18323236132" k="920.56368"/>
+  <Angle type1="nf" type2="cf" type3="nf" angle="2.16193934445" k="890.915856"/>
+  <Angle type1="f" type2="c" type3="o" angle="2.15443442866" k="989.064128"/>
+  <Angle type1="pf" type2="cf" type3="pf" angle="2.26526283616" k="819.294144"/>
+  <Angle type1="py" type2="cf" type3="py" angle="1.88600278971" k="904.070352"/>
+  <Angle type1="f" type2="c" type3="s" angle="2.16420827247" k="706.225728"/>
+  <Angle type1="sx" type2="cf" type3="sx" angle="2.099980156" k="516.531536"/>
+  <Angle type1="sy" type2="cf" type3="sy" angle="2.09387150362" k="526.071056"/>
+  <Angle type1="c1" type2="cg" type3="ca" angle="3.13408773781" k="490.130496"/>
+  <Angle type1="c1" type2="cg" type3="cc" angle="3.11733257699" k="493.159712"/>
+  <Angle type1="c1" type2="cg" type3="ce" angle="3.10755873318" k="493.619952"/>
+  <Angle type1="c1" type2="cg" type3="cg" angle="3.13583306706" k="505.243104"/>
+  <Angle type1="c1" type2="cg" type3="ne" angle="2.96740879424" k="663.62424"/>
+  <Angle type1="c1" type2="cg" type3="pe" angle="3.02448106078" k="628.846832"/>
+  <Angle type1="ca" type2="cg" type3="ch" angle="3.13164427685" k="491.544688"/>
+  <Angle type1="ca" type2="cg" type3="n1" angle="3.1326914744" k="622.127328"/>
+  <Angle type1="c" type2="cg" type3="c1" angle="3.12658282202" k="486.289584"/>
+  <Angle type1="cc" type2="cg" type3="n1" angle="3.11750710991" k="626.001712"/>
+  <Angle type1="ce" type2="cg" type3="ch" angle="3.105638871" k="495.025776"/>
+  <Angle type1="ce" type2="cg" type3="n1" angle="3.10616246977" k="626.712992"/>
+  <Angle type1="n1" type2="cg" type3="ne" angle="3.03739649725" k="836.348128"/>
+  <Angle type1="h4" type2="c" type3="o" angle="2.10661240716" k="557.05776"/>
+  <Angle type1="h5" type2="c" type3="n" angle="1.95756128904" k="531.334528"/>
+  <Angle type1="h5" type2="c" type3="o" angle="2.15809962009" k="551.70224"/>
+  <Angle type1="ha" type2="c" type3="ha" angle="2.01777514823" k="313.323024"/>
+  <Angle type1="ha" type2="c" type3="i" angle="1.92998508686" k="319.389824"/>
+  <Angle type1="ha" type2="c" type3="n" angle="1.96122648047" k="531.28432"/>
+  <Angle type1="ha" type2="c" type3="o" angle="2.12825448988" k="556.338112"/>
+  <Angle type1="ha" type2="c" type3="oh" angle="1.95162716958" k="540.890784"/>
+  <Angle type1="ha" type2="c" type3="os" angle="1.92579629665" k="542.355184"/>
+  <Angle type1="ha" type2="c" type3="s" angle="2.08671565368" k="374.55168"/>
+  <Angle type1="c1" type2="ch" type3="ca" angle="3.13408773781" k="489.712096"/>
+  <Angle type1="c1" type2="ch" type3="cf" angle="3.10755873318" k="493.193184"/>
+  <Angle type1="c1" type2="ch" type3="ch" angle="3.13583306706" k="504.724288"/>
+  <Angle type1="c1" type2="ch" type3="nf" angle="2.96740879424" k="662.879488"/>
+  <Angle type1="c1" type2="ch" type3="pf" angle="3.02448106078" k="628.579056"/>
+  <Angle type1="ca" type2="ch" type3="cg" angle="3.13164427685" k="491.544688"/>
+  <Angle type1="ca" type2="ch" type3="n1" angle="3.1326914744" k="622.127328"/>
+  <Angle type1="c" type2="ch" type3="c1" angle="3.12658282202" k="485.896288"/>
+  <Angle type1="cd" type2="ch" type3="n1" angle="3.11768164284" k="625.984976"/>
+  <Angle type1="cf" type2="ch" type3="cg" angle="3.105638871" k="495.025776"/>
+  <Angle type1="cf" type2="ch" type3="n1" angle="3.10616246977" k="626.712992"/>
+  <Angle type1="cg" type2="ch" type3="ch" angle="3.13426227073" k="506.858128"/>
+  <Angle type1="n1" type2="ch" type3="nf" angle="3.03739649725" k="836.348128"/>
+  <Angle type1="i" type2="c" type3="i" angle="2.03243591395" k="547.032896"/>
+  <Angle type1="i" type2="c" type3="o" angle="2.12965075328" k="600.136224"/>
+  <Angle type1="f" type2="cl" type3="f" angle="1.5271630955" k="0.0"/>
+  <Angle type1="n2" type2="c" type3="n2" angle="1.92527269787" k="926.931728"/>
+  <Angle type1="n2" type2="c" type3="o" angle="2.13802833369" k="935.843648"/>
+  <Angle type1="n4" type2="c" type3="n4" angle="2.00084545449" k="835.151504"/>
+  <Angle type1="n4" type2="c" type3="o" angle="2.07397475014" k="892.11248"/>
+  <Angle type1="nc" type2="c" type3="o" angle="2.14989657261" k="948.34544"/>
+  <Angle type1="nd" type2="c" type3="o" angle="2.14989657261" k="948.34544"/>
+  <Angle type1="ne" type2="c" type3="ne" angle="1.92527269787" k="946.320384"/>
+  <Angle type1="ne" type2="c" type3="o" angle="2.19579873193" k="936.496352"/>
+  <Angle type1="nf" type2="c" type3="nf" angle="1.92527269787" k="946.320384"/>
+  <Angle type1="nf" type2="c" type3="o" angle="2.19579873193" k="936.496352"/>
+  <Angle type1="n" type2="c" type3="n" angle="1.98199589856" k="940.797504"/>
+  <Angle type1="n" type2="c" type3="nc" angle="2.04395508701" k="923.802096"/>
+  <Angle type1="n" type2="c" type3="nd" angle="2.04395508701" k="923.802096"/>
+  <Angle type1="n" type2="c" type3="ne" angle="1.92440003325" k="950.6048"/>
+  <Angle type1="n" type2="c" type3="o" angle="2.14762764458" k="952.370448"/>
+  <Angle type1="n" type2="c" type3="oh" angle="1.9690804621" k="953.223984"/>
+  <Angle type1="no" type2="c" type3="no" angle="1.90729580658" k="858.72416"/>
+  <Angle type1="no" type2="c" type3="o" angle="2.1879447503" k="871.23432"/>
+  <Angle type1="n" type2="c" type3="os" angle="1.90624860903" k="966.386848"/>
+  <Angle type1="n" type2="c" type3="s" angle="2.1650809371" k="689.506464"/>
+  <Angle type1="n" type2="c" type3="sh" angle="1.97169845598" k="682.99616"/>
+  <Angle type1="n" type2="c" type3="ss" angle="1.92492363202" k="690.326528"/>
+  <Angle type1="oh" type2="c" type3="oh" angle="1.929636021" k="972.955728"/>
+  <Angle type1="oh" type2="c" type3="s" angle="2.15443442866" k="694.702992"/>
+  <Angle type1="o" type2="c" type3="o" angle="2.27329135072" k="994.260656"/>
+  <Angle type1="o" type2="c" type3="oh" angle="2.13104701669" k="968.55416"/>
+  <Angle type1="o" type2="c" type3="os" angle="2.15111830308" k="960.830496"/>
+  <Angle type1="o" type2="c" type3="p2" angle="2.14850030921" k="804.675248"/>
+  <Angle type1="o" type2="c" type3="p3" angle="2.10818320348" k="819.821328"/>
+  <Angle type1="o" type2="c" type3="p5" angle="2.11481545464" k="819.068208"/>
+  <Angle type1="o" type2="c" type3="pe" angle="2.1471040458" k="800.173264"/>
+  <Angle type1="o" type2="c" type3="pf" angle="2.1471040458" k="800.173264"/>
+  <Angle type1="o" type2="c" type3="px" angle="2.07868713913" k="816.315136"/>
+  <Angle type1="o" type2="c" type3="py" angle="2.12947622036" k="822.7836"/>
+  <Angle type1="o" type2="c" type3="s4" angle="2.11446638879" k="642.361152"/>
+  <Angle type1="o" type2="c" type3="s6" angle="2.08479579151" k="646.913344"/>
+  <Angle type1="o" type2="c" type3="s" angle="2.1020745511" k="716.208752"/>
+  <Angle type1="o" type2="c" type3="sh" angle="2.13017435206" k="665.615824"/>
+  <Angle type1="os" type2="c" type3="os" angle="1.94237692454" k="964.688144"/>
+  <Angle type1="o" type2="c" type3="ss" angle="2.15234003356" k="661.147312"/>
+  <Angle type1="os" type2="c" type3="s" angle="2.18183609792" k="689.456256"/>
+  <Angle type1="os" type2="c" type3="ss" angle="1.94429678672" k="688.569248"/>
+  <Angle type1="o" type2="c" type3="sx" angle="2.11446638879" k="637.18136"/>
+  <Angle type1="o" type2="c" type3="sy" angle="2.08252686348" k="649.013712"/>
+  <Angle type1="p2" type2="c" type3="p2" angle="1.98531202414" k="837.38576"/>
+  <Angle type1="p3" type2="c" type3="p3" angle="2.06018664905" k="829.452896"/>
+  <Angle type1="p3" type2="c" type3="py" angle="1.5721925902" k="953.508496"/>
+  <Angle type1="p5" type2="c" type3="p5" angle="2.16001948227" k="810.574688"/>
+  <Angle type1="ca" type2="cp" type3="ca" angle="2.06612076851" k="576.362736"/>
+  <Angle type1="ca" type2="cp" type3="cp" angle="2.11376825709" k="553.300528"/>
+  <Angle type1="ca" type2="cp" type3="na" angle="2.08566845613" k="723.890576"/>
+  <Angle type1="ca" type2="cp" type3="nb" angle="2.12266943628" k="728.610128"/>
+  <Angle type1="cp" type2="cp" type3="cp" angle="1.57079632679" k="625.600048"/>
+  <Angle type1="cp" type2="cp" type3="cq" angle="2.16892066145" k="537.920144"/>
+  <Angle type1="cp" type2="cp" type3="nb" angle="2.03522844075" k="720.091504"/>
+  <Angle type1="pe" type2="c" type3="pe" angle="1.98566108999" k="832.49048"/>
+  <Angle type1="pf" type2="c" type3="pf" angle="1.98566108999" k="832.49048"/>
+  <Angle type1="nb" type2="cp" type3="nb" angle="2.19544966608" k="920.739408"/>
+  <Angle type1="py" type2="c" type3="py" angle="2.16071761397" k="816.867424"/>
+  <Angle type1="ca" type2="cq" type3="ca" angle="2.06612076851" k="576.362736"/>
+  <Angle type1="ca" type2="cq" type3="cq" angle="2.11376825709" k="553.300528"/>
+  <Angle type1="ca" type2="cq" type3="nb" angle="2.12266943628" k="728.610128"/>
+  <Angle type1="cp" type2="cq" type3="cq" angle="2.1692697273" k="537.878304"/>
+  <Angle type1="cq" type2="cq" type3="cq" angle="1.57079632679" k="625.600048"/>
+  <Angle type1="cq" type2="cq" type3="nb" angle="2.03522844075" k="720.091504"/>
+  <Angle type1="s4" type2="c" type3="s4" angle="1.8990927591" k="528.204896"/>
+  <Angle type1="s6" type2="c" type3="s6" angle="2.02021860918" k="512.1216"/>
+  <Angle type1="sh" type2="c" type3="sh" angle="2.01288822633" k="533.870032"/>
+  <Angle type1="s" type2="c" type3="s" angle="2.20784150377" k="547.794384"/>
+  <Angle type1="s" type2="c" type3="sh" angle="2.14064632757" k="534.9244"/>
+  <Angle type1="s" type2="c" type3="ss" angle="2.15007110553" k="533.242432"/>
+  <Angle type1="ss" type2="c" type3="ss" angle="1.96209914509" k="539.86152"/>
+  <Angle type1="sx" type2="c" type3="sx" angle="1.89891822617" k="524.020896"/>
+  <Angle type1="sy" type2="c" type3="sy" angle="2.02074220796" k="513.427008"/>
+  <Angle type1="c2" type2="cu" type3="cx" angle="2.59181393921" k="511.544208"/>
+  <Angle type1="c" type2="cu" type3="cu" angle="1.09257611175" k="820.39872"/>
+  <Angle type1="cu" type2="cu" type3="cx" angle="0.886627260013" k="881.669216"/>
+  <Angle type1="cu" type2="cu" type3="ha" angle="2.57837490397" k="389.86512"/>
+  <Angle type1="cv" type2="cv" type3="cy" angle="1.64776534681" k="631.583168"/>
+  <Angle type1="cv" type2="cv" type3="ha" angle="2.33350520992" k="399.898352"/>
+  <Angle type1="cx" type2="cv" type3="cx" angle="1.11526539202" k="731.32136"/>
+  <Angle type1="cy" type2="cv" type3="ha" angle="2.30627807359" k="362.175408"/>
+  <Angle type1="c1" type2="cx" type3="cx" angle="2.08689018661" k="546.413664"/>
+  <Angle type1="c2" type2="cx" type3="cx" angle="2.09963109015" k="537.819728"/>
+  <Angle type1="c2" type2="cx" type3="h1" angle="2.02213847136" k="393.789712"/>
+  <Angle type1="c2" type2="cx" type3="hc" angle="2.00974663367" k="395.09512"/>
+  <Angle type1="c2" type2="cx" type3="os" angle="2.0341812432" k="699.681952"/>
+  <Angle type1="c3" type2="cx" type3="c3" angle="1.99386413748" k="543.20872"/>
+  <Angle type1="c3" type2="cx" type3="cx" angle="2.09614043165" k="532.271744"/>
+  <Angle type1="c3" type2="cx" type3="h1" angle="2.0127136934" k="386.886112"/>
+  <Angle type1="c3" type2="cx" type3="hc" angle="1.99648213136" k="388.52624"/>
+  <Angle type1="c3" type2="cx" type3="n3" angle="2.06821516361" k="678.335184"/>
+  <Angle type1="c3" type2="cx" type3="os" angle="2.01899687871" k="693.590048"/>
+  <Angle type1="ca" type2="cx" type3="cx" angle="2.12842902281" k="533.20896"/>
+  <Angle type1="ca" type2="cx" type3="h1" angle="2.00189265204" k="394.492624"/>
+  <Angle type1="ca" type2="cx" type3="hc" angle="1.98304309612" k="396.450736"/>
+  <Angle type1="ca" type2="cx" type3="oh" angle="1.97100032428" k="725.739904"/>
+  <Angle type1="ca" type2="cx" type3="os" angle="2.06489903803" k="693.062864"/>
+  <Angle type1="c" type2="cx" type3="c3" angle="2.05023827232" k="539.27576"/>
+  <Angle type1="cc" type2="cx" type3="cx" angle="2.08776285124" k="541.501648"/>
+  <Angle type1="cc" type2="cx" type3="hc" angle="1.9884536168" k="400.099184"/>
+  <Angle type1="c" type2="cx" type3="cx" angle="2.05896491858" k="540.74016"/>
+  <Angle type1="cd" type2="cx" type3="cx" angle="2.08776285124" k="541.501648"/>
+  <Angle type1="c" type2="cx" type3="h1" angle="2.0341812432" k="389.547136"/>
+  <Angle type1="c" type2="cx" type3="hc" angle="2.0355775066" k="389.496928"/>
+  <Angle type1="cl" type2="cx" type3="cl" angle="1.92946148808" k="691.096384"/>
+  <Angle type1="cl" type2="cx" type3="cx" angle="2.09177710852" k="586.488016"/>
+  <Angle type1="cl" type2="cx" type3="h1" angle="1.9448203855" k="408.868848"/>
+  <Angle type1="cl" type2="cx" type3="hc" angle="2.02109127381" k="401.028032"/>
+  <Angle type1="c" type2="cx" type3="os" angle="2.01742608238" k="699.163136"/>
+  <Angle type1="cu" type2="cx" type3="cu" angle="0.952949771589" k="803.24432"/>
+  <Angle type1="cu" type2="cx" type3="cx" angle="1.02014494779" k="771.395712"/>
+  <Angle type1="cu" type2="cx" type3="hc" angle="2.06943689409" k="389.19568"/>
+  <Angle type1="cx" type2="cx" type3="cx" angle="1.0471975512" k="756.668032"/>
+  <Angle type1="cx" type2="cx" type3="cy" angle="1.75457949703" k="582.437904"/>
+  <Angle type1="cx" type2="cx" type3="f" angle="2.06908782824" k="714.551888"/>
+  <Angle type1="cx" type2="cx" type3="h1" angle="2.07170582212" k="384.584912"/>
+  <Angle type1="cx" type2="cx" type3="hc" angle="2.0542525296" k="386.291984"/>
+  <Angle type1="cx" type2="cx" type3="hx" angle="2.08758831831" k="383.271136"/>
+  <Angle type1="cx" type2="cx" type3="n3" angle="1.04004170126" k="961.416256"/>
+  <Angle type1="cx" type2="cx" type3="na" angle="2.19946392336" k="663.013376"/>
+  <Angle type1="cx" type2="cx" type3="nh" angle="1.03271131841" k="969.583424"/>
+  <Angle type1="cx" type2="cx" type3="os" angle="1.031315055" k="975.641856"/>
+  <Angle type1="cy" type2="cx" type3="hc" angle="2.18916648078" k="371.781872"/>
+  <Angle type1="f" type2="cx" type3="f" angle="1.86575697038" k="1011.557312"/>
+  <Angle type1="f" type2="cx" type3="h1" angle="1.94918370863" k="547.719072"/>
+  <Angle type1="f" type2="cx" type3="hc" angle="1.96000474999" k="546.4304"/>
+  <Angle type1="h1" type2="cx" type3="h1" angle="2.01515715435" k="316.97984"/>
+  <Angle type1="h1" type2="cx" type3="n3" angle="2.0327849798" k="496.063408"/>
+  <Angle type1="h1" type2="cx" type3="n" angle="2.00800130442" k="507.502464"/>
+  <Angle type1="h1" type2="cx" type3="na" angle="1.89123877746" k="517.01688"/>
+  <Angle type1="h1" type2="cx" type3="nh" angle="2.02964338714" k="500.983792"/>
+  <Angle type1="h1" type2="cx" type3="os" angle="2.00590690932" k="509.217904"/>
+  <Angle type1="h2" type2="cx" type3="h2" angle="2.08444672566" k="312.561536"/>
+  <Angle type1="h2" type2="cx" type3="n2" angle="2.04517681749" k="491.268544"/>
+  <Angle type1="hc" type2="cx" type3="hc" angle="1.99718026306" k="318.98816"/>
+  <Angle type1="hc" type2="cx" type3="os" angle="1.99142067653" k="511.217856"/>
+  <Angle type1="hx" type2="cx" type3="n4" angle="1.99787839476" k="492.983984"/>
+  <Angle type1="n2" type2="cx" type3="n2" angle="0.8754571528" k="1317.089728"/>
+  <Angle type1="n" type2="cx" type3="oh" angle="2.09003177926" k="899.995136"/>
+  <Angle type1="n" type2="cx" type3="os" angle="1.15156824047" k="1182.490448"/>
+  <Angle type1="oh" type2="cx" type3="oh" angle="1.88233759828" k="978.076944"/>
+  <Angle type1="oh" type2="cx" type3="os" angle="2.06158291246" k="907.936368"/>
+  <Angle type1="os" type2="cx" type3="os" angle="2.02545459694" k="893.150112"/>
+  <Angle type1="c2" type2="cy" type3="cy" angle="1.752310569" k="573.777024"/>
+  <Angle type1="c3" type2="cy" type3="c3" angle="1.94499491842" k="545.141728"/>
+  <Angle type1="c3" type2="cy" type3="cy" angle="2.07170582212" k="523.987424"/>
+  <Angle type1="c3" type2="cy" type3="h1" angle="1.95092903788" k="389.622448"/>
+  <Angle type1="c3" type2="cy" type3="hc" angle="1.92230563815" k="392.517776"/>
+  <Angle type1="c3" type2="cy" type3="n3" angle="1.98356669489" k="687.498144"/>
+  <Angle type1="c3" type2="cy" type3="n" angle="1.8174113501" k="720.225392"/>
+  <Angle type1="c3" type2="cy" type3="os" angle="1.96017928291" k="699.89952"/>
+  <Angle type1="c" type2="cy" type3="c3" angle="2.03697377" k="529.368048"/>
+  <Angle type1="cc" type2="cy" type3="cy" angle="2.11568811927" k="522.807536"/>
+  <Angle type1="c" type2="cy" type3="cy" angle="1.48510066052" k="615.165152"/>
+  <Angle type1="cd" type2="cy" type3="cy" angle="2.11568811927" k="522.807536"/>
+  <Angle type1="ce" type2="cy" type3="h2" angle="2.04901654184" k="383.873632"/>
+  <Angle type1="ce" type2="cy" type3="n" angle="1.5348425442" k="788.22376"/>
+  <Angle type1="ce" type2="cy" type3="ss" angle="2.10381988035" k="505.879072"/>
+  <Angle type1="c" type2="cy" type3="h1" angle="1.97274565353" k="383.120512"/>
+  <Angle type1="c" type2="cy" type3="hc" angle="1.94290052332" k="386.05768"/>
+  <Angle type1="cl" type2="cy" type3="cy" angle="2.04220975776" k="581.86888"/>
+  <Angle type1="cl" type2="cy" type3="h1" angle="1.8603464497" k="412.216048"/>
+  <Angle type1="cl" type2="cy" type3="hc" angle="1.98967534727" k="398.584576"/>
+  <Angle type1="c" type2="cy" type3="n" angle="2.04796934429" k="673.808096"/>
+  <Angle type1="c" type2="cy" type3="os" angle="2.00712863979" k="686.686448"/>
+  <Angle type1="cv" type2="cy" type3="cy" angle="1.5133749944" k="616.26136"/>
+  <Angle type1="cv" type2="cy" type3="hc" angle="1.99700573013" k="388.927904"/>
+  <Angle type1="cx" type2="cy" type3="cy" angle="1.76679680179" k="570.387984"/>
+  <Angle type1="cx" type2="cy" type3="hc" angle="2.06472450511" k="382.54312"/>
+  <Angle type1="cy" type2="cy" type3="cy" angle="1.54287105876" k="602.512736"/>
+  <Angle type1="cy" type2="cy" type3="f" angle="1.96995312673" k="717.154336"/>
+  <Angle type1="cy" type2="cy" type3="h1" angle="1.97641084496" k="381.564064"/>
+  <Angle type1="cy" type2="cy" type3="h2" angle="2.03819550048" k="375.790144"/>
+  <Angle type1="cy" type2="cy" type3="hc" angle="2.00346344836" k="378.98672"/>
+  <Angle type1="cy" type2="cy" type3="n3" angle="1.5285593589" k="776.366304"/>
+  <Angle type1="cy" type2="cy" type3="n" angle="1.58179190108" k="765.21176"/>
+  <Angle type1="cy" type2="cy" type3="na" angle="2.08671565368" k="670.77888"/>
+  <Angle type1="cy" type2="cy" type3="oh" angle="1.99299147285" k="692.753248"/>
+  <Angle type1="cy" type2="cy" type3="os" angle="1.95075450495" k="695.121392"/>
+  <Angle type1="cy" type2="cy" type3="s6" angle="2.04587494919" k="509.017072"/>
+  <Angle type1="cy" type2="cy" type3="ss" angle="2.06646983436" k="506.824656"/>
+  <Angle type1="h1" type2="cy" type3="h1" angle="1.91043739923" k="323.741184"/>
+  <Angle type1="h1" type2="cy" type3="n3" angle="1.9884536168" k="498.657488"/>
+  <Angle type1="h1" type2="cy" type3="n" angle="1.94220239162" k="507.22632"/>
+  <Angle type1="h1" type2="cy" type3="oh" angle="1.94586758305" k="523.870272"/>
+  <Angle type1="h1" type2="cy" type3="os" angle="1.92213110522" k="519.058672"/>
+  <Angle type1="h1" type2="cy" type3="s6" angle="1.94813651108" k="348.200848"/>
+  <Angle type1="h2" type2="cy" type3="n" angle="1.99840199353" k="500.172096"/>
+  <Angle type1="h2" type2="cy" type3="os" angle="1.90572501025" k="521.45192"/>
+  <Angle type1="h2" type2="cy" type3="s6" angle="1.92003671012" k="350.669408"/>
+  <Angle type1="h2" type2="cy" type3="ss" angle="1.91584791991" k="351.430896"/>
+  <Angle type1="hc" type2="cy" type3="hc" angle="1.90205981882" k="324.51104"/>
+  <Angle type1="n" type2="cy" type3="os" angle="1.87483268249" k="916.9236"/>
+  <Angle type1="n" type2="cy" type3="s6" angle="1.80083072221" k="689.196848"/>
+  <Angle type1="n" type2="cy" type3="ss" angle="1.83486464262" k="683.28904"/>
+  <Angle type1="nh" type2="cz" type3="nh" angle="2.09683856335" k="941.927184"/>
+  <Angle type1="br" type2="n1" type3="c1" angle="3.14159265359" k="436.182"/>
+  <Angle type1="c1" type2="n1" type3="c1" angle="3.14019639019" k="551.626928"/>
+  <Angle type1="c1" type2="n1" type3="c2" angle="3.10197367957" k="516.615216"/>
+  <Angle type1="c1" type2="n1" type3="c3" angle="3.10179914664" k="483.62856"/>
+  <Angle type1="c1" type2="n1" type3="ca" angle="3.14141812066" k="505.88744"/>
+  <Angle type1="c1" type2="n1" type3="cl" angle="3.14071998896" k="520.464496"/>
+  <Angle type1="c1" type2="n1" type3="f" angle="3.14089452189" k="618.035376"/>
+  <Angle type1="c1" type2="n1" type3="hn" angle="3.14124358774" k="381.061984"/>
+  <Angle type1="c1" type2="n1" type3="i" angle="3.14071998896" k="410.74328"/>
+  <Angle type1="c1" type2="n1" type3="n1" angle="3.14159265359" k="696.25944"/>
+  <Angle type1="c1" type2="n1" type3="n2" angle="2.99428686472" k="683.16352"/>
+  <Angle type1="c1" type2="n1" type3="n3" angle="3.06462363358" k="636.47008"/>
+  <Angle type1="c1" type2="n1" type3="n4" angle="3.13618213291" k="625.9264"/>
+  <Angle type1="c1" type2="n1" type3="na" angle="3.14159265359" k="628.620896"/>
+  <Angle type1="c1" type2="n1" type3="nh" angle="3.07788813589" k="638.361248"/>
+  <Angle type1="c1" type2="n1" type3="o" angle="3.14071998896" k="652.24376"/>
+  <Angle type1="c1" type2="n1" type3="oh" angle="3.04228341915" k="655.2144"/>
+  <Angle type1="c1" type2="n1" type3="os" angle="3.08242599195" k="647.674832"/>
+  <Angle type1="c1" type2="n1" type3="p2" angle="3.01645254622" k="594.019216"/>
+  <Angle type1="c1" type2="n1" type3="p3" angle="3.02832078514" k="598.922864"/>
+  <Angle type1="c1" type2="n1" type3="p4" angle="3.03058971316" k="591.960688"/>
+  <Angle type1="c1" type2="n1" type3="p5" angle="3.09411969794" k="622.897184"/>
+  <Angle type1="c1" type2="n1" type3="s2" angle="3.10860593073" k="517.795104"/>
+  <Angle type1="c1" type2="n1" type3="s4" angle="2.96007841138" k="474.71664"/>
+  <Angle type1="c1" type2="n1" type3="s" angle="3.14141812066" k="458.474352"/>
+  <Angle type1="c1" type2="n1" type3="s6" angle="3.07038322011" k="530.296896"/>
+  <Angle type1="c1" type2="n1" type3="sh" angle="3.0412362216" k="479.009424"/>
+  <Angle type1="c1" type2="n1" type3="ss" angle="3.07282668106" k="476.540864"/>
+  <Angle type1="c2" type2="n1" type3="n1" angle="3.14159265359" k="646.428"/>
+  <Angle type1="c2" type2="n1" type3="o" angle="2.04098802728" k="765.08624"/>
+  <Angle type1="c2" type2="n1" type3="s" angle="2.05948851735" k="556.948976"/>
+  <Angle type1="c3" type2="n1" type3="n1" angle="3.14159265359" k="604.00224"/>
+  <Angle type1="ca" type2="n1" type3="n1" angle="3.14159265359" k="636.729488"/>
+  <Angle type1="ce" type2="n1" type3="o" angle="2.13628300444" k="746.283344"/>
+  <Angle type1="ce" type2="n1" type3="s" angle="2.04796934429" k="558.06192"/>
+  <Angle type1="cf" type2="n1" type3="o" angle="2.13628300444" k="746.283344"/>
+  <Angle type1="cf" type2="n1" type3="s" angle="2.04796934429" k="558.06192"/>
+  <Angle type1="cl" type2="n1" type3="n1" angle="3.14054545604" k="652.561744"/>
+  <Angle type1="f" type2="n1" type3="n1" angle="3.14037092311" k="777.111056"/>
+  <Angle type1="hn" type2="n1" type3="n1" angle="3.14002185726" k="482.733184"/>
+  <Angle type1="i" type2="n1" type3="n1" angle="3.14054545604" k="512.933296"/>
+  <Angle type1="n1" type2="n1" type3="n1" angle="3.14106905481" k="879.39312"/>
+  <Angle type1="n1" type2="n1" type3="n2" angle="3.01680161207" k="858.104928"/>
+  <Angle type1="n1" type2="n1" type3="n3" angle="3.05589698732" k="802.0728"/>
+  <Angle type1="n1" type2="n1" type3="n4" angle="3.14002185726" k="787.060608"/>
+  <Angle type1="n1" type2="n1" type3="na" angle="3.14106905481" k="791.119088"/>
+  <Angle type1="n1" type2="n1" type3="nh" angle="3.07177948351" k="804.231744"/>
+  <Angle type1="n1" type2="n1" type3="o" angle="3.14054545604" k="821.7376"/>
+  <Angle type1="n1" type2="n1" type3="oh" angle="3.03285864119" k="826.432048"/>
+  <Angle type1="n1" type2="n1" type3="os" angle="3.07387387861" k="816.666592"/>
+  <Angle type1="n1" type2="n1" type3="p2" angle="3.04926473616" k="740.350432"/>
+  <Angle type1="n1" type2="n1" type3="p3" angle="3.04158528745" k="749.01968"/>
+  <Angle type1="n1" type2="n1" type3="s" angle="3.14159265359" k="574.613824"/>
+  <Angle type1="n1" type2="n1" type3="sh" angle="3.05554792147" k="599.299424"/>
+  <Angle type1="n1" type2="n1" type3="ss" angle="3.06497269943" k="598.370576"/>
+  <Angle type1="o" type2="n1" type3="p2" angle="2.02545459694" k="897.936608"/>
+  <Angle type1="p2" type2="n1" type3="s" angle="2.09317337192" k="700.552224"/>
+  <Angle type1="br" type2="n2" type3="br" angle="1.86052098263" k="539.376176"/>
+  <Angle type1="br" type2="n2" type3="c2" angle="1.96175007924" k="504.146896"/>
+  <Angle type1="br" type2="n2" type3="n2" angle="1.92719256005" k="636.562128"/>
+  <Angle type1="br" type2="n2" type3="o" angle="1.99787839476" k="623.24864"/>
+  <Angle type1="br" type2="n2" type3="p2" angle="1.93783906849" k="691.623568"/>
+  <Angle type1="br" type2="n2" type3="s" angle="2.02074220796" k="531.677616"/>
+  <Angle type1="c1" type2="n2" type3="c1" angle="2.11359372417" k="647.8924"/>
+  <Angle type1="c1" type2="n2" type3="c3" angle="2.65080606793" k="509.586096"/>
+  <Angle type1="c1" type2="n2" type3="cl" angle="2.07345115137" k="575.751872"/>
+  <Angle type1="c1" type2="n2" type3="hn" angle="2.20784150377" k="438.006224"/>
+  <Angle type1="c1" type2="n2" type3="n2" angle="1.97920337176" k="813.394704"/>
+  <Angle type1="c1" type2="n2" type3="o" angle="1.98251949734" k="830.624416"/>
+  <Angle type1="c1" type2="n2" type3="p2" angle="2.08689018661" k="740.852512"/>
+  <Angle type1="c1" type2="n2" type3="s" angle="2.05372893082" k="602.019024"/>
+  <Angle type1="c2" type2="n2" type3="c2" angle="2.06263011001" k="612.554336"/>
+  <Angle type1="c2" type2="n2" type3="c3" angle="2.01236462755" k="573.350256"/>
+  <Angle type1="c2" type2="n2" type3="ca" angle="2.09334790484" k="602.947872"/>
+  <Angle type1="c2" type2="n2" type3="cl" angle="1.96593886945" k="589.69296"/>
+  <Angle type1="c2" type2="n2" type3="f" angle="1.88739905311" k="759.588464"/>
+  <Angle type1="c2" type2="n2" type3="hn" angle="1.93382481121" k="445.05208"/>
+  <Angle type1="c2" type2="n2" type3="i" angle="2.00259078374" k="459.419936"/>
+  <Angle type1="c2" type2="n2" type3="n1" angle="2.00869943612" k="792.516544"/>
+  <Angle type1="c2" type2="n2" type3="n2" angle="1.80798657214" k="824.047168"/>
+  <Angle type1="c2" type2="n2" type3="n3" angle="2.06193197831" k="752.810384"/>
+  <Angle type1="c2" type2="n2" type3="n4" angle="1.95860848659" k="657.440288"/>
+  <Angle type1="c2" type2="n2" type3="n" angle="2.05826678688" k="743.689264"/>
+  <Angle type1="c2" type2="n2" type3="na" angle="2.05215813449" k="742.526112"/>
+  <Angle type1="c2" type2="n2" type3="nh" angle="2.05268173327" k="747.212192"/>
+  <Angle type1="c2" type2="n2" type3="no" angle="2.0598375832" k="719.806992"/>
+  <Angle type1="c2" type2="n2" type3="o" angle="2.04098802728" k="789.98104"/>
+  <Angle type1="c2" type2="n2" type3="oh" angle="1.93940986482" k="756.115744"/>
+  <Angle type1="c2" type2="n2" type3="os" angle="1.93661733801" k="753.278992"/>
+  <Angle type1="c2" type2="n2" type3="p2" angle="2.02458193231" k="742.860832"/>
+  <Angle type1="c2" type2="n2" type3="p3" angle="2.08217779763" k="677.088352"/>
+  <Angle type1="c2" type2="n2" type3="p4" angle="2.07292755259" k="692.343216"/>
+  <Angle type1="c2" type2="n2" type3="s4" angle="1.95983021706" k="586.914784"/>
+  <Angle type1="c2" type2="n2" type3="s6" angle="2.02877072252" k="592.630128"/>
+  <Angle type1="c2" type2="n2" type3="s" angle="2.05948851735" k="591.776592"/>
+  <Angle type1="c2" type2="n2" type3="sh" angle="2.0155062202" k="543.300768"/>
+  <Angle type1="c2" type2="n2" type3="ss" angle="2.06018664905" k="559.718784"/>
+  <Angle type1="c3" type2="n2" type3="c3" angle="1.93207948196" k="553.308896"/>
+  <Angle type1="c3" type2="n2" type3="ca" angle="2.00800130442" k="570.73944"/>
+  <Angle type1="c3" type2="n2" type3="ce" angle="2.07118222334" k="564.312816"/>
+  <Angle type1="c3" type2="n2" type3="cf" angle="2.07118222334" k="564.312816"/>
+  <Angle type1="c3" type2="n2" type3="hn" angle="2.06646983436" k="383.706272"/>
+  <Angle type1="c3" type2="n2" type3="n1" angle="2.02632726157" k="724.560016"/>
+  <Angle type1="c3" type2="n2" type3="n2" angle="1.93452294291" k="735.078592"/>
+  <Angle type1="c3" type2="n2" type3="nh" angle="1.91968764427" k="720.802784"/>
+  <Angle type1="c3" type2="n2" type3="o" angle="1.96175007924" k="738.584784"/>
+  <Angle type1="c3" type2="n2" type3="p2" angle="1.9933405387" k="718.635472"/>
+  <Angle type1="c3" type2="n2" type3="s6" angle="1.98688282047" k="571.768704"/>
+  <Angle type1="c3" type2="n2" type3="s" angle="2.03714830293" k="567.325296"/>
+  <Angle type1="ca" type2="n2" type3="ca" angle="1.95825942074" k="618.386832"/>
+  <Angle type1="ca" type2="n2" type3="hn" angle="2.09439510239" k="422.140496"/>
+  <Angle type1="ca" type2="n2" type3="n2" angle="1.98147229979" k="780.366208"/>
+  <Angle type1="ca" type2="n2" type3="o" angle="2.02458193231" k="785.696624"/>
+  <Angle type1="ca" type2="n2" type3="p2" angle="2.06140837953" k="733.37152"/>
+  <Angle type1="ca" type2="n2" type3="s" angle="2.09631496457" k="583.83536"/>
+  <Angle type1="c" type2="n2" type3="c2" angle="2.11132479614" k="571.45072"/>
+  <Angle type1="c" type2="n2" type3="c" angle="2.16071761397" k="540.19624"/>
+  <Angle type1="c" type2="n2" type3="ca" angle="2.10312174865" k="568.965424"/>
+  <Angle type1="cc" type2="n2" type3="cl" angle="2.02091674088" k="581.299856"/>
+  <Angle type1="cc" type2="n2" type3="hn" angle="1.94167879284" k="441.78856"/>
+  <Angle type1="cc" type2="n2" type3="na" angle="1.90659767488" k="768.123824"/>
+  <Angle type1="cc" type2="n2" type3="nh" angle="2.06769156484" k="742.275072"/>
+  <Angle type1="cd" type2="n2" type3="cl" angle="2.02091674088" k="581.299856"/>
+  <Angle type1="cd" type2="n2" type3="hn" angle="1.94167879284" k="441.78856"/>
+  <Angle type1="ce" type2="n2" type3="hn" angle="1.93731546971" k="443.119072"/>
+  <Angle type1="ce" type2="n2" type3="n" angle="2.0591394515" k="742.124448"/>
+  <Angle type1="ce" type2="n2" type3="nh" angle="2.06542263681" k="743.463328"/>
+  <Angle type1="ce" type2="n2" type3="o" angle="1.95756128904" k="804.608304"/>
+  <Angle type1="ce" type2="n2" type3="oh" angle="1.96855686332" k="749.161936"/>
+  <Angle type1="ce" type2="n2" type3="os" angle="1.96855686332" k="745.848208"/>
+  <Angle type1="ce" type2="n2" type3="s" angle="2.02946885422" k="595.408304"/>
+  <Angle type1="cf" type2="n2" type3="hn" angle="1.93818813434" k="443.018656"/>
+  <Angle type1="cf" type2="n2" type3="n" angle="2.0591394515" k="742.124448"/>
+  <Angle type1="cf" type2="n2" type3="nh" angle="2.06542263681" k="743.463328"/>
+  <Angle type1="cf" type2="n2" type3="o" angle="1.95756128904" k="804.608304"/>
+  <Angle type1="cf" type2="n2" type3="oh" angle="1.96855686332" k="749.161936"/>
+  <Angle type1="cf" type2="n2" type3="os" angle="1.96855686332" k="745.848208"/>
+  <Angle type1="cf" type2="n2" type3="s" angle="2.02946885422" k="595.408304"/>
+  <Angle type1="cl" type2="n2" type3="n1" angle="1.89717289692" k="753.387776"/>
+  <Angle type1="cl" type2="n2" type3="n2" angle="1.92806522468" k="746.283344"/>
+  <Angle type1="cl" type2="n2" type3="o" angle="1.99019894605" k="735.773136"/>
+  <Angle type1="cl" type2="n2" type3="p2" angle="1.9718729889" k="779.445728"/>
+  <Angle type1="cl" type2="n2" type3="s" angle="2.02056767503" k="607.843152"/>
+  <Angle type1="cx" type2="n2" type3="n2" angle="1.13306775039" k="953.382976"/>
+  <Angle type1="f" type2="n2" type3="n2" angle="2.00014732279" k="927.726688"/>
+  <Angle type1="f" type2="n2" type3="o" angle="1.92160750645" k="958.38704"/>
+  <Angle type1="f" type2="n2" type3="p2" angle="1.86924762889" k="948.0944"/>
+  <Angle type1="f" type2="n2" type3="s" angle="1.93260308073" k="744.718528"/>
+  <Angle type1="hn" type2="n2" type3="hn" angle="2.09439510239" k="320.444192"/>
+  <Angle type1="hn" type2="n2" type3="n1" angle="1.99142067653" k="566.362976"/>
+  <Angle type1="hn" type2="n2" type3="n2" angle="1.83277024752" k="577.659776"/>
+  <Angle type1="hn" type2="n2" type3="ne" angle="1.89472943597" k="566.563808"/>
+  <Angle type1="hn" type2="n2" type3="nf" angle="1.89472943597" k="566.563808"/>
+  <Angle type1="hn" type2="n2" type3="o" angle="1.87396001787" k="588.412656"/>
+  <Angle type1="hn" type2="n2" type3="p2" angle="1.95633955856" k="500.53192"/>
+  <Angle type1="hn" type2="n2" type3="p4" angle="1.94307505625" k="465.277536"/>
+  <Angle type1="hn" type2="n2" type3="p5" angle="2.13523580689" k="480.959168"/>
+  <Angle type1="hn" type2="n2" type3="pe" angle="1.94447131965" k="523.468608"/>
+  <Angle type1="hn" type2="n2" type3="pf" angle="1.94447131965" k="523.468608"/>
+  <Angle type1="hn" type2="n2" type3="s2" angle="2.02109127381" k="399.036448"/>
+  <Angle type1="hn" type2="n2" type3="s4" angle="1.94098066114" k="390.308624"/>
+  <Angle type1="hn" type2="n2" type3="s" angle="1.88792265188" k="413.688816"/>
+  <Angle type1="hn" type2="n2" type3="s6" angle="1.94028252944" k="404.735056"/>
+  <Angle type1="i" type2="n2" type3="n2" angle="1.9511035708" k="581.684784"/>
+  <Angle type1="i" type2="n2" type3="o" angle="2.03889363218" k="564.605696"/>
+  <Angle type1="i" type2="n2" type3="p2" angle="1.97675991081" k="649.473952"/>
+  <Angle type1="i" type2="n2" type3="s" angle="2.03941723096" k="499.100992"/>
+  <Angle type1="n1" type2="n2" type3="n1" angle="1.95476876223" k="1027.858176"/>
+  <Angle type1="n2" type2="n2" type3="n1" angle="3.14159265359" k="798.625184"/>
+  <Angle type1="n2" type2="n2" type3="n2" angle="1.91096099801" k="1009.699616"/>
+  <Angle type1="n2" type2="n2" type3="n3" angle="1.90031448957" k="987.122752"/>
+  <Angle type1="n2" type2="n2" type3="n4" angle="1.85790298875" k="846.900176"/>
+  <Angle type1="n2" type2="n2" type3="na" angle="1.95878301951" k="956.33688"/>
+  <Angle type1="n2" type2="n2" type3="nh" angle="1.94953277448" k="964.922448"/>
+  <Angle type1="n2" type2="n2" type3="no" angle="1.84952540834" k="955.182096"/>
+  <Angle type1="n2" type2="n2" type3="o" angle="1.92736709298" k="1024.653232"/>
+  <Angle type1="n2" type2="n2" type3="oh" angle="1.9462166489" k="949.51696"/>
+  <Angle type1="n2" type2="n2" type3="os" angle="1.89158784331" k="958.72176"/>
+  <Angle type1="n2" type2="n2" type3="p2" angle="1.90502687855" k="961.416256"/>
+  <Angle type1="n2" type2="n2" type3="p3" angle="1.97309471938" k="872.079488"/>
+  <Angle type1="n2" type2="n2" type3="p4" angle="2.07292755259" k="868.330624"/>
+  <Angle type1="n2" type2="n2" type3="p5" angle="1.92789069175" k="958.520928"/>
+  <Angle type1="n2" type2="n2" type3="s4" angle="1.87273828739" k="753.722496"/>
+  <Angle type1="n2" type2="n2" type3="s6" angle="1.94167879284" k="760.852032"/>
+  <Angle type1="n2" type2="n2" type3="s" angle="2.02301113599" k="750.02384"/>
+  <Angle type1="n2" type2="n2" type3="sh" angle="1.93906079897" k="694.62768"/>
+  <Angle type1="n2" type2="n2" type3="ss" angle="1.95721222319" k="720.61032"/>
+  <Angle type1="n3" type2="n2" type3="n3" angle="2.00835037027" k="938.814288"/>
+  <Angle type1="n3" type2="n2" type3="o" angle="1.98967534727" k="980.838384"/>
+  <Angle type1="n3" type2="n2" type3="p2" angle="2.01306275925" k="924.672368"/>
+  <Angle type1="n3" type2="n2" type3="s" angle="2.04430415286" k="735.915392"/>
+  <Angle type1="n4" type2="n2" type3="n4" angle="1.86226631188" k="771.713696"/>
+  <Angle type1="n4" type2="n2" type3="o" angle="1.95825942074" k="829.293904"/>
+  <Angle type1="n4" type2="n2" type3="p2" angle="1.97344378523" k="848.406416"/>
+  <Angle type1="n4" type2="n2" type3="s" angle="2.06821516361" k="656.862896"/>
+  <Angle type1="na" type2="n2" type3="na" angle="1.86750229963" k="946.094448"/>
+  <Angle type1="na" type2="n2" type3="o" angle="1.97379285108" k="967.248752"/>
+  <Angle type1="na" type2="n2" type3="p2" angle="2.07973433668" k="902.36328"/>
+  <Angle type1="na" type2="n2" type3="s" angle="2.06402637341" k="725.430288"/>
+  <Angle type1="ne" type2="n2" type3="nh" angle="1.97815617421" k="956.4624"/>
+  <Angle type1="ne" type2="n2" type3="o" angle="1.92527269787" k="1023.15536"/>
+  <Angle type1="ne" type2="n2" type3="s" angle="2.02842165667" k="748.316768"/>
+  <Angle type1="nf" type2="n2" type3="nh" angle="1.97815617421" k="956.4624"/>
+  <Angle type1="nf" type2="n2" type3="o" angle="1.92527269787" k="1023.15536"/>
+  <Angle type1="nf" type2="n2" type3="s" angle="2.02842165667" k="748.316768"/>
+  <Angle type1="nh" type2="n2" type3="nh" angle="2.11533905342" k="898.940768"/>
+  <Angle type1="nh" type2="n2" type3="o" angle="1.9870573534" k="970.913936"/>
+  <Angle type1="nh" type2="n2" type3="p2" angle="2.07397475014" k="906.597488"/>
+  <Angle type1="nh" type2="n2" type3="s" angle="2.04028989558" k="732.45104"/>
+  <Angle type1="n" type2="n2" type3="n2" angle="1.88774811896" k="977.206672"/>
+  <Angle type1="n" type2="n2" type3="o" angle="2.00904850197" k="961.976912"/>
+  <Angle type1="no" type2="n2" type3="no" angle="1.80990643432" k="916.153744"/>
+  <Angle type1="no" type2="n2" type3="o" angle="1.75859375431" k="992.185392"/>
+  <Angle type1="no" type2="n2" type3="p2" angle="1.95389609761" k="916.354576"/>
+  <Angle type1="n" type2="n2" type3="p2" angle="2.04727121259" k="910.923744"/>
+  <Angle type1="n" type2="n2" type3="s" angle="2.02004407626" k="734.62672"/>
+  <Angle type1="oh" type2="n2" type3="oh" angle="1.77499984928" k="953.977104"/>
+  <Angle type1="oh" type2="n2" type3="p2" angle="2.00904850197" k="913.216576"/>
+  <Angle type1="oh" type2="n2" type3="s" angle="2.02597819572" k="727.689648"/>
+  <Angle type1="o" type2="n2" type3="o" angle="2.01358635803" k="1023.716016"/>
+  <Angle type1="o" type2="n2" type3="oh" angle="1.95738675611" k="960.453936"/>
+  <Angle type1="o" type2="n2" type3="os" angle="1.92597082958" k="963.483152"/>
+  <Angle type1="o" type2="n2" type3="p2" angle="2.02597819572" k="939.199216"/>
+  <Angle type1="o" type2="n2" type3="p3" angle="1.97972697054" k="873.267744"/>
+  <Angle type1="o" type2="n2" type3="p4" angle="1.93050868563" k="903.467856"/>
+  <Angle type1="o" type2="n2" type3="p5" angle="1.90432874685" k="971.767472"/>
+  <Angle type1="o" type2="n2" type3="pe" angle="2.34851504148" k="902.179184"/>
+  <Angle type1="o" type2="n2" type3="pf" angle="2.34851504148" k="902.179184"/>
+  <Angle type1="o" type2="n2" type3="s4" angle="1.90083808835" k="753.571872"/>
+  <Angle type1="o" type2="n2" type3="s6" angle="1.94324958917" k="767.370704"/>
+  <Angle type1="o" type2="n2" type3="s" angle="2.04517681749" k="752.935904"/>
+  <Angle type1="o" type2="n2" type3="sh" angle="2.00677957394" k="685.347568"/>
+  <Angle type1="os" type2="n2" type3="os" angle="1.92492363202" k="909.342192"/>
+  <Angle type1="os" type2="n2" type3="p2" angle="1.9233528357" k="931.090624"/>
+  <Angle type1="o" type2="n2" type3="ss" angle="2.02056767503" k="713.447312"/>
+  <Angle type1="os" type2="n2" type3="s" angle="1.95878301951" k="738.007392"/>
+  <Angle type1="p2" type2="n2" type3="p2" angle="2.03854456633" k="947.115344"/>
+  <Angle type1="p2" type2="n2" type3="p3" angle="2.17258585288" k="870.246896"/>
+  <Angle type1="p2" type2="n2" type3="p4" angle="2.24047916079" k="868.908016"/>
+  <Angle type1="p2" type2="n2" type3="p5" angle="2.15495802744" k="922.898352"/>
+  <Angle type1="p2" type2="n2" type3="s4" angle="1.95651409149" k="752.149312"/>
+  <Angle type1="p2" type2="n2" type3="s6" angle="2.01934594456" k="753.136736"/>
+  <Angle type1="p2" type2="n2" type3="s" angle="2.05669599055" k="749.078256"/>
+  <Angle type1="p2" type2="n2" type3="sh" angle="2.06734249899" k="701.472704"/>
+  <Angle type1="p2" type2="n2" type3="ss" angle="2.10190001818" k="715.08744"/>
+  <Angle type1="p3" type2="n2" type3="p3" angle="2.1013764194" k="848.76624"/>
+  <Angle type1="p3" type2="n2" type3="s" angle="2.10940493396" k="698.26776"/>
+  <Angle type1="p4" type2="n2" type3="s" angle="2.30104208583" k="678.661536"/>
+  <Angle type1="p5" type2="n2" type3="p5" angle="2.10486707791" k="935.567504"/>
+  <Angle type1="p5" type2="n2" type3="s" angle="2.09247524022" k="744.16624"/>
+  <Angle type1="pe" type2="n2" type3="s" angle="2.01986954333" k="772.458448"/>
+  <Angle type1="pf" type2="n2" type3="s" angle="2.01986954333" k="772.458448"/>
+  <Angle type1="s4" type2="n2" type3="s4" angle="2.08008340253" k="567.534496"/>
+  <Angle type1="s4" type2="n2" type3="s6" angle="2.08008340253" k="577.249744"/>
+  <Angle type1="s6" type2="n2" type3="s6" angle="2.08008340253" k="588.0612"/>
+  <Angle type1="sh" type2="n2" type3="sh" angle="2.162986542" k="515.560848"/>
+  <Angle type1="sh" type2="n2" type3="ss" angle="2.162986542" k="527.401568"/>
+  <Angle type1="s" type2="n2" type3="s" angle="2.10975399981" k="588.764112"/>
+  <Angle type1="s" type2="n2" type3="s4" angle="1.97222205475" k="595.040112"/>
+  <Angle type1="s" type2="n2" type3="s6" angle="2.08758831831" k="589.408448"/>
+  <Angle type1="s" type2="n2" type3="sh" angle="2.13017435206" k="546.773488"/>
+  <Angle type1="s" type2="n2" type3="ss" angle="2.06280464293" k="572.521824"/>
+  <Angle type1="ss" type2="n2" type3="ss" angle="2.162986542" k="541.091616"/>
+  <Angle type1="br" type2="n3" type3="br" angle="1.87012029351" k="561.693632"/>
+  <Angle type1="br" type2="n3" type3="c3" angle="1.86628056916" k="534.9244"/>
+  <Angle type1="c1" type2="n3" type3="c1" angle="2.15268909941" k="570.329408"/>
+  <Angle type1="c1" type2="n3" type3="f" angle="1.82735972684" k="768.918784"/>
+  <Angle type1="c1" type2="n3" type3="hn" angle="2.00328891544" k="420.207488"/>
+  <Angle type1="c1" type2="n3" type3="o" angle="2.0355775066" k="746.358656"/>
+  <Angle type1="c2" type2="n3" type3="c2" angle="2.17607651139" k="570.429824"/>
+  <Angle type1="c2" type2="n3" type3="hn" angle="2.08357406103" k="413.96496"/>
+  <Angle type1="c3" type2="n3" type3="c3" angle="1.96087741462" k="549.752496"/>
+  <Angle type1="c3" type2="n3" type3="cl" angle="1.87151655691" k="602.53784"/>
+  <Angle type1="c3" type2="n3" type3="cx" angle="2.02458193231" k="540.037248"/>
+  <Angle type1="c3" type2="n3" type3="cy" angle="2.05163453572" k="534.874192"/>
+  <Angle type1="c3" type2="n3" type3="f" angle="1.79995805758" k="743.16208"/>
+  <Angle type1="c3" type2="n3" type3="hn" angle="1.9074703395" k="399.839776"/>
+  <Angle type1="c3" type2="n3" type3="i" angle="1.89333317256" k="505.218"/>
+  <Angle type1="c3" type2="n3" type3="n2" angle="2.07257848674" k="698.845152"/>
+  <Angle type1="c3" type2="n3" type3="n3" angle="1.93382481121" k="698.677792"/>
+  <Angle type1="c3" type2="n3" type3="n4" angle="1.91375352481" k="705.004"/>
+  <Angle type1="c3" type2="n3" type3="n" angle="1.9497073074" k="704.33456"/>
+  <Angle type1="c3" type2="n3" type3="nh" angle="1.95075450495" k="701.57312"/>
+  <Angle type1="c3" type2="n3" type3="no" angle="2.04081349436" k="689.832816"/>
+  <Angle type1="c3" type2="n3" type3="o" angle="1.97763257543" k="720.618688"/>
+  <Angle type1="c3" type2="n3" type3="oh" angle="1.85860112045" k="718.919984"/>
+  <Angle type1="c3" type2="n3" type3="os" angle="1.84655834861" k="715.204592"/>
+  <Angle type1="c3" type2="n3" type3="p3" angle="2.08863551586" k="668.368896"/>
+  <Angle type1="c3" type2="n3" type3="p5" angle="2.09195164144" k="684.2932"/>
+  <Angle type1="c3" type2="n3" type3="s4" angle="1.99822746061" k="527.158896"/>
+  <Angle type1="c3" type2="n3" type3="s6" angle="2.0341812432" k="540.1544"/>
+  <Angle type1="c3" type2="n3" type3="s" angle="1.92021124304" k="529.426624"/>
+  <Angle type1="c3" type2="n3" type3="sh" angle="1.966986067" k="534.698464"/>
+  <Angle type1="c3" type2="n3" type3="ss" angle="2.02894525544" k="529.794816"/>
+  <Angle type1="c3" type2="n3" type3="sy" angle="2.01149196292" k="538.02056"/>
+  <Angle type1="cl" type2="n3" type3="cl" angle="1.88984251406" k="672.603104"/>
+  <Angle type1="cl" type2="n3" type3="hn" angle="1.82194920616" k="403.889888"/>
+  <Angle type1="cl" type2="n3" type3="n3" angle="1.87884693977" k="756.082272"/>
+  <Angle type1="cx" type2="n3" type3="cx" angle="1.05993845474" k="744.994672"/>
+  <Angle type1="cx" type2="n3" type3="hn" angle="1.91689511747" k="397.48"/>
+  <Angle type1="cx" type2="n3" type3="p5" angle="2.08409765981" k="684.728336"/>
+  <Angle type1="cx" type2="n3" type3="py" angle="2.1249383643" k="671.607312"/>
+  <Angle type1="cy" type2="n3" type3="cy" angle="1.59016948149" k="604.696784"/>
+  <Angle type1="cy" type2="n3" type3="hn" angle="1.93155588318" k="393.789712"/>
+  <Angle type1="f" type2="n3" type3="f" angle="1.78407556139" k="968.821936"/>
+  <Angle type1="f" type2="n3" type3="hn" angle="1.74183859349" k="551.74408"/>
+  <Angle type1="hn" type2="n3" type3="hn" angle="1.85703032412" k="341.648704"/>
+  <Angle type1="hn" type2="n3" type3="i" angle="1.91951311134" k="307.515632"/>
+  <Angle type1="hn" type2="n3" type3="n1" angle="1.92282923692" k="536.26328"/>
+  <Angle type1="hn" type2="n3" type3="n2" angle="2.02353473476" k="529.635824"/>
+  <Angle type1="hn" type2="n3" type3="n3" angle="1.87937053855" k="511.95424"/>
+  <Angle type1="hn" type2="n3" type3="n4" angle="1.86593150331" k="517.577536"/>
+  <Angle type1="hn" type2="n3" type3="n" angle="1.88704998726" k="523.16736"/>
+  <Angle type1="hn" type2="n3" type3="na" angle="1.88303572998" k="518.506384"/>
+  <Angle type1="hn" type2="n3" type3="nh" angle="1.89036611284" k="518.949888"/>
+  <Angle type1="hn" type2="n3" type3="no" angle="1.82875599024" k="533.602256"/>
+  <Angle type1="hn" type2="n3" type3="o" angle="1.97780710836" k="544.405344"/>
+  <Angle type1="hn" type2="n3" type3="oh" angle="1.78547182479" k="534.21312"/>
+  <Angle type1="hn" type2="n3" type3="os" angle="1.79332580642" k="524.397456"/>
+  <Angle type1="hn" type2="n3" type3="p2" angle="2.09893295845" k="463.319424"/>
+  <Angle type1="hn" type2="n3" type3="p3" angle="2.04011536266" k="452.139776"/>
+  <Angle type1="hn" type2="n3" type3="p4" angle="1.97309471938" k="469.620528"/>
+  <Angle type1="hn" type2="n3" type3="p5" angle="1.99526040088" k="475.327504"/>
+  <Angle type1="hn" type2="n3" type3="s4" angle="1.90485234563" k="358.94536"/>
+  <Angle type1="hn" type2="n3" type3="s" angle="1.91061193216" k="349.874448"/>
+  <Angle type1="hn" type2="n3" type3="s6" angle="1.91288086019" k="377.614368"/>
+  <Angle type1="hn" type2="n3" type3="sh" angle="1.89664929814" k="363.288352"/>
+  <Angle type1="hn" type2="n3" type3="ss" angle="1.93434840999" k="363.313456"/>
+  <Angle type1="hn" type2="n3" type3="sy" angle="1.91113553093" k="372.016176"/>
+  <Angle type1="i" type2="n3" type3="i" angle="1.94202785869" k="547.752544"/>
+  <Angle type1="n1" type2="n3" type3="n1" angle="1.97588724618" k="931.7768"/>
+  <Angle type1="n2" type2="n3" type3="n2" angle="2.07222942089" k="924.237232"/>
+  <Angle type1="n2" type2="n3" type3="o" angle="2.00555784347" k="948.563008"/>
+  <Angle type1="n3" type2="n3" type3="n3" angle="1.84498755228" k="903.057824"/>
+  <Angle type1="n4" type2="n3" type3="n4" angle="1.98059963516" k="878.59816"/>
+  <Angle type1="n4" type2="n3" type3="nh" angle="1.86994576059" k="908.748064"/>
+  <Angle type1="na" type2="n3" type3="na" angle="1.95476876223" k="890.614608"/>
+  <Angle type1="nh" type2="n3" type3="nh" angle="1.87012029351" k="913.375568"/>
+  <Angle type1="n" type2="n3" type3="n" angle="1.92946148808" k="906.522176"/>
+  <Angle type1="no" type2="n3" type3="no" angle="2.01166649585" k="891.869808"/>
+  <Angle type1="oh" type2="n3" type3="oh" angle="1.87064389229" k="913.70192"/>
+  <Angle type1="o" type2="n3" type3="o" angle="2.20155831847" k="914.572192"/>
+  <Angle type1="o" type2="n3" type3="p2" angle="2.04238429068" k="894.463888"/>
+  <Angle type1="o" type2="n3" type3="p4" angle="2.03592657245" k="884.254928"/>
+  <Angle type1="o" type2="n3" type3="s4" angle="1.9912461436" k="677.448176"/>
+  <Angle type1="o" type2="n3" type3="s6" angle="1.98618468877" k="705.991424"/>
+  <Angle type1="o" type2="n3" type3="s" angle="2.09107897681" k="648.921664"/>
+  <Angle type1="os" type2="n3" type3="os" angle="1.85912471922" k="900.179232"/>
+  <Angle type1="p2" type2="n3" type3="p2" angle="2.27119695562" k="862.372608"/>
+  <Angle type1="p3" type2="n3" type3="p3" angle="2.07240395382" k="871.476992"/>
+  <Angle type1="p4" type2="n3" type3="p4" angle="2.0306905847" k="897.501472"/>
+  <Angle type1="p5" type2="n3" type3="p5" angle="2.08427219273" k="900.421904"/>
+  <Angle type1="s4" type2="n3" type3="s4" angle="2.09474416824" k="519.000096"/>
+  <Angle type1="s4" type2="n3" type3="s6" angle="2.11097573029" k="528.77392"/>
+  <Angle type1="s6" type2="n3" type3="s6" angle="2.06891329531" k="547.861328"/>
+  <Angle type1="sh" type2="n3" type3="sh" angle="2.07048409164" k="526.648448"/>
+  <Angle type1="sh" type2="n3" type3="ss" angle="2.08863551586" k="526.665184"/>
+  <Angle type1="s" type2="n3" type3="s" angle="2.29266450542" k="485.67872"/>
+  <Angle type1="ss" type2="n3" type3="ss" angle="2.08689018661" k="529.267632"/>
+  <Angle type1="br" type2="n4" type3="br" angle="2.00398704714" k="549.936592"/>
+  <Angle type1="br" type2="n4" type3="hn" angle="1.89263504086" k="345.188368"/>
+  <Angle type1="c1" type2="n4" type3="c1" angle="1.98740641925" k="564.455072"/>
+  <Angle type1="c1" type2="n4" type3="hn" angle="1.92317830277" k="410.006896"/>
+  <Angle type1="c2" type2="n4" type3="c2" angle="1.9648916719" k="531.836608"/>
+  <Angle type1="c2" type2="n4" type3="c3" angle="1.93661733801" k="535.9704"/>
+  <Angle type1="c2" type2="n4" type3="hn" angle="1.92631989543" k="385.714592"/>
+  <Angle type1="c3" type2="n4" type3="c3" angle="1.91392805774" k="539.40128"/>
+  <Angle type1="c3" type2="n4" type3="ca" angle="1.92911242223" k="541.99536"/>
+  <Angle type1="c3" type2="n4" type3="cc" angle="1.93801360141" k="539.217184"/>
+  <Angle type1="c3" type2="n4" type3="cl" angle="1.88565372385" k="600.755456"/>
+  <Angle type1="c3" type2="n4" type3="hn" angle="1.92178203937" k="386.543024"/>
+  <Angle type1="c3" type2="n4" type3="n3" angle="1.8797196044" k="699.297024"/>
+  <Angle type1="c3" type2="n4" type3="n4" angle="1.99089707775" k="668.14296"/>
+  <Angle type1="c3" type2="n4" type3="n" angle="1.91532432114" k="692.351584"/>
+  <Angle type1="c3" type2="n4" type3="nh" angle="1.95005637325" k="678.987888"/>
+  <Angle type1="c3" type2="n4" type3="no" angle="1.90380514808" k="684.134208"/>
+  <Angle type1="c3" type2="n4" type3="o" angle="1.9289378893" k="704.12536"/>
+  <Angle type1="c3" type2="n4" type3="oh" angle="1.98496295829" k="686.569296"/>
+  <Angle type1="c3" type2="n4" type3="os" angle="1.87483268249" k="702.100304"/>
+  <Angle type1="c3" type2="n4" type3="p2" angle="1.96384447434" k="626.738096"/>
+  <Angle type1="c3" type2="n4" type3="p3" angle="1.93260308073" k="648.168544"/>
+  <Angle type1="c3" type2="n4" type3="p5" angle="1.97606177911" k="654.143296"/>
+  <Angle type1="c3" type2="n4" type3="s4" angle="1.88896984943" k="491.753888"/>
+  <Angle type1="c3" type2="n4" type3="s6" angle="1.94708931352" k="496.197296"/>
+  <Angle type1="c3" type2="n4" type3="s" angle="1.98182136564" k="508.573568"/>
+  <Angle type1="c3" type2="n4" type3="sh" angle="2.02126580673" k="507.85392"/>
+  <Angle type1="c3" type2="n4" type3="ss" angle="1.98409029367" k="512.381008"/>
+  <Angle type1="ca" type2="n4" type3="ca" angle="1.99805292768" k="537.459904"/>
+  <Angle type1="ca" type2="n4" type3="hn" angle="1.92858882345" k="392.467568"/>
+  <Angle type1="c" type2="n4" type3="c" angle="1.89560210059" k="529.73624"/>
+  <Angle type1="c" type2="n4" type3="hn" angle="1.93940986482" k="376.30896"/>
+  <Angle type1="cl" type2="n4" type3="cl" angle="2.00555784347" k="661.917168"/>
+  <Angle type1="cl" type2="n4" type3="hn" angle="1.90013995665" k="402.20792"/>
+  <Angle type1="f" type2="n4" type3="f" angle="1.9032815493" k="1008.268688"/>
+  <Angle type1="f" type2="n4" type3="hn" angle="1.89176237624" k="561.676896"/>
+  <Angle type1="hn" type2="n4" type3="hn" angle="1.89019157991" k="334.88736"/>
+  <Angle type1="hn" type2="n4" type3="i" angle="1.89752196277" k="315.992416"/>
+  <Angle type1="hn" type2="n4" type3="n1" angle="1.90921566876" k="533.903504"/>
+  <Angle type1="hn" type2="n4" type3="n2" angle="1.91427712359" k="435.730128"/>
+  <Angle type1="hn" type2="n4" type3="n3" angle="1.9268434942" k="508.782768"/>
+  <Angle type1="hn" type2="n4" type3="n4" angle="1.89647476522" k="495.67848"/>
+  <Angle type1="hn" type2="n4" type3="n" angle="1.90380514808" k="511.209488"/>
+  <Angle type1="hn" type2="n4" type3="na" angle="1.903979681" k="510.222064"/>
+  <Angle type1="hn" type2="n4" type3="nh" angle="1.91846591379" k="498.465024"/>
+  <Angle type1="hn" type2="n4" type3="no" angle="1.82177467323" k="507.01712"/>
+  <Angle type1="hn" type2="n4" type3="o" angle="1.9434241221" k="528.8576"/>
+  <Angle type1="hn" type2="n4" type3="oh" angle="1.88652638848" k="523.937216"/>
+  <Angle type1="hn" type2="n4" type3="os" angle="1.90921566876" k="514.021136"/>
+  <Angle type1="hn" type2="n4" type3="p2" angle="1.92858882345" k="407.337504"/>
+  <Angle type1="hn" type2="n4" type3="p3" angle="1.91794231502" k="424.609056"/>
+  <Angle type1="hn" type2="n4" type3="p4" angle="1.94307505625" k="406.827056"/>
+  <Angle type1="hn" type2="n4" type3="p5" angle="1.91986217719" k="437.972752"/>
+  <Angle type1="hn" type2="n4" type3="py" angle="2.05756865518" k="404.333392"/>
+  <Angle type1="hn" type2="n4" type3="s4" angle="1.92160750645" k="312.109664"/>
+  <Angle type1="hn" type2="n4" type3="s" angle="1.86558243746" k="345.76576"/>
+  <Angle type1="hn" type2="n4" type3="s6" angle="1.90136168712" k="325.306"/>
+  <Angle type1="hn" type2="n4" type3="sh" angle="1.89472943597" k="347.682032"/>
+  <Angle type1="hn" type2="n4" type3="ss" angle="1.9053759444" k="346.485408"/>
+  <Angle type1="i" type2="n4" type3="i" angle="2.06804063069" k="538.18792"/>
+  <Angle type1="n1" type2="n4" type3="n1" angle="1.93155588318" k="935.475456"/>
+  <Angle type1="n2" type2="n4" type3="n2" angle="1.89612569937" k="764.784992"/>
+  <Angle type1="n3" type2="n4" type3="n3" angle="1.93853720019" k="888.079104"/>
+  <Angle type1="n4" type2="n4" type3="n4" angle="2.01568075313" k="839.22672"/>
+  <Angle type1="na" type2="n4" type3="na" angle="2.08741378539" k="852.841456"/>
+  <Angle type1="nh" type2="n4" type3="nh" angle="1.90904113583" k="872.941392"/>
+  <Angle type1="n" type2="n4" type3="n" angle="2.07030955872" k="858.155136"/>
+  <Angle type1="oh" type2="n4" type3="oh" angle="1.88827171773" k="919.107648"/>
+  <Angle type1="o" type2="n4" type3="o" angle="2.11132479614" k="894.104064"/>
+  <Angle type1="os" type2="n4" type3="os" angle="1.82212373908" k="921.810512"/>
+  <Angle type1="p2" type2="n4" type3="p2" angle="1.98810455095" k="792.625328"/>
+  <Angle type1="p3" type2="n4" type3="p3" angle="2.11848064607" k="793.169248"/>
+  <Angle type1="p5" type2="n4" type3="p5" angle="1.86785136548" k="867.795072"/>
+  <Angle type1="py" type2="n4" type3="py" angle="1.21806528497" k="1033.933344"/>
+  <Angle type1="s4" type2="n4" type3="s4" angle="2.01463355558" k="470.817152"/>
+  <Angle type1="s6" type2="n4" type3="s6" angle="1.91131006386" k="498.02152"/>
+  <Angle type1="sh" type2="n4" type3="sh" angle="1.96506620482" k="519.100512"/>
+  <Angle type1="s" type2="n4" type3="s" angle="2.17380758336" k="487.887872"/>
+  <Angle type1="ss" type2="n4" type3="ss" angle="1.90589954318" k="526.80744"/>
+  <Angle type1="br" type2="na" type3="br" angle="2.14675497995" k="511.167648"/>
+  <Angle type1="br" type2="na" type3="c2" angle="1.7537068324" k="542.145984"/>
+  <Angle type1="br" type2="na" type3="ca" angle="2.17834543941" k="486.825136"/>
+  <Angle type1="br" type2="na" type3="cc" angle="2.17502931384" k="487.26864"/>
+  <Angle type1="br" type2="na" type3="cd" angle="2.17502931384" k="487.26864"/>
+  <Angle type1="br" type2="na" type3="nc" angle="2.08427219273" k="623.809296"/>
+  <Angle type1="br" type2="na" type3="nd" angle="2.08427219273" k="623.8344"/>
+  <Angle type1="br" type2="na" type3="os" angle="1.83242118167" k="662.444352"/>
+  <Angle type1="br" type2="na" type3="p2" angle="2.11202292784" k="655.858736"/>
+  <Angle type1="br" type2="na" type3="pc" angle="2.09893295845" k="659.992528"/>
+  <Angle type1="br" type2="na" type3="pd" angle="2.09893295845" k="659.992528"/>
+  <Angle type1="br" type2="na" type3="ss" angle="1.95965568414" k="532.196432"/>
+  <Angle type1="c1" type2="na" type3="c1" angle="2.04552588334" k="578.848032"/>
+  <Angle type1="c1" type2="na" type3="c2" angle="2.1851522235" k="551.819392"/>
+  <Angle type1="c1" type2="na" type3="ca" angle="2.10434347913" k="566.05336"/>
+  <Angle type1="c1" type2="na" type3="cc" angle="2.1179570473" k="565.032464"/>
+  <Angle type1="c1" type2="na" type3="cd" angle="2.1179570473" k="565.032464"/>
+  <Angle type1="c1" type2="na" type3="nc" angle="2.0985838926" k="717.26312"/>
+  <Angle type1="c1" type2="na" type3="nd" angle="2.0985838926" k="717.706624"/>
+  <Angle type1="c1" type2="na" type3="os" angle="1.86680416793" k="735.338"/>
+  <Angle type1="c1" type2="na" type3="p2" angle="2.13366501056" k="667.523728"/>
+  <Angle type1="c1" type2="na" type3="pc" angle="2.12022597532" k="674.895936"/>
+  <Angle type1="c1" type2="na" type3="pd" angle="2.12022597532" k="674.895936"/>
+  <Angle type1="c1" type2="na" type3="ss" angle="2.06472450511" k="532.79056"/>
+  <Angle type1="c2" type2="na" type3="c2" angle="1.92631989543" k="579.676464"/>
+  <Angle type1="c2" type2="na" type3="c3" angle="2.04552588334" k="549.970064"/>
+  <Angle type1="c2" type2="na" type3="ca" angle="2.18113796622" k="548.14584"/>
+  <Angle type1="c2" type2="na" type3="cc" angle="2.2087141684" k="545.434608"/>
+  <Angle type1="c2" type2="na" type3="cd" angle="2.2087141684" k="545.434608"/>
+  <Angle type1="c2" type2="na" type3="cl" angle="1.76295707744" k="611.190352"/>
+  <Angle type1="c2" type2="na" type3="f" angle="1.79960899173" k="759.237008"/>
+  <Angle type1="c2" type2="na" type3="hn" angle="2.08182873178" k="398.81888"/>
+  <Angle type1="c2" type2="na" type3="i" angle="1.86296444358" k="522.83264"/>
+  <Angle type1="c2" type2="na" type3="n1" angle="2.17834543941" k="694.903824"/>
+  <Angle type1="c2" type2="na" type3="n2" angle="2.18166156499" k="690.242848"/>
+  <Angle type1="c2" type2="na" type3="n3" angle="2.17817090649" k="678.109248"/>
+  <Angle type1="c2" type2="na" type3="n4" angle="2.11743344852" k="684.00032"/>
+  <Angle type1="c2" type2="na" type3="n" angle="2.17642557724" k="681.548496"/>
+  <Angle type1="c2" type2="na" type3="na" angle="2.17468024798" k="683.314144"/>
+  <Angle type1="c2" type2="na" type3="nc" angle="2.10835773641" k="704.970528"/>
+  <Angle type1="c2" type2="na" type3="nd" angle="2.10835773641" k="705.372192"/>
+  <Angle type1="c2" type2="na" type3="nh" angle="2.18131249914" k="682.519184"/>
+  <Angle type1="c2" type2="na" type3="no" angle="2.16769893098" k="676.117664"/>
+  <Angle type1="c2" type2="na" type3="o" angle="2.19736952826" k="715.957712"/>
+  <Angle type1="c2" type2="na" type3="oh" angle="2.16246294322" k="687.314048"/>
+  <Angle type1="c2" type2="na" type3="os" angle="1.92562176373" k="714.869872"/>
+  <Angle type1="c2" type2="na" type3="p2" angle="2.13174514839" k="663.825072"/>
+  <Angle type1="c2" type2="na" type3="p3" angle="2.20086018676" k="649.574368"/>
+  <Angle type1="c2" type2="na" type3="p4" angle="2.18166156499" k="710.016432"/>
+  <Angle type1="c2" type2="na" type3="p5" angle="2.18340689424" k="665.79992"/>
+  <Angle type1="c2" type2="na" type3="pc" angle="2.12162223872" k="670.410688"/>
+  <Angle type1="c2" type2="na" type3="pd" angle="2.12162223872" k="670.410688"/>
+  <Angle type1="c2" type2="na" type3="s4" angle="2.17991623574" k="501.603024"/>
+  <Angle type1="c2" type2="na" type3="s6" angle="2.17118958948" k="518.514752"/>
+  <Angle type1="c2" type2="na" type3="s" angle="2.19562419901" k="506.088272"/>
+  <Angle type1="c2" type2="na" type3="sh" angle="2.18340689424" k="517.452016"/>
+  <Angle type1="c2" type2="na" type3="ss" angle="2.01637888483" k="535.744464"/>
+  <Angle type1="c3" type2="na" type3="c3" angle="2.19195900758" k="520.606752"/>
+  <Angle type1="c3" type2="na" type3="ca" angle="2.17049145778" k="536.84904"/>
+  <Angle type1="c3" type2="na" type3="cc" angle="2.20714337207" k="532.99976"/>
+  <Angle type1="c3" type2="na" type3="cd" angle="2.20714337207" k="532.99976"/>
+  <Angle type1="c3" type2="na" type3="cp" angle="2.08776285124" k="547.384352"/>
+  <Angle type1="c3" type2="na" type3="n2" angle="2.08113060008" k="690.02528"/>
+  <Angle type1="c3" type2="na" type3="n" angle="1.97012765965" k="700.493648"/>
+  <Angle type1="c3" type2="na" type3="nc" angle="2.09753669505" k="689.77424"/>
+  <Angle type1="c3" type2="na" type3="nd" angle="2.09753669505" k="690.125696"/>
+  <Angle type1="c3" type2="na" type3="os" angle="1.82194920616" k="719.664736"/>
+  <Angle type1="c3" type2="na" type3="p2" angle="2.14884937506" k="654.051248"/>
+  <Angle type1="c3" type2="na" type3="pc" angle="2.13122154961" k="661.356512"/>
+  <Angle type1="c3" type2="na" type3="pd" angle="2.13122154961" k="661.356512"/>
+  <Angle type1="c3" type2="na" type3="sh" angle="1.9247490991" k="544.723328"/>
+  <Angle type1="c3" type2="na" type3="ss" angle="1.93504654169" k="540.723424"/>
+  <Angle type1="ca" type2="na" type3="ca" angle="2.09526776702" k="562.840048"/>
+  <Angle type1="ca" type2="na" type3="cc" angle="1.97484004863" k="580.546736"/>
+  <Angle type1="ca" type2="na" type3="cd" angle="1.97484004863" k="580.546736"/>
+  <Angle type1="ca" type2="na" type3="cl" angle="2.17799637356" k="550.999328"/>
+  <Angle type1="ca" type2="na" type3="cp" angle="2.10940493396" k="560.94888"/>
+  <Angle type1="ca" type2="na" type3="cx" angle="2.17450571506" k="536.731888"/>
+  <Angle type1="ca" type2="na" type3="f" angle="2.03156324932" k="718.93672"/>
+  <Angle type1="ca" type2="na" type3="hn" angle="2.19108634295" k="393.120272"/>
+  <Angle type1="ca" type2="na" type3="i" angle="2.12266943628" k="489.77904"/>
+  <Angle type1="ca" type2="na" type3="n2" angle="2.07816354035" k="711.882496"/>
+  <Angle type1="ca" type2="na" type3="n4" angle="2.09771122797" k="691.213536"/>
+  <Angle type1="ca" type2="na" type3="n" angle="2.12930168743" k="693.280432"/>
+  <Angle type1="ca" type2="na" type3="na" angle="2.16001948227" k="689.883024"/>
+  <Angle type1="ca" type2="na" type3="nb" angle="2.14047179465" k="706.476768"/>
+  <Angle type1="ca" type2="na" type3="nc" angle="2.05687052348" k="718.535056"/>
+  <Angle type1="ca" type2="na" type3="nd" angle="2.05687052348" k="718.961824"/>
+  <Angle type1="ca" type2="na" type3="nh" angle="2.17136412241" k="688.334944"/>
+  <Angle type1="ca" type2="na" type3="o" angle="2.09736216212" k="738.793984"/>
+  <Angle type1="ca" type2="na" type3="oh" angle="2.09526776702" k="702.652592"/>
+  <Angle type1="ca" type2="na" type3="os" angle="1.91043739923" k="721.815312"/>
+  <Angle type1="ca" type2="na" type3="p2" angle="2.19649686363" k="655.775056"/>
+  <Angle type1="ca" type2="na" type3="p3" angle="2.17084052363" k="655.775056"/>
+  <Angle type1="ca" type2="na" type3="p4" angle="2.18113796622" k="713.279952"/>
+  <Angle type1="ca" type2="na" type3="p5" angle="2.15199096771" k="672.695152"/>
+  <Angle type1="ca" type2="na" type3="pc" angle="2.13157061546" k="670.795616"/>
+  <Angle type1="ca" type2="na" type3="pd" angle="2.13157061546" k="670.795616"/>
+  <Angle type1="ca" type2="na" type3="py" angle="2.45881985021" k="630.168976"/>
+  <Angle type1="ca" type2="na" type3="s4" angle="2.04604948211" k="518.991728"/>
+  <Angle type1="ca" type2="na" type3="s6" angle="2.10643787423" k="527.995696"/>
+  <Angle type1="ca" type2="na" type3="s" angle="2.19283167221" k="507.736768"/>
+  <Angle type1="ca" type2="na" type3="sh" angle="2.1893410137" k="518.297184"/>
+  <Angle type1="ca" type2="na" type3="ss" angle="2.26753176419" k="506.674032"/>
+  <Angle type1="cc" type2="na" type3="cc" angle="1.91811684794" k="589.877056"/>
+  <Angle type1="cc" type2="na" type3="cd" angle="2.23419597548" k="546.564288"/>
+  <Angle type1="cc" type2="na" type3="ce" angle="2.20976136595" k="541.359392"/>
+  <Angle type1="cc" type2="na" type3="cl" angle="2.17485478091" k="551.635296"/>
+  <Angle type1="cc" type2="na" type3="f" angle="2.06001211613" k="714.886608"/>
+  <Angle type1="cc" type2="na" type3="hn" angle="2.19038821125" k="394.141168"/>
+  <Angle type1="cc" type2="na" type3="i" angle="2.19387886976" k="481.74576"/>
+  <Angle type1="cc" type2="na" type3="n2" angle="2.11341919124" k="706.911904"/>
+  <Angle type1="cc" type2="na" type3="n4" angle="2.11027759859" k="690.008544"/>
+  <Angle type1="cc" type2="na" type3="n" angle="1.92073484182" k="730.911328"/>
+  <Angle type1="cc" type2="na" type3="na" angle="2.04831841014" k="709.388832"/>
+  <Angle type1="cc" type2="na" type3="nc" angle="1.96105194754" k="736.944656"/>
+  <Angle type1="cc" type2="na" type3="nd" angle="2.20312911479" k="695.690416"/>
+  <Angle type1="cc" type2="na" type3="nh" angle="2.15705242254" k="691.53152"/>
+  <Angle type1="cc" type2="na" type3="no" angle="2.15443442866" k="683.004528"/>
+  <Angle type1="cc" type2="na" type3="o" angle="2.18532675642" k="725.036992"/>
+  <Angle type1="cc" type2="na" type3="oh" angle="2.13593393859" k="696.870304"/>
+  <Angle type1="cc" type2="na" type3="os" angle="2.03959176388" k="699.447648"/>
+  <Angle type1="cc" type2="na" type3="p2" angle="2.19667139656" k="656.126512"/>
+  <Angle type1="cc" type2="na" type3="p3" angle="2.18602488812" k="653.858784"/>
+  <Angle type1="cc" type2="na" type3="p4" angle="2.22930905357" k="706.208992"/>
+  <Angle type1="cc" type2="na" type3="p5" angle="2.17642557724" k="669.339584"/>
+  <Angle type1="cc" type2="na" type3="s4" angle="2.11237199369" k="511.03376"/>
+  <Angle type1="cc" type2="na" type3="s6" angle="2.15635429084" k="522.179936"/>
+  <Angle type1="cc" type2="na" type3="s" angle="2.19318073806" k="507.97944"/>
+  <Angle type1="cc" type2="na" type3="sh" angle="2.16351014077" k="521.711328"/>
+  <Angle type1="cc" type2="na" type3="ss" angle="2.11411732294" k="525.05016"/>
+  <Angle type1="cd" type2="na" type3="cd" angle="1.91811684794" k="589.877056"/>
+  <Angle type1="cd" type2="na" type3="cl" angle="2.17485478091" k="551.635296"/>
+  <Angle type1="cd" type2="na" type3="f" angle="2.06001211613" k="714.886608"/>
+  <Angle type1="cd" type2="na" type3="hn" angle="2.19038821125" k="394.141168"/>
+  <Angle type1="cd" type2="na" type3="i" angle="2.19387886976" k="481.74576"/>
+  <Angle type1="cd" type2="na" type3="n2" angle="2.11341919124" k="706.911904"/>
+  <Angle type1="cd" type2="na" type3="n4" angle="2.11027759859" k="690.008544"/>
+  <Angle type1="cd" type2="na" type3="n" angle="1.92073484182" k="730.911328"/>
+  <Angle type1="cd" type2="na" type3="na" angle="2.04831841014" k="709.388832"/>
+  <Angle type1="cd" type2="na" type3="nc" angle="2.20312911479" k="695.280384"/>
+  <Angle type1="cd" type2="na" type3="nd" angle="1.96105194754" k="737.38816"/>
+  <Angle type1="cd" type2="na" type3="nh" angle="2.15792508717" k="691.397632"/>
+  <Angle type1="cd" type2="na" type3="no" angle="2.15443442866" k="683.004528"/>
+  <Angle type1="cd" type2="na" type3="o" angle="2.18532675642" k="725.036992"/>
+  <Angle type1="cd" type2="na" type3="oh" angle="2.13593393859" k="696.870304"/>
+  <Angle type1="cd" type2="na" type3="os" angle="2.03959176388" k="699.447648"/>
+  <Angle type1="cd" type2="na" type3="p2" angle="2.19667139656" k="656.126512"/>
+  <Angle type1="cd" type2="na" type3="p3" angle="2.18602488812" k="653.858784"/>
+  <Angle type1="cd" type2="na" type3="p4" angle="2.22930905357" k="706.208992"/>
+  <Angle type1="cd" type2="na" type3="p5" angle="2.17642557724" k="669.339584"/>
+  <Angle type1="cd" type2="na" type3="s4" angle="2.11237199369" k="511.03376"/>
+  <Angle type1="cd" type2="na" type3="s6" angle="2.15635429084" k="522.179936"/>
+  <Angle type1="cd" type2="na" type3="s" angle="2.19318073806" k="507.97944"/>
+  <Angle type1="cd" type2="na" type3="sh" angle="2.16351014077" k="521.711328"/>
+  <Angle type1="cd" type2="na" type3="ss" angle="2.11411732294" k="525.05016"/>
+  <Angle type1="cl" type2="na" type3="cl" angle="2.14326432145" k="611.692432"/>
+  <Angle type1="cl" type2="na" type3="nc" angle="2.08322499518" k="707.59808"/>
+  <Angle type1="cl" type2="na" type3="nd" angle="2.08322499518" k="707.715232"/>
+  <Angle type1="cl" type2="na" type3="os" angle="1.86017191678" k="740.927824"/>
+  <Angle type1="cl" type2="na" type3="p2" angle="2.11690984974" k="723.488912"/>
+  <Angle type1="cl" type2="na" type3="pc" angle="2.10329628158" k="728.911376"/>
+  <Angle type1="cl" type2="na" type3="pd" angle="2.10329628158" k="728.911376"/>
+  <Angle type1="cl" type2="na" type3="ss" angle="1.95319796591" k="589.333136"/>
+  <Angle type1="f" type2="na" type3="f" angle="2.0978857609" k="890.254784"/>
+  <Angle type1="f" type2="na" type3="nc" angle="2.06036118198" k="902.539008"/>
+  <Angle type1="f" type2="na" type3="nd" angle="2.06036118198" k="903.049456"/>
+  <Angle type1="f" type2="na" type3="os" angle="1.81269896112" k="932.981792"/>
+  <Angle type1="f" type2="na" type3="p2" angle="2.09352243777" k="849.577936"/>
+  <Angle type1="f" type2="na" type3="pc" angle="2.07868713913" k="858.950096"/>
+  <Angle type1="f" type2="na" type3="pd" angle="2.07868713913" k="858.950096"/>
+  <Angle type1="f" type2="na" type3="ss" angle="1.88513012508" k="702.677696"/>
+  <Angle type1="hn" type2="na" type3="hn" angle="2.03854456633" k="328.98792"/>
+  <Angle type1="hn" type2="na" type3="n" angle="1.94499491842" k="514.8412"/>
+  <Angle type1="hn" type2="na" type3="nc" angle="2.08654112076" k="513.602736"/>
+  <Angle type1="hn" type2="na" type3="nd" angle="2.08654112076" k="514.155024"/>
+  <Angle type1="hn" type2="na" type3="os" angle="1.78233023214" k="525.21752"/>
+  <Angle type1="hn" type2="na" type3="p2" angle="2.13837739954" k="435.780336"/>
+  <Angle type1="hn" type2="na" type3="pc" angle="2.12022597532" k="442.483104"/>
+  <Angle type1="hn" type2="na" type3="pd" angle="2.12022597532" k="442.483104"/>
+  <Angle type1="hn" type2="na" type3="ss" angle="1.98880268265" k="355.89104"/>
+  <Angle type1="i" type2="na" type3="i" angle="2.16769893098" k="532.096016"/>
+  <Angle type1="i" type2="na" type3="nc" angle="2.09491870117" k="617.09816"/>
+  <Angle type1="i" type2="na" type3="nd" angle="2.09491870117" k="617.073056"/>
+  <Angle type1="i" type2="na" type3="os" angle="1.91829138087" k="644.854816"/>
+  <Angle type1="i" type2="na" type3="p2" angle="2.13418860934" k="658.89632"/>
+  <Angle type1="i" type2="na" type3="pc" angle="2.11882971192" k="662.904592"/>
+  <Angle type1="i" type2="na" type3="pd" angle="2.11882971192" k="662.904592"/>
+  <Angle type1="i" type2="na" type3="ss" angle="2.06646983436" k="523.016736"/>
+  <Angle type1="n2" type2="na" type3="n2" angle="2.03697377" k="905.886208"/>
+  <Angle type1="n2" type2="na" type3="nc" angle="2.09369697069" k="897.367584"/>
+  <Angle type1="n2" type2="na" type3="nd" angle="2.09369697069" k="897.919872"/>
+  <Angle type1="n2" type2="na" type3="os" angle="1.94656571475" k="900.170864"/>
+  <Angle type1="n2" type2="na" type3="p2" angle="2.17956716989" k="826.390208"/>
+  <Angle type1="n2" type2="na" type3="pc" angle="2.14989657261" k="838.574016"/>
+  <Angle type1="n2" type2="na" type3="pd" angle="2.14989657261" k="838.574016"/>
+  <Angle type1="n2" type2="na" type3="ss" angle="2.17537837969" k="649.448848"/>
+  <Angle type1="n3" type2="na" type3="n3" angle="2.16420827247" k="846.4232"/>
+  <Angle type1="n4" type2="na" type3="n4" angle="1.94953277448" k="882.48928"/>
+  <Angle type1="n4" type2="na" type3="nc" angle="2.03226138102" k="887.434768"/>
+  <Angle type1="n4" type2="na" type3="nd" angle="2.03226138102" k="887.911744"/>
+  <Angle type1="n4" type2="na" type3="os" angle="1.79716553078" k="916.245792"/>
+  <Angle type1="n4" type2="na" type3="p2" angle="2.15652882376" k="821.796176"/>
+  <Angle type1="n4" type2="na" type3="pc" angle="2.12895262158" k="833.092976"/>
+  <Angle type1="n4" type2="na" type3="pd" angle="2.12895262158" k="833.092976"/>
+  <Angle type1="na" type2="na" type3="na" angle="2.15722695546" k="859.293184"/>
+  <Angle type1="na" type2="na" type3="nc" angle="2.08811191709" k="887.233936"/>
+  <Angle type1="na" type2="na" type3="nd" angle="2.08811191709" k="887.744384"/>
+  <Angle type1="na" type2="na" type3="os" angle="1.91061193216" k="898.857088"/>
+  <Angle type1="na" type2="na" type3="p2" angle="2.12441476553" k="832.78336"/>
+  <Angle type1="na" type2="na" type3="pc" angle="2.11027759859" k="841.854272"/>
+  <Angle type1="na" type2="na" type3="pd" angle="2.11027759859" k="841.854272"/>
+  <Angle type1="na" type2="na" type3="ss" angle="2.03330857857" k="668.14296"/>
+  <Angle type1="nc" type2="na" type3="nc" angle="2.02981792007" k="915.383888"/>
+  <Angle type1="nc" type2="na" type3="nd" angle="2.14256618975" k="891.52672"/>
+  <Angle type1="nc" type2="na" type3="nh" angle="2.10399441328" k="884.221456"/>
+  <Angle type1="nc" type2="na" type3="no" angle="2.0806070013" k="877.209072"/>
+  <Angle type1="nc" type2="na" type3="o" angle="2.14308978852" k="927.082352"/>
+  <Angle type1="nc" type2="na" type3="oh" angle="2.08078153423" k="891.710816"/>
+  <Angle type1="nc" type2="na" type3="os" angle="2.08828645001" k="872.313792"/>
+  <Angle type1="nc" type2="na" type3="p2" angle="2.09422056947" k="844.473456"/>
+  <Angle type1="nc" type2="na" type3="p3" angle="2.09561683287" k="839.1012"/>
+  <Angle type1="nc" type2="na" type3="p4" angle="2.09038084511" k="918.714352"/>
+  <Angle type1="nc" type2="na" type3="p5" angle="2.07606914525" k="861.594384"/>
+  <Angle type1="nc" type2="na" type3="pc" angle="2.07100769042" k="855.912512"/>
+  <Angle type1="nc" type2="na" type3="s4" angle="2.08043246838" k="646.779456"/>
+  <Angle type1="nc" type2="na" type3="s6" angle="2.08113060008" k="668.1848"/>
+  <Angle type1="nc" type2="na" type3="s" angle="2.13383954349" k="647.0556"/>
+  <Angle type1="nc" type2="na" type3="sh" angle="2.10312174865" k="665.205792"/>
+  <Angle type1="nc" type2="na" type3="ss" angle="2.10312174865" k="661.682864"/>
+  <Angle type1="nd" type2="na" type3="nd" angle="2.02981792007" k="916.530304"/>
+  <Angle type1="nd" type2="na" type3="nh" angle="2.10399441328" k="884.731904"/>
+  <Angle type1="nd" type2="na" type3="no" angle="2.0806070013" k="877.67768"/>
+  <Angle type1="nd" type2="na" type3="o" angle="2.14308978852" k="927.793632"/>
+  <Angle type1="nd" type2="na" type3="oh" angle="2.08078153423" k="892.229632"/>
+  <Angle type1="nd" type2="na" type3="os" angle="2.08828645001" k="872.774032"/>
+  <Angle type1="nd" type2="na" type3="p2" angle="2.09422056947" k="844.674288"/>
+  <Angle type1="nd" type2="na" type3="p3" angle="2.09561683287" k="839.285296"/>
+  <Angle type1="nd" type2="na" type3="p4" angle="2.09038084511" k="919.082544"/>
+  <Angle type1="nd" type2="na" type3="p5" angle="2.07606914525" k="861.828688"/>
+  <Angle type1="nd" type2="na" type3="pd" angle="2.07100769042" k="856.121712"/>
+  <Angle type1="nd" type2="na" type3="s4" angle="2.08043246838" k="646.904976"/>
+  <Angle type1="nd" type2="na" type3="s6" angle="2.08113060008" k="668.35216"/>
+  <Angle type1="nd" type2="na" type3="s" angle="2.13383954349" k="647.197856"/>
+  <Angle type1="nd" type2="na" type3="sh" angle="2.10312174865" k="665.373152"/>
+  <Angle type1="nd" type2="na" type3="ss" angle="2.10312174865" k="661.841856"/>
+  <Angle type1="nh" type2="na" type3="nh" angle="2.15722695546" k="859.904048"/>
+  <Angle type1="nh" type2="na" type3="os" angle="1.94377318795" k="891.44304"/>
+  <Angle type1="nh" type2="na" type3="p2" angle="2.10940493396" k="835.871152"/>
+  <Angle type1="nh" type2="na" type3="pc" angle="2.10102735355" k="843.845856"/>
+  <Angle type1="nh" type2="na" type3="pd" angle="2.10102735355" k="843.845856"/>
+  <Angle type1="nh" type2="na" type3="ss" angle="1.96087741462" k="680.48576"/>
+  <Angle type1="n" type2="na" type3="n" angle="2.16071761397" k="854.87488"/>
+  <Angle type1="n" type2="na" type3="nc" angle="2.09177710852" k="884.37208"/>
+  <Angle type1="n" type2="na" type3="nd" angle="2.09177710852" k="884.87416"/>
+  <Angle type1="no" type2="na" type3="no" angle="2.14326432145" k="841.896112"/>
+  <Angle type1="no" type2="na" type3="os" angle="1.859648318" k="900.840304"/>
+  <Angle type1="no" type2="na" type3="pc" angle="2.09631496457" k="839.611648"/>
+  <Angle type1="no" type2="na" type3="pd" angle="2.09631496457" k="839.611648"/>
+  <Angle type1="n" type2="na" type3="os" angle="1.82753425976" k="917.199744"/>
+  <Angle type1="no" type2="na" type3="ss" angle="2.00625597517" k="668.628304"/>
+  <Angle type1="n" type2="na" type3="p2" angle="2.1179570473" k="833.218496"/>
+  <Angle type1="n" type2="na" type3="pc" angle="2.10556520961" k="841.912848"/>
+  <Angle type1="n" type2="na" type3="pd" angle="2.10556520961" k="841.912848"/>
+  <Angle type1="n" type2="na" type3="ss" angle="2.02632726157" k="668.594832"/>
+  <Angle type1="oh" type2="na" type3="oh" angle="2.13279234594" k="869.47704"/>
+  <Angle type1="oh" type2="na" type3="p2" angle="2.10765960471" k="837.2184"/>
+  <Angle type1="oh" type2="na" type3="pc" angle="2.09422056947" k="846.280944"/>
+  <Angle type1="oh" type2="na" type3="pd" angle="2.09422056947" k="846.280944"/>
+  <Angle type1="oh" type2="na" type3="ss" angle="1.97292018645" k="679.255664"/>
+  <Angle type1="o" type2="na" type3="o" angle="2.20260551602" k="961.274"/>
+  <Angle type1="o" type2="na" type3="os" angle="2.07310208552" k="904.714688"/>
+  <Angle type1="o" type2="na" type3="p2" angle="2.14326432145" k="844.942064"/>
+  <Angle type1="o" type2="na" type3="pc" angle="2.13523580689" k="854.096656"/>
+  <Angle type1="o" type2="na" type3="pd" angle="2.13523580689" k="854.096656"/>
+  <Angle type1="os" type2="na" type3="os" angle="1.82299640371" k="906.915472"/>
+  <Angle type1="os" type2="na" type3="p2" angle="2.0570450564" k="840.071888"/>
+  <Angle type1="os" type2="na" type3="p3" angle="1.82735972684" k="886.42224"/>
+  <Angle type1="os" type2="na" type3="p5" angle="1.94447131965" k="876.430848"/>
+  <Angle type1="os" type2="na" type3="pc" angle="2.09282430607" k="838.825056"/>
+  <Angle type1="os" type2="na" type3="pd" angle="2.09282430607" k="838.825056"/>
+  <Angle type1="os" type2="na" type3="s4" angle="1.84795461201" k="677.858208"/>
+  <Angle type1="os" type2="na" type3="s6" angle="1.95476876223" k="678.954416"/>
+  <Angle type1="os" type2="na" type3="ss" angle="1.91357899189" k="683.41456"/>
+  <Angle type1="p2" type2="na" type3="p2" angle="2.11027759859" k="854.238912"/>
+  <Angle type1="p2" type2="na" type3="p3" angle="2.17817090649" k="837.67864"/>
+  <Angle type1="p2" type2="na" type3="p5" angle="2.16403373955" k="851.678304"/>
+  <Angle type1="p2" type2="na" type3="pc" angle="2.10696147301" k="859.042144"/>
+  <Angle type1="p2" type2="na" type3="pd" angle="2.10696147301" k="859.042144"/>
+  <Angle type1="p2" type2="na" type3="s4" angle="2.13750473492" k="652.971776"/>
+  <Angle type1="p2" type2="na" type3="s6" angle="2.13802833369" k="666.235056"/>
+  <Angle type1="p2" type2="na" type3="s" angle="2.12668369356" k="660.017632"/>
+  <Angle type1="p2" type2="na" type3="sh" angle="2.1249383643" k="668.6032"/>
+  <Angle type1="p2" type2="na" type3="ss" angle="2.12720729233" k="666.0928"/>
+  <Angle type1="p3" type2="na" type3="p3" angle="2.20958683302" k="828.657936"/>
+  <Angle type1="p3" type2="na" type3="pc" angle="2.15234003356" k="846.690976"/>
+  <Angle type1="p3" type2="na" type3="pd" angle="2.15234003356" k="846.690976"/>
+  <Angle type1="p5" type2="na" type3="p5" angle="2.17468024798" k="858.171872"/>
+  <Angle type1="p5" type2="na" type3="pc" angle="2.14134445927" k="860.52328"/>
+  <Angle type1="p5" type2="na" type3="pd" angle="2.14134445927" k="860.52328"/>
+  <Angle type1="p5" type2="na" type3="ss" angle="2.06856422946" k="682.125888"/>
+  <Angle type1="pc" type2="na" type3="pc" angle="2.10800867056" k="863.083888"/>
+  <Angle type1="pc" type2="na" type3="s4" angle="2.1207495741" k="658.511392"/>
+  <Angle type1="pc" type2="na" type3="s6" angle="2.1214477058" k="672.193072"/>
+  <Angle type1="pc" type2="na" type3="s" angle="2.1200514424" k="664.176528"/>
+  <Angle type1="pc" type2="na" type3="sh" angle="2.11324465831" k="673.824832"/>
+  <Angle type1="pc" type2="na" type3="ss" angle="2.11533905342" k="671.272592"/>
+  <Angle type1="pd" type2="na" type3="pd" angle="2.10800867056" k="863.083888"/>
+  <Angle type1="pd" type2="na" type3="s4" angle="2.1207495741" k="658.511392"/>
+  <Angle type1="pd" type2="na" type3="s6" angle="2.1214477058" k="672.193072"/>
+  <Angle type1="pd" type2="na" type3="s" angle="2.1200514424" k="664.176528"/>
+  <Angle type1="pd" type2="na" type3="sh" angle="2.11324465831" k="673.824832"/>
+  <Angle type1="pd" type2="na" type3="ss" angle="2.11533905342" k="671.272592"/>
+  <Angle type1="py" type2="na" type3="py" angle="1.36572013969" k="1084.810784"/>
+  <Angle type1="s4" type2="na" type3="s4" angle="2.16769893098" k="499.201408"/>
+  <Angle type1="s4" type2="na" type3="s6" angle="1.9697785938" k="533.727776"/>
+  <Angle type1="s4" type2="na" type3="ss" angle="1.95337249883" k="534.58968"/>
+  <Angle type1="s6" type2="na" type3="s6" angle="2.15024563846" k="521.677856"/>
+  <Angle type1="s6" type2="na" type3="ss" angle="2.07868713913" k="529.0668"/>
+  <Angle type1="sh" type2="na" type3="sh" angle="2.17468024798" k="519.251136"/>
+  <Angle type1="sh" type2="na" type3="ss" angle="2.07327661844" k="530.020752"/>
+  <Angle type1="s" type2="na" type3="s" angle="2.19911485751" k="503.485824"/>
+  <Angle type1="s" type2="na" type3="ss" angle="1.96332087557" k="537.72768"/>
+  <Angle type1="ss" type2="na" type3="ss" angle="1.97641084496" k="541.058144"/>
+  <Angle type1="sy" type2="na" type3="sy" angle="2.15024563846" k="520.380816"/>
+  <Angle type1="ca" type2="nb" type3="ca" angle="2.04587494919" k="588.739008"/>
+  <Angle type1="ca" type2="nb" type3="cp" angle="2.06036118198" k="586.730688"/>
+  <Angle type1="ca" type2="nb" type3="cq" angle="2.06036118198" k="586.730688"/>
+  <Angle type1="ca" type2="nb" type3="nb" angle="2.09526776702" k="729.999216"/>
+  <Angle type1="cp" type2="nb" type3="nb" angle="2.11115026321" k="727.329824"/>
+  <Angle type1="nb" type2="nb" type3="nb" angle="2.11254652661" k="912.27936"/>
+  <Angle type1="br" type2="n" type3="br" angle="2.02807259082" k="562.128768"/>
+  <Angle type1="br" type2="n" type3="c" angle="2.11621171804" k="524.916272"/>
+  <Angle type1="br" type2="n" type3="ca" angle="2.06280464293" k="529.886864"/>
+  <Angle type1="br" type2="n" type3="cc" angle="2.06280464293" k="531.5772"/>
+  <Angle type1="br" type2="n" type3="cd" angle="2.06280464293" k="531.5772"/>
+  <Angle type1="c1" type2="n" type3="c1" angle="1.79227860887" k="633.265136"/>
+  <Angle type1="c1" type2="n" type3="ca" angle="2.07484741477" k="569.927744"/>
+  <Angle type1="c1" type2="n" type3="cc" angle="2.07484741477" k="577.157696"/>
+  <Angle type1="c1" type2="n" type3="cd" angle="2.07484741477" k="577.157696"/>
+  <Angle type1="c2" type2="n" type3="c2" angle="2.0376719017" k="564.46344"/>
+  <Angle type1="c2" type2="n" type3="c3" angle="2.09614043165" k="543.853056"/>
+  <Angle type1="c2" type2="n" type3="ca" angle="2.03400671027" k="562.396544"/>
+  <Angle type1="c2" type2="n" type3="cc" angle="2.03400671027" k="568.714384"/>
+  <Angle type1="c2" type2="n" type3="cd" angle="2.03400671027" k="568.714384"/>
+  <Angle type1="c2" type2="n" type3="hn" angle="2.0577431881" k="401.563584"/>
+  <Angle type1="c3" type2="n" type3="c3" angle="2.01829874701" k="542.91584"/>
+  <Angle type1="c3" type2="n" type3="ca" angle="2.09142804266" k="542.254768"/>
+  <Angle type1="c3" type2="n" type3="cc" angle="2.10923040104" k="545.359296"/>
+  <Angle type1="c3" type2="n" type3="cd" angle="2.10923040104" k="545.359296"/>
+  <Angle type1="c3" type2="n" type3="cy" angle="2.04343148823" k="538.120976"/>
+  <Angle type1="c3" type2="n" type3="hn" angle="2.05390346375" k="386.158096"/>
+  <Angle type1="c3" type2="n" type3="n2" angle="2.1242402326" k="684.75344"/>
+  <Angle type1="c3" type2="n" type3="n" angle="2.01393542388" k="693.715568"/>
+  <Angle type1="c3" type2="n" type3="nc" angle="2.0120155617" k="703.698592"/>
+  <Angle type1="c3" type2="n" type3="nd" angle="2.0120155617" k="703.698592"/>
+  <Angle type1="c3" type2="n" type3="oh" angle="1.97169845598" k="700.686112"/>
+  <Angle type1="c3" type2="n" type3="os" angle="1.96419354019" k="701.414128"/>
+  <Angle type1="c3" type2="n" type3="sy" angle="2.10975399981" k="521.393344"/>
+  <Angle type1="ca" type2="n" type3="ca" angle="2.04849294307" k="557.902928"/>
+  <Angle type1="ca" type2="n" type3="cc" angle="1.9898498802" k="572.28752"/>
+  <Angle type1="ca" type2="n" type3="cd" angle="1.9898498802" k="572.28752"/>
+  <Angle type1="ca" type2="n" type3="cl" angle="2.05460159545" k="595.793232"/>
+  <Angle type1="ca" type2="n" type3="f" angle="2.00573237639" k="720.007824"/>
+  <Angle type1="ca" type2="n" type3="hn" angle="2.02458193231" k="401.571952"/>
+  <Angle type1="ca" type2="n" type3="i" angle="2.08217779763" k="501.695072"/>
+  <Angle type1="ca" type2="n" type3="n2" angle="2.12965075328" k="697.489536"/>
+  <Angle type1="ca" type2="n" type3="n4" angle="2.1464059141" k="677.674112"/>
+  <Angle type1="ca" type2="n" type3="n" angle="2.06908782824" k="697.062768"/>
+  <Angle type1="ca" type2="n" type3="na" angle="2.08217779763" k="694.184176"/>
+  <Angle type1="ca" type2="n" type3="nc" angle="2.03330857857" k="713.941024"/>
+  <Angle type1="ca" type2="n" type3="nd" angle="2.03330857857" k="713.941024"/>
+  <Angle type1="ca" type2="n" type3="nh" angle="2.03243591395" k="703.991472"/>
+  <Angle type1="ca" type2="n" type3="p2" angle="1.96035381584" k="695.866144"/>
+  <Angle type1="ca" type2="n" type3="p3" angle="2.18358142717" k="648.762672"/>
+  <Angle type1="ca" type2="n" type3="s4" angle="2.06646983436" k="520.087936"/>
+  <Angle type1="ca" type2="n" type3="s6" angle="2.04762027844" k="533.8784"/>
+  <Angle type1="ca" type2="n" type3="ss" angle="2.03505390783" k="533.828192"/>
+  <Angle type1="c" type2="n" type3="c1" angle="2.04273335653" k="582.086448"/>
+  <Angle type1="c" type2="n" type3="c2" angle="2.13191968131" k="555.852768"/>
+  <Angle type1="c" type2="n" type3="c3" angle="2.10643787423" k="546.028736"/>
+  <Angle type1="c3" type2="nc" type3="cd" angle="1.91131006386" k="585.25792"/>
+  <Angle type1="c" type2="n" type3="c" angle="2.21796441343" k="549.074688"/>
+  <Angle type1="c" type2="n" type3="ca" angle="2.15914681764" k="549.727392"/>
+  <Angle type1="ca" type2="nc" type3="ca" angle="1.91898951257" k="602.178016"/>
+  <Angle type1="ca" type2="nc" type3="cd" angle="1.83050131949" k="624.319744"/>
+  <Angle type1="ca" type2="nc" type3="n" angle="1.82718519391" k="770.44176"/>
+  <Angle type1="ca" type2="nc" type3="na" angle="1.79350033935" k="778.826496"/>
+  <Angle type1="ca" type2="nc" type3="os" angle="1.82352000248" k="759.136592"/>
+  <Angle type1="ca" type2="nc" type3="ss" angle="1.86872403011" k="588.847792"/>
+  <Angle type1="c" type2="n" type3="cc" angle="2.15146736893" k="557.133072"/>
+  <Angle type1="c" type2="nc" type3="ca" angle="2.10591427546" k="567.300192"/>
+  <Angle type1="cc" type2="n" type3="cc" angle="1.90101262127" k="592.312144"/>
+  <Angle type1="cc" type2="nc" type3="cc" angle="1.81095363187" k="611.86816"/>
+  <Angle type1="cc" type2="nc" type3="cd" angle="1.84114782793" k="618.152528"/>
+  <Angle type1="c" type2="nc" type3="cd" angle="2.10294721573" k="574.371152"/>
+  <Angle type1="cc" type2="n" type3="cl" angle="2.05460159545" k="599.081856"/>
+  <Angle type1="cc" type2="nc" type3="na" angle="1.79716553078" k="772.943792"/>
+  <Angle type1="cc" type2="nc" type3="nd" angle="1.89577663352" k="767.613376"/>
+  <Angle type1="c" type2="n" type3="cd" angle="2.15146736893" k="557.133072"/>
+  <Angle type1="cd" type2="nc" type3="cd" angle="2.04727121259" k="598.278528"/>
+  <Angle type1="cd" type2="nc" type3="n" angle="2.04535135041" k="737.212432"/>
+  <Angle type1="cd" type2="nc" type3="na" angle="1.81200082942" k="784.525104"/>
+  <Angle type1="cd" type2="nc" type3="nc" angle="1.8818139995" k="767.144768"/>
+  <Angle type1="cd" type2="nc" type3="os" angle="1.82683612806" k="767.102928"/>
+  <Angle type1="cd" type2="nc" type3="ss" angle="1.88617732263" k="590.010944"/>
+  <Angle type1="c" type2="n" type3="ce" angle="2.29301357127" k="531.008176"/>
+  <Angle type1="cc" type2="n" type3="f" angle="2.00573237639" k="728.14152"/>
+  <Angle type1="cc" type2="n" type3="hn" angle="2.08147966593" k="404.04888"/>
+  <Angle type1="cc" type2="n" type3="i" angle="2.08217779763" k="501.854064"/>
+  <Angle type1="c" type2="n" type3="cl" angle="2.0306905847" k="602.780512"/>
+  <Angle type1="cc" type2="n" type3="n2" angle="1.93504654169" k="740.534528"/>
+  <Angle type1="cc" type2="n" type3="n" angle="2.11830611315" k="696.59416"/>
+  <Angle type1="cc" type2="n" type3="na" angle="2.05198360157" k="707.029056"/>
+  <Angle type1="cc" type2="n" type3="nc" angle="1.95284890006" k="737.279376"/>
+  <Angle type1="cc" type2="n" type3="nh" angle="2.05111093694" k="708.627344"/>
+  <Angle type1="cc" type2="n" type3="no" angle="2.02318566891" k="698.912096"/>
+  <Angle type1="cc" type2="n" type3="o" angle="2.10381988035" k="737.990656"/>
+  <Angle type1="cc" type2="n" type3="oh" angle="2.08217779763" k="702.11704"/>
+  <Angle type1="cc" type2="n" type3="os" angle="2.0169024836" k="712.677456"/>
+  <Angle type1="cc" type2="n" type3="p2" angle="1.96035381584" k="699.531328"/>
+  <Angle type1="cc" type2="n" type3="p3" angle="2.18358142717" k="651.800256"/>
+  <Angle type1="cc" type2="n" type3="p5" angle="2.11184839491" k="678.803792"/>
+  <Angle type1="cc" type2="n" type3="s4" angle="2.06646983436" k="522.548128"/>
+  <Angle type1="cc" type2="n" type3="s6" angle="2.04762027844" k="536.8072"/>
+  <Angle type1="cc" type2="n" type3="s" angle="2.06454997218" k="523.050208"/>
+  <Angle type1="cc" type2="n" type3="sh" angle="2.0792107379" k="530.472624"/>
+  <Angle type1="cc" type2="n" type3="ss" angle="2.03505390783" k="536.698416"/>
+  <Angle type1="c" type2="n" type3="cx" angle="2.13052341791" k="547.216992"/>
+  <Angle type1="c" type2="n" type3="cy" angle="1.64444922123" k="616.094"/>
+  <Angle type1="cd" type2="n" type3="cd" angle="1.90101262127" k="592.312144"/>
+  <Angle type1="cd" type2="n" type3="cl" angle="2.05460159545" k="599.081856"/>
+  <Angle type1="cd" type2="n" type3="f" angle="2.00573237639" k="728.14152"/>
+  <Angle type1="cd" type2="n" type3="hn" angle="2.08147966593" k="404.04888"/>
+  <Angle type1="cd" type2="n" type3="i" angle="2.08217779763" k="501.854064"/>
+  <Angle type1="cd" type2="n" type3="n2" angle="1.93504654169" k="740.534528"/>
+  <Angle type1="cd" type2="n" type3="n" angle="2.11830611315" k="696.59416"/>
+  <Angle type1="cd" type2="n" type3="na" angle="2.05198360157" k="707.029056"/>
+  <Angle type1="cd" type2="n" type3="nd" angle="1.95284890006" k="737.279376"/>
+  <Angle type1="cd" type2="n" type3="nh" angle="2.05111093694" k="708.627344"/>
+  <Angle type1="cd" type2="n" type3="no" angle="2.02318566891" k="698.912096"/>
+  <Angle type1="cd" type2="n" type3="o" angle="2.10381988035" k="737.990656"/>
+  <Angle type1="cd" type2="n" type3="oh" angle="2.08217779763" k="702.11704"/>
+  <Angle type1="cd" type2="n" type3="os" angle="2.0169024836" k="712.677456"/>
+  <Angle type1="cd" type2="n" type3="p2" angle="1.96035381584" k="699.531328"/>
+  <Angle type1="cd" type2="n" type3="p3" angle="2.18358142717" k="651.800256"/>
+  <Angle type1="cd" type2="n" type3="p5" angle="2.11184839491" k="678.803792"/>
+  <Angle type1="cd" type2="n" type3="s4" angle="2.06646983436" k="522.548128"/>
+  <Angle type1="cd" type2="n" type3="s6" angle="2.04762027844" k="536.8072"/>
+  <Angle type1="cd" type2="n" type3="s" angle="2.06454997218" k="523.050208"/>
+  <Angle type1="cd" type2="n" type3="sh" angle="2.0792107379" k="530.472624"/>
+  <Angle type1="cd" type2="n" type3="ss" angle="2.03505390783" k="536.698416"/>
+  <Angle type1="ce" type2="n" type3="cy" angle="1.9497073074" k="557.81088"/>
+  <Angle type1="c" type2="n" type3="f" angle="1.89595116644" k="749.39624"/>
+  <Angle type1="cf" type2="n" type3="cy" angle="1.9497073074" k="557.81088"/>
+  <Angle type1="c" type2="n" type3="hn" angle="2.05163453572" k="407.446288"/>
+  <Angle type1="c" type2="n" type3="i" angle="2.10102735355" k="499.594704"/>
+  <Angle type1="cl" type2="n" type3="cl" angle="1.94935824155" k="685.832912"/>
+  <Angle type1="c" type2="n" type3="n2" angle="2.09282430607" k="712.551936"/>
+  <Angle type1="c" type2="n" type3="n3" angle="2.09614043165" k="700.73632"/>
+  <Angle type1="c" type2="n" type3="n4" angle="1.96035381584" k="717.037184"/>
+  <Angle type1="c" type2="n" type3="n" angle="2.06681890021" k="705.656704"/>
+  <Angle type1="c" type2="n" type3="na" angle="1.94604211597" k="726.46792"/>
+  <Angle type1="na" type2="nc" type3="nd" angle="1.85423779732" k="977.399136"/>
+  <Angle type1="c" type2="n" type3="nc" angle="2.17921810404" k="698.410016"/>
+  <Angle type1="nc" type2="nc" type3="nd" angle="1.94534398427" k="950.805632"/>
+  <Angle type1="c" type2="n" type3="nd" angle="2.17921810404" k="698.410016"/>
+  <Angle type1="nd" type2="nc" type3="os" angle="1.87134202399" k="954.654912"/>
+  <Angle type1="c" type2="n" type3="nh" angle="2.07188035504" k="705.50608"/>
+  <Angle type1="c" type2="n" type3="no" angle="2.06228104416" k="692.644464"/>
+  <Angle type1="c" type2="n" type3="o" angle="2.06577170266" k="745.371232"/>
+  <Angle type1="c" type2="n" type3="oh" angle="2.01602981898" k="713.991232"/>
+  <Angle type1="c" type2="n" type3="os" angle="1.97466551571" k="720.702368"/>
+  <Angle type1="c" type2="n" type3="p2" angle="2.17398211628" k="664.46104"/>
+  <Angle type1="c" type2="n" type3="p3" angle="2.13872646539" k="658.7708"/>
+  <Angle type1="c" type2="n" type3="p4" angle="2.15443442866" k="667.163904"/>
+  <Angle type1="c" type2="n" type3="p5" angle="2.24274808881" k="658.887952"/>
+  <Angle type1="c" type2="n" type3="pc" angle="2.13331594471" k="668.64504"/>
+  <Angle type1="c" type2="n" type3="pd" angle="2.13331594471" k="668.64504"/>
+  <Angle type1="c" type2="n" type3="s4" angle="2.10155095233" k="518.297184"/>
+  <Angle type1="c" type2="n" type3="s6" angle="2.17747277479" k="520.707168"/>
+  <Angle type1="c" type2="n" type3="s" angle="2.2087141684" k="505.820496"/>
+  <Angle type1="c" type2="n" type3="sh" angle="2.08636658783" k="529.711136"/>
+  <Angle type1="c" type2="n" type3="ss" angle="2.1242402326" k="525.46856"/>
+  <Angle type1="c" type2="n" type3="sy" angle="2.17625104431" k="521.393344"/>
+  <Angle type1="cx" type2="n" type3="hn" angle="2.06821516361" k="389.848384"/>
+  <Angle type1="cx" type2="n" type3="os" angle="0.943175927778" k="1019.799792"/>
+  <Angle type1="cy" type2="n" type3="hn" angle="2.07886167205" k="381.907152"/>
+  <Angle type1="c3" type2="nd" type3="cc" angle="1.91131006386" k="585.25792"/>
+  <Angle type1="ca" type2="nd" type3="ca" angle="1.91898951257" k="602.178016"/>
+  <Angle type1="ca" type2="nd" type3="cc" angle="1.83050131949" k="624.319744"/>
+  <Angle type1="ca" type2="nd" type3="n" angle="1.82718519391" k="770.44176"/>
+  <Angle type1="ca" type2="nd" type3="na" angle="1.79350033935" k="779.320208"/>
+  <Angle type1="ca" type2="nd" type3="nc" angle="1.89088971161" k="774.20736"/>
+  <Angle type1="ca" type2="nd" type3="os" angle="1.82352000248" k="759.136592"/>
+  <Angle type1="ca" type2="nd" type3="ss" angle="1.86872403011" k="588.847792"/>
+  <Angle type1="c" type2="nd" type3="ca" angle="2.10591427546" k="567.300192"/>
+  <Angle type1="c" type2="nd" type3="cc" angle="2.10294721573" k="574.371152"/>
+  <Angle type1="cc" type2="nd" type3="cc" angle="2.04727121259" k="598.278528"/>
+  <Angle type1="cc" type2="nd" type3="cd" angle="1.84114782793" k="618.152528"/>
+  <Angle type1="cc" type2="nd" type3="n" angle="2.04535135041" k="737.212432"/>
+  <Angle type1="cc" type2="nd" type3="na" angle="1.81200082942" k="785.04392"/>
+  <Angle type1="cc" type2="nd" type3="nd" angle="1.8818139995" k="767.144768"/>
+  <Angle type1="cc" type2="nd" type3="os" angle="1.82683612806" k="767.102928"/>
+  <Angle type1="cc" type2="nd" type3="ss" angle="1.88617732263" k="590.010944"/>
+  <Angle type1="cd" type2="nd" type3="cd" angle="1.81095363187" k="611.86816"/>
+  <Angle type1="cd" type2="nd" type3="na" angle="1.79716553078" k="773.420768"/>
+  <Angle type1="cd" type2="nd" type3="nc" angle="1.89577663352" k="767.613376"/>
+  <Angle type1="na" type2="nd" type3="nc" angle="1.85423779732" k="978.076944"/>
+  <Angle type1="nc" type2="nd" type3="nd" angle="1.94534398427" k="950.805632"/>
+  <Angle type1="nc" type2="nd" type3="os" angle="1.87134202399" k="954.654912"/>
+  <Angle type1="c1" type2="ne" type3="ca" angle="2.65202779841" k="523.987424"/>
+  <Angle type1="c1" type2="ne" type3="cg" angle="2.44346095279" k="567.860848"/>
+  <Angle type1="c2" type2="ne" type3="ca" angle="2.10888133518" k="573.141056"/>
+  <Angle type1="c2" type2="ne" type3="ce" angle="2.02475646524" k="588.379184"/>
+  <Angle type1="c2" type2="ne" type3="cg" angle="2.15076923723" k="587.249504"/>
+  <Angle type1="c2" type2="ne" type3="n2" angle="1.97763257543" k="783.437264"/>
+  <Angle type1="c2" type2="ne" type3="ne" angle="1.93487200876" k="744.66832"/>
+  <Angle type1="c2" type2="ne" type3="p2" angle="2.33926479645" k="703.79064"/>
+  <Angle type1="c2" type2="ne" type3="pe" angle="2.1034708145" k="690.636144"/>
+  <Angle type1="c2" type2="ne" type3="px" angle="2.05512519422" k="702.15888"/>
+  <Angle type1="c2" type2="ne" type3="py" angle="2.04273335653" k="738.30864"/>
+  <Angle type1="c2" type2="ne" type3="sx" angle="1.95441969638" k="524.271936"/>
+  <Angle type1="c2" type2="ne" type3="sy" angle="2.10486707791" k="548.56424"/>
+  <Angle type1="ca" type2="ne" type3="cf" angle="2.1242402326" k="570.212256"/>
+  <Angle type1="ca" type2="ne" type3="n2" angle="1.99578399966" k="742.216496"/>
+  <Angle type1="ca" type2="ne" type3="nf" angle="2.01009569952" k="741.337856"/>
+  <Angle type1="ca" type2="ne" type3="o" angle="2.01917141163" k="746.4256"/>
+  <Angle type1="ca" type2="ne" type3="p2" angle="2.06105931368" k="729.572448"/>
+  <Angle type1="ca" type2="ne" type3="s" angle="2.09631496457" k="569.593024"/>
+  <Angle type1="c" type2="ne" type3="c2" angle="2.06873876239" k="582.91488"/>
+  <Angle type1="ce" type2="ne" type3="n2" angle="1.94063159529" k="757.278896"/>
+  <Angle type1="ce" type2="ne" type3="o" angle="1.95756128904" k="762.99424"/>
+  <Angle type1="ce" type2="ne" type3="p2" angle="2.04238429068" k="735.513728"/>
+  <Angle type1="ce" type2="ne" type3="s" angle="2.02946885422" k="581.07392"/>
+  <Angle type1="cg" type2="ne" type3="n1" angle="2.0978857609" k="755.011168"/>
+  <Angle type1="cg" type2="ne" type3="n2" angle="1.97902883884" k="772.140464"/>
+  <Angle type1="cg" type2="ne" type3="o" angle="2.00189265204" k="778.458304"/>
+  <Angle type1="cg" type2="ne" type3="p2" angle="2.08689018661" k="739.630784"/>
+  <Angle type1="cg" type2="ne" type3="s" angle="2.0542525296" k="587.701376"/>
+  <Angle type1="c" type2="ne" type3="sy" angle="2.0320868481" k="548.974272"/>
+  <Angle type1="n2" type2="ne" type3="n2" angle="1.87134202399" k="1016.636688"/>
+  <Angle type1="n2" type2="ne" type3="ne" angle="1.93242854781" k="938.529776"/>
+  <Angle type1="n2" type2="ne" type3="o" angle="1.99142067653" k="1001.013632"/>
+  <Angle type1="n2" type2="ne" type3="p2" angle="1.91392805774" k="978.235936"/>
+  <Angle type1="n2" type2="ne" type3="pe" angle="1.95738675611" k="898.606048"/>
+  <Angle type1="n2" type2="ne" type3="px" angle="2.02405833354" k="888.13768"/>
+  <Angle type1="n2" type2="ne" type3="py" angle="2.00014732279" k="937.600928"/>
+  <Angle type1="n2" type2="ne" type3="s" angle="2.02283660306" k="750.785328"/>
+  <Angle type1="n2" type2="ne" type3="sx" angle="1.87256375446" k="671.40648"/>
+  <Angle type1="n2" type2="ne" type3="sy" angle="1.94098066114" k="717.313328"/>
+  <Angle type1="ne" type2="ne" type3="o" angle="1.92771615883" k="950.136192"/>
+  <Angle type1="ne" type2="ne" type3="p2" angle="1.99648213136" k="924.74768"/>
+  <Angle type1="ne" type2="ne" type3="s" angle="2.02370926769" k="723.045408"/>
+  <Angle type1="o" type2="ne" type3="o" angle="2.1657790688" k="976.261088"/>
+  <Angle type1="o" type2="ne" type3="pe" angle="2.30941966624" k="830.48216"/>
+  <Angle type1="o" type2="ne" type3="px" angle="1.93068321856" k="913.07432"/>
+  <Angle type1="o" type2="ne" type3="py" angle="1.93365027828" k="959.625504"/>
+  <Angle type1="o" type2="ne" type3="s" angle="2.04535135041" k="752.626288"/>
+  <Angle type1="o" type2="ne" type3="sx" angle="1.90101262127" k="667.197376"/>
+  <Angle type1="o" type2="ne" type3="sy" angle="1.94324958917" k="720.300704"/>
+  <Angle type1="p2" type2="ne" type3="pe" angle="2.03871909925" k="924.438064"/>
+  <Angle type1="p2" type2="ne" type3="px" angle="2.24013009493" k="885.058256"/>
+  <Angle type1="p2" type2="ne" type3="py" angle="2.15495802744" k="933.090576"/>
+  <Angle type1="p2" type2="ne" type3="sx" angle="1.95686315734" k="701.715376"/>
+  <Angle type1="p2" type2="ne" type3="sy" angle="2.01986954333" k="733.940544"/>
+  <Angle type1="pe" type2="ne" type3="s" angle="2.01986954333" k="728.275408"/>
+  <Angle type1="px" type2="ne" type3="s" angle="2.30104208583" k="684.862224"/>
+  <Angle type1="py" type2="ne" type3="s" angle="2.02772352497" k="755.312416"/>
+  <Angle type1="s" type2="ne" type3="s" angle="2.10957946689" k="590.32056"/>
+  <Angle type1="s" type2="ne" type3="sx" angle="1.97152392305" k="547.401088"/>
+  <Angle type1="s" type2="ne" type3="sy" angle="2.08793738416" k="566.337872"/>
+  <Angle type1="c1" type2="nf" type3="ca" angle="2.65202779841" k="523.987424"/>
+  <Angle type1="c1" type2="nf" type3="ch" angle="2.44346095279" k="567.860848"/>
+  <Angle type1="c2" type2="nf" type3="ca" angle="2.10888133518" k="573.141056"/>
+  <Angle type1="c2" type2="nf" type3="cf" angle="2.02475646524" k="588.379184"/>
+  <Angle type1="c2" type2="nf" type3="n2" angle="1.97763257543" k="783.437264"/>
+  <Angle type1="c2" type2="nf" type3="nf" angle="1.93487200876" k="744.66832"/>
+  <Angle type1="c2" type2="nf" type3="p2" angle="2.33926479645" k="703.79064"/>
+  <Angle type1="c2" type2="nf" type3="pf" angle="2.1034708145" k="690.636144"/>
+  <Angle type1="c2" type2="nf" type3="px" angle="2.05512519422" k="702.15888"/>
+  <Angle type1="c2" type2="nf" type3="py" angle="2.04273335653" k="738.30864"/>
+  <Angle type1="c2" type2="nf" type3="sx" angle="1.95441969638" k="524.271936"/>
+  <Angle type1="c2" type2="nf" type3="sy" angle="2.10486707791" k="548.56424"/>
+  <Angle type1="ca" type2="nf" type3="ce" angle="2.1242402326" k="570.212256"/>
+  <Angle type1="ca" type2="nf" type3="n2" angle="1.99578399966" k="742.216496"/>
+  <Angle type1="ca" type2="nf" type3="ne" angle="2.01009569952" k="741.337856"/>
+  <Angle type1="ca" type2="nf" type3="o" angle="2.01917141163" k="746.4256"/>
+  <Angle type1="ca" type2="nf" type3="p2" angle="2.06105931368" k="729.572448"/>
+  <Angle type1="ca" type2="nf" type3="s" angle="2.09631496457" k="569.593024"/>
+  <Angle type1="c" type2="nf" type3="c2" angle="2.06873876239" k="582.91488"/>
+  <Angle type1="cf" type2="nf" type3="n2" angle="1.94063159529" k="757.278896"/>
+  <Angle type1="cf" type2="nf" type3="o" angle="1.95756128904" k="762.99424"/>
+  <Angle type1="cf" type2="nf" type3="p2" angle="2.04238429068" k="735.513728"/>
+  <Angle type1="cf" type2="nf" type3="s" angle="2.02946885422" k="581.07392"/>
+  <Angle type1="ch" type2="nf" type3="n1" angle="2.0978857609" k="755.011168"/>
+  <Angle type1="ch" type2="nf" type3="n2" angle="1.97902883884" k="772.140464"/>
+  <Angle type1="ch" type2="nf" type3="o" angle="2.00189265204" k="778.458304"/>
+  <Angle type1="ch" type2="nf" type3="p2" angle="2.08689018661" k="739.630784"/>
+  <Angle type1="ch" type2="nf" type3="s" angle="2.0542525296" k="587.701376"/>
+  <Angle type1="f" type2="n" type3="f" angle="1.7973400637" k="971.457856"/>
+  <Angle type1="n2" type2="nf" type3="n2" angle="1.87134202399" k="1016.636688"/>
+  <Angle type1="n2" type2="nf" type3="nf" angle="1.93242854781" k="938.529776"/>
+  <Angle type1="n2" type2="nf" type3="o" angle="1.99142067653" k="1001.013632"/>
+  <Angle type1="n2" type2="nf" type3="p2" angle="1.91392805774" k="978.235936"/>
+  <Angle type1="n2" type2="nf" type3="pf" angle="1.95738675611" k="898.606048"/>
+  <Angle type1="n2" type2="nf" type3="px" angle="2.02405833354" k="888.13768"/>
+  <Angle type1="n2" type2="nf" type3="py" angle="2.00014732279" k="937.600928"/>
+  <Angle type1="n2" type2="nf" type3="s" angle="2.02283660306" k="750.785328"/>
+  <Angle type1="n2" type2="nf" type3="sx" angle="1.87256375446" k="671.40648"/>
+  <Angle type1="n2" type2="nf" type3="sy" angle="1.94098066114" k="717.313328"/>
+  <Angle type1="nf" type2="nf" type3="o" angle="1.92771615883" k="950.136192"/>
+  <Angle type1="nf" type2="nf" type3="p2" angle="1.99648213136" k="924.74768"/>
+  <Angle type1="nf" type2="nf" type3="s" angle="2.02370926769" k="723.045408"/>
+  <Angle type1="o" type2="nf" type3="o" angle="2.1657790688" k="976.261088"/>
+  <Angle type1="o" type2="nf" type3="pf" angle="2.30941966624" k="830.48216"/>
+  <Angle type1="o" type2="nf" type3="px" angle="1.93068321856" k="913.07432"/>
+  <Angle type1="o" type2="nf" type3="py" angle="1.93365027828" k="959.625504"/>
+  <Angle type1="o" type2="nf" type3="s" angle="2.04535135041" k="752.626288"/>
+  <Angle type1="o" type2="nf" type3="sx" angle="1.90101262127" k="667.197376"/>
+  <Angle type1="o" type2="nf" type3="sy" angle="1.94324958917" k="720.300704"/>
+  <Angle type1="p2" type2="nf" type3="pf" angle="2.03871909925" k="924.438064"/>
+  <Angle type1="p2" type2="nf" type3="px" angle="2.24013009493" k="885.058256"/>
+  <Angle type1="p2" type2="nf" type3="py" angle="2.15495802744" k="933.090576"/>
+  <Angle type1="p2" type2="nf" type3="sx" angle="1.95686315734" k="701.715376"/>
+  <Angle type1="p2" type2="nf" type3="sy" angle="2.01986954333" k="733.940544"/>
+  <Angle type1="pf" type2="nf" type3="s" angle="2.01986954333" k="728.275408"/>
+  <Angle type1="px" type2="nf" type3="s" angle="2.30104208583" k="684.862224"/>
+  <Angle type1="py" type2="nf" type3="s" angle="2.02772352497" k="755.312416"/>
+  <Angle type1="s" type2="nf" type3="s" angle="2.10957946689" k="590.32056"/>
+  <Angle type1="s" type2="nf" type3="sx" angle="1.97152392305" k="547.401088"/>
+  <Angle type1="s" type2="nf" type3="sy" angle="2.08793738416" k="566.337872"/>
+  <Angle type1="br" type2="nh" type3="br" angle="1.85476139609" k="566.337872"/>
+  <Angle type1="br" type2="nh" type3="ca" angle="1.95267436713" k="528.338784"/>
+  <Angle type1="br" type2="nh" type3="hn" angle="1.77255638833" k="351.338848"/>
+  <Angle type1="c1" type2="nh" type3="c1" angle="2.04168615898" k="587.89384"/>
+  <Angle type1="c1" type2="nh" type3="c2" angle="2.15286363234" k="562.78984"/>
+  <Angle type1="c1" type2="nh" type3="ca" angle="2.13558487274" k="565.350448"/>
+  <Angle type1="c1" type2="nh" type3="hn" angle="2.04901654184" k="417.295424"/>
+  <Angle type1="c2" type2="nh" type3="c2" angle="2.17694917601" k="550.90728"/>
+  <Angle type1="c2" type2="nh" type3="c3" angle="2.15914681764" k="537.493376"/>
+  <Angle type1="c2" type2="nh" type3="ca" angle="2.22634199384" k="545.016208"/>
+  <Angle type1="c2" type2="nh" type3="cc" angle="2.20522350989" k="550.053744"/>
+  <Angle type1="c2" type2="nh" type3="cd" angle="2.20522350989" k="550.053744"/>
+  <Angle type1="c2" type2="nh" type3="cx" angle="2.17031692485" k="538.054032"/>
+  <Angle type1="c2" type2="nh" type3="hn" angle="2.00869943612" k="409.647072"/>
+  <Angle type1="c2" type2="nh" type3="n2" angle="2.09823482675" k="711.388784"/>
+  <Angle type1="c2" type2="nh" type3="n3" angle="2.03976629681" k="705.330352"/>
+  <Angle type1="c2" type2="nh" type3="no" angle="2.19248260636" k="687.623664"/>
+  <Angle type1="c2" type2="nh" type3="oh" angle="1.95791035489" k="719.765152"/>
+  <Angle type1="c2" type2="nh" type3="os" angle="1.97134939013" k="717.547632"/>
+  <Angle type1="c2" type2="nh" type3="sy" angle="2.11411732294" k="528.77392"/>
+  <Angle type1="c3" type2="nh" type3="c3" angle="1.99857652646" k="544.807008"/>
+  <Angle type1="c3" type2="nh" type3="ca" angle="2.09404603654" k="546.003632"/>
+  <Angle type1="c3" type2="nh" type3="cc" angle="2.08950818049" k="548.698128"/>
+  <Angle type1="c3" type2="nh" type3="cd" angle="2.08950818049" k="548.698128"/>
+  <Angle type1="c3" type2="nh" type3="cf" angle="2.0964894975" k="544.974368"/>
+  <Angle type1="c3" type2="nh" type3="cz" angle="2.18969007955" k="541.543488"/>
+  <Angle type1="c3" type2="nh" type3="hn" angle="2.02440739939" k="388.450928"/>
+  <Angle type1="c3" type2="nh" type3="n2" angle="1.96087741462" k="713.807136"/>
+  <Angle type1="c3" type2="nh" type3="n" angle="1.94202785869" k="706.493504"/>
+  <Angle type1="c3" type2="nh" type3="na" angle="1.96157554632" k="703.322032"/>
+  <Angle type1="c3" type2="nh" type3="p2" angle="2.15286363234" k="672.126128"/>
+  <Angle type1="c3" type2="nh" type3="sy" angle="2.03016698592" k="531.761296"/>
+  <Angle type1="ca" type2="nh" type3="ca" angle="2.22459666459" k="545.484816"/>
+  <Angle type1="ca" type2="nh" type3="cc" angle="2.26543736909" k="542.95768"/>
+  <Angle type1="ca" type2="nh" type3="cd" angle="2.26543736909" k="542.95768"/>
+  <Angle type1="ca" type2="nh" type3="cl" angle="1.97484004863" k="597.818288"/>
+  <Angle type1="ca" type2="nh" type3="cx" angle="2.15897228472" k="539.69416"/>
+  <Angle type1="ca" type2="nh" type3="f" angle="1.85161980344" k="748.366976"/>
+  <Angle type1="ca" type2="nh" type3="hn" angle="2.02580366279" k="408.249616"/>
+  <Angle type1="ca" type2="nh" type3="i" angle="2.05652145762" k="492.666"/>
+  <Angle type1="ca" type2="nh" type3="n1" angle="2.04430415286" k="724.158352"/>
+  <Angle type1="ca" type2="nh" type3="n2" angle="2.11411732294" k="709.070848"/>
+  <Angle type1="ca" type2="nh" type3="n3" angle="2.05652145762" k="702.761376"/>
+  <Angle type1="ca" type2="nh" type3="n4" angle="1.90136168712" k="716.986976"/>
+  <Angle type1="ca" type2="nh" type3="n" angle="2.02510553109" k="711.86576"/>
+  <Angle type1="ca" type2="nh" type3="na" angle="2.02388380061" k="712.49336"/>
+  <Angle type1="ca" type2="nh" type3="nh" angle="2.00433611299" k="715.388688"/>
+  <Angle type1="ca" type2="nh" type3="no" angle="1.98827908387" k="722.40944"/>
+  <Angle type1="ca" type2="nh" type3="o" angle="2.12790542403" k="727.748224"/>
+  <Angle type1="ca" type2="nh" type3="oh" angle="1.97169845598" k="717.564368"/>
+  <Angle type1="ca" type2="nh" type3="os" angle="1.95215076836" k="721.388544"/>
+  <Angle type1="ca" type2="nh" type3="p2" angle="2.18637395397" k="677.874944"/>
+  <Angle type1="ca" type2="nh" type3="p3" angle="2.19387886976" k="661.590816"/>
+  <Angle type1="ca" type2="nh" type3="p4" angle="2.1643828054" k="673.239072"/>
+  <Angle type1="ca" type2="nh" type3="p5" angle="2.23698850228" k="672.511056"/>
+  <Angle type1="ca" type2="nh" type3="s4" angle="2.01794968116" k="532.966288"/>
+  <Angle type1="ca" type2="nh" type3="s6" angle="2.14413698608" k="529.058432"/>
+  <Angle type1="ca" type2="nh" type3="s" angle="2.13872646539" k="509.577728"/>
+  <Angle type1="ca" type2="nh" type3="sh" angle="2.11900424485" k="529.719504"/>
+  <Angle type1="ca" type2="nh" type3="ss" angle="2.12057504117" k="529.259264"/>
+  <Angle type1="ca" type2="nh" type3="sy" angle="2.18567582227" k="520.163248"/>
+  <Angle type1="cc" type2="nh" type3="cx" angle="2.15897228472" k="541.802896"/>
+  <Angle type1="cc" type2="nh" type3="hn" angle="2.01812421408" k="412.266256"/>
+  <Angle type1="cc" type2="nh" type3="n2" angle="2.09596589872" k="715.497472"/>
+  <Angle type1="cc" type2="nh" type3="sy" angle="2.13837739954" k="526.983168"/>
+  <Angle type1="cd" type2="nh" type3="cx" angle="2.15897228472" k="541.802896"/>
+  <Angle type1="cd" type2="nh" type3="hn" angle="2.01812421408" k="412.266256"/>
+  <Angle type1="ce" type2="nh" type3="hn" angle="2.01899687871" k="407.847952"/>
+  <Angle type1="ce" type2="nh" type3="o" angle="2.25897965086" k="704.995632"/>
+  <Angle type1="ce" type2="nh" type3="sy" angle="1.97902883884" k="546.254672"/>
+  <Angle type1="cf" type2="nh" type3="hn" angle="2.01899687871" k="407.847952"/>
+  <Angle type1="cf" type2="nh" type3="o" angle="2.25897965086" k="704.995632"/>
+  <Angle type1="cl" type2="nh" type3="cl" angle="1.86052098263" k="683.339248"/>
+  <Angle type1="cl" type2="nh" type3="hn" angle="1.81758588303" k="407.705696"/>
+  <Angle type1="cx" type2="nh" type3="cx" angle="1.08227866916" k="745.12856"/>
+  <Angle type1="cx" type2="nh" type3="hn" angle="2.07484741477" k="386.032576"/>
+  <Angle type1="cz" type2="nh" type3="hn" angle="2.11446638879" k="411.638656"/>
+  <Angle type1="f" type2="nh" type3="f" angle="1.77499984928" k="957.667392"/>
+  <Angle type1="f" type2="nh" type3="hn" angle="1.76679680179" k="541.250608"/>
+  <Angle type1="hn" type2="nh" type3="hn" angle="2.0092230349" k="330.694992"/>
+  <Angle type1="hn" type2="nh" type3="i" angle="1.87745067637" k="316.921264"/>
+  <Angle type1="hn" type2="nh" type3="n1" angle="1.92981055393" k="539.23392"/>
+  <Angle type1="hn" type2="nh" type3="n2" angle="2.06193197831" k="517.611008"/>
+  <Angle type1="hn" type2="nh" type3="n3" angle="1.9891517485" k="506.230528"/>
+  <Angle type1="hn" type2="nh" type3="n4" angle="1.82212373908" k="512.063024"/>
+  <Angle type1="hn" type2="nh" type3="n" angle="1.88792265188" k="524.29704"/>
+  <Angle type1="hn" type2="nh" type3="na" angle="1.88914438236" k="524.665232"/>
+  <Angle type1="hn" type2="nh" type3="nh" angle="1.93487200876" k="517.703056"/>
+  <Angle type1="hn" type2="nh" type3="no" angle="1.91881497964" k="525.125472"/>
+  <Angle type1="hn" type2="nh" type3="o" angle="2.03243591395" k="551.258736"/>
+  <Angle type1="hn" type2="nh" type3="oh" angle="1.85860112045" k="523.510448"/>
+  <Angle type1="hn" type2="nh" type3="os" angle="1.85127073759" k="524.849328"/>
+  <Angle type1="hn" type2="nh" type3="p2" angle="2.06263011001" k="464.407264"/>
+  <Angle type1="hn" type2="nh" type3="p3" angle="2.02789805789" k="453.143936"/>
+  <Angle type1="hn" type2="nh" type3="p4" angle="1.96524073775" k="467.52016"/>
+  <Angle type1="hn" type2="nh" type3="p5" angle="2.00869943612" k="473.04304"/>
+  <Angle type1="hn" type2="nh" type3="s4" angle="1.87587988004" k="362.652384"/>
+  <Angle type1="hn" type2="nh" type3="s" angle="1.99613306551" k="343.7156"/>
+  <Angle type1="hn" type2="nh" type3="s6" angle="1.91846591379" k="370.752608"/>
+  <Angle type1="hn" type2="nh" type3="sh" angle="1.95913208536" k="364.392928"/>
+  <Angle type1="hn" type2="nh" type3="ss" angle="1.99142067653" k="361.171248"/>
+  <Angle type1="hn" type2="nh" type3="sy" angle="1.93574467339" k="365.146048"/>
+  <Angle type1="i" type2="nh" type3="i" angle="2.02144033966" k="545.627072"/>
+  <Angle type1="n1" type2="nh" type3="n1" angle="1.8624408448" k="966.897296"/>
+  <Angle type1="n2" type2="nh" type3="n2" angle="2.05076187109" k="912.982272"/>
+  <Angle type1="n2" type2="nh" type3="n3" angle="2.07798900742" k="885.351136"/>
+  <Angle type1="n2" type2="nh" type3="o" angle="2.20016205506" k="909.501184"/>
+  <Angle type1="n3" type2="nh" type3="n3" angle="1.93696640386" k="897.476368"/>
+  <Angle type1="n4" type2="nh" type3="n4" angle="1.89123877746" k="877.041712"/>
+  <Angle type1="na" type2="nh" type3="na" angle="1.95494329516" k="903.300496"/>
+  <Angle type1="hn" type2="n" type3="hn" angle="2.05861585273" k="326.444048"/>
+  <Angle type1="nh" type2="nh" type3="nh" angle="1.95878301951" k="900.999296"/>
+  <Angle type1="hn" type2="n" type3="i" angle="2.04622401504" k="313.440176"/>
+  <Angle type1="hn" type2="n" type3="n2" angle="2.07833807327" k="512.908192"/>
+  <Angle type1="hn" type2="n" type3="n3" angle="2.04622401504" k="502.732704"/>
+  <Angle type1="hn" type2="n" type3="n4" angle="1.96663700115" k="503.761968"/>
+  <Angle type1="hn" type2="n" type3="n" angle="1.97571271326" k="511.594416"/>
+  <Angle type1="hn" type2="n" type3="na" angle="1.99578399966" k="508.10496"/>
+  <Angle type1="hn" type2="n" type3="nc" angle="2.01445902265" k="521.142304"/>
+  <Angle type1="hn" type2="n" type3="nh" angle="1.97588724618" k="512.45632"/>
+  <Angle type1="hn" type2="n" type3="no" angle="1.92178203937" k="501.812224"/>
+  <Angle type1="hn" type2="n" type3="o" angle="2.03016698592" k="558.153968"/>
+  <Angle type1="n" type2="nh" type3="o" angle="2.01812421408" k="929.232928"/>
+  <Angle type1="hn" type2="n" type3="oh" angle="1.93277761366" k="516.615216"/>
+  <Angle type1="no" type2="nh" type3="no" angle="1.89455490304" k="926.580272"/>
+  <Angle type1="hn" type2="n" type3="os" angle="1.92003671012" k="517.43528"/>
+  <Angle type1="hn" type2="n" type3="p2" angle="2.06036118198" k="448.734"/>
+  <Angle type1="hn" type2="n" type3="p3" angle="2.08793738416" k="435.244784"/>
+  <Angle type1="hn" type2="n" type3="p4" angle="2.01952047748" k="452.951472"/>
+  <Angle type1="hn" type2="n" type3="p5" angle="1.98286856319" k="462.139536"/>
+  <Angle type1="hn" type2="n" type3="s4" angle="1.96279727679" k="350.225904"/>
+  <Angle type1="hn" type2="n" type3="s" angle="2.00573237639" k="346.702976"/>
+  <Angle type1="hn" type2="n" type3="s6" angle="1.96454260604" k="361.439024"/>
+  <Angle type1="hn" type2="n" type3="sh" angle="2.00555784347" k="355.55632"/>
+  <Angle type1="hn" type2="n" type3="ss" angle="2.01760061531" k="354.97056"/>
+  <Angle type1="hn" type2="n" type3="sy" angle="1.96052834877" k="362.342768"/>
+  <Angle type1="oh" type2="nh" type3="oh" angle="1.85476139609" k="916.764608"/>
+  <Angle type1="o" type2="nh" type3="o" angle="2.2350686401" k="936.580032"/>
+  <Angle type1="os" type2="nh" type3="os" angle="1.83730810357" k="921.69336"/>
+  <Angle type1="p2" type2="nh" type3="p2" angle="2.22232773656" k="867.125632"/>
+  <Angle type1="p3" type2="nh" type3="p3" angle="2.18305782839" k="849.10096"/>
+  <Angle type1="p5" type2="nh" type3="p5" angle="1.96803326455" k="925.860624"/>
+  <Angle type1="s4" type2="nh" type3="s4" angle="1.96157554632" k="537.97872"/>
+  <Angle type1="s6" type2="nh" type3="s6" angle="2.09910749137" k="535.836512"/>
+  <Angle type1="sh" type2="nh" type3="sh" angle="2.07694180987" k="535.376272"/>
+  <Angle type1="s" type2="nh" type3="s" angle="2.07222942089" k="513.150864"/>
+  <Angle type1="ss" type2="nh" type3="ss" angle="2.081305133" k="534.472528"/>
+  <Angle type1="i" type2="n" type3="i" angle="2.06297917586" k="553.492992"/>
+  <Angle type1="n2" type2="n" type3="n2" angle="2.04011536266" k="909.97816"/>
+  <Angle type1="n3" type2="n" type3="n3" angle="2.0584413198" k="877.660944"/>
+  <Angle type1="n4" type2="n" type3="n4" angle="1.96681153407" k="880.43912"/>
+  <Angle type1="na" type2="n" type3="na" angle="2.04866747599" k="877.937088"/>
+  <Angle type1="nc" type2="n" type3="nc" angle="2.03173778225" k="912.187312"/>
+  <Angle type1="nc" type2="n" type3="p2" angle="2.04570041626" k="860.27224"/>
+  <Angle type1="nc" type2="n" type3="pc" angle="2.04570041626" k="857.502432"/>
+  <Angle type1="nd" type2="n" type3="nd" angle="2.03173778225" k="912.187312"/>
+  <Angle type1="nd" type2="n" type3="p2" angle="2.04570041626" k="860.27224"/>
+  <Angle type1="nd" type2="n" type3="pd" angle="2.04570041626" k="857.502432"/>
+  <Angle type1="nh" type2="n" type3="nh" angle="2.01027023245" k="889.761072"/>
+  <Angle type1="n" type2="n" type3="n" angle="2.00049638864" k="890.221312"/>
+  <Angle type1="no" type2="n" type3="no" angle="1.89647476522" k="881.844944"/>
+  <Angle type1="br" type2="no" type3="o" angle="1.97553818033" k="606.420592"/>
+  <Angle type1="c1" type2="no" type3="o" angle="2.0355775066" k="745.3796"/>
+  <Angle type1="c2" type2="no" type3="o" angle="2.05372893082" k="726.811008"/>
+  <Angle type1="c3" type2="no" type3="o" angle="2.04081349436" k="698.828416"/>
+  <Angle type1="ca" type2="no" type3="o" angle="2.05529972715" k="719.162656"/>
+  <Angle type1="cc" type2="no" type3="o" angle="2.05058733817" k="734.183216"/>
+  <Angle type1="cl" type2="no" type3="o" angle="2.0085249032" k="724.099776"/>
+  <Angle type1="c" type2="no" type3="o" angle="2.01166649585" k="701.522912"/>
+  <Angle type1="hn" type2="no" type3="o" angle="2.01568075313" k="564.413232"/>
+  <Angle type1="oh" type2="n" type3="oh" angle="1.87204015569" k="919.0156"/>
+  <Angle type1="i" type2="no" type3="o" angle="2.02999245299" k="588.872896"/>
+  <Angle type1="n1" type2="no" type3="o" angle="2.00712863979" k="942.2368"/>
+  <Angle type1="n2" type2="no" type3="o" angle="2.03365764442" k="920.655728"/>
+  <Angle type1="n3" type2="no" type3="o" angle="2.03802096755" k="936.04448"/>
+  <Angle type1="n4" type2="no" type3="o" angle="1.90240888467" k="930.94"/>
+  <Angle type1="na" type2="no" type3="o" angle="2.01707701653" k="924.429696"/>
+  <Angle type1="nh" type2="no" type3="o" angle="2.02597819572" k="943.893664"/>
+  <Angle type1="n" type2="no" type3="o" angle="2.01742608238" k="914.764656"/>
+  <Angle type1="no" type2="no" type3="o" angle="1.96140101339" k="766.625952"/>
+  <Angle type1="o" type2="n" type3="o" angle="2.24466795099" k="949.466752"/>
+  <Angle type1="o" type2="no" type3="o" angle="2.18305782839" k="976.118832"/>
+  <Angle type1="o" type2="no" type3="oh" angle="2.00189265204" k="940.780768"/>
+  <Angle type1="o" type2="no" type3="os" angle="2.00293984959" k="933.751648"/>
+  <Angle type1="o" type2="no" type3="p2" angle="2.04866747599" k="870.02096"/>
+  <Angle type1="o" type2="no" type3="p3" angle="2.03819550048" k="824.33168"/>
+  <Angle type1="o" type2="no" type3="p4" angle="2.03575203953" k="813.419808"/>
+  <Angle type1="o" type2="no" type3="p5" angle="2.03662470415" k="829.076336"/>
+  <Angle type1="o" type2="no" type3="s4" angle="1.99822746061" k="597.952176"/>
+  <Angle type1="o" type2="no" type3="s6" angle="1.99648213136" k="604.663312"/>
+  <Angle type1="o" type2="no" type3="s" angle="2.09107897681" k="669.60736"/>
+  <Angle type1="o" type2="no" type3="sh" angle="2.02632726157" k="658.134832"/>
+  <Angle type1="o" type2="no" type3="ss" angle="2.01725154946" k="651.214496"/>
+  <Angle type1="os" type2="n" type3="os" angle="1.85929925215" k="920.387952"/>
+  <Angle type1="p2" type2="n" type3="p2" angle="2.08776285124" k="866.75744"/>
+  <Angle type1="p3" type2="n" type3="p3" angle="1.89769649569" k="890.120896"/>
+  <Angle type1="p4" type2="n" type3="p4" angle="1.89455490304" k="909.358928"/>
+  <Angle type1="p5" type2="n" type3="p5" angle="1.74515471907" k="956.805488"/>
+  <Angle type1="pc" type2="n" type3="pc" angle="2.08776285124" k="863.267984"/>
+  <Angle type1="pd" type2="n" type3="pd" angle="2.08776285124" k="863.267984"/>
+  <Angle type1="s4" type2="n" type3="s4" angle="1.98531202414" k="528.974752"/>
+  <Angle type1="s6" type2="n" type3="s6" angle="2.08881004879" k="530.556304"/>
+  <Angle type1="sh" type2="n" type3="sh" angle="2.07746540865" k="529.10864"/>
+  <Angle type1="s" type2="n" type3="s" angle="2.19911485751" k="502.9168"/>
+  <Angle type1="ss" type2="n" type3="ss" angle="2.06804063069" k="530.957968"/>
+  <Angle type1="br" type2="oh" type3="ho" angle="1.77325452003" k="361.263296"/>
+  <Angle type1="c1" type2="oh" type3="ho" angle="1.89822009447" k="434.751072"/>
+  <Angle type1="c2" type2="oh" type3="ho" angle="1.87849787392" k="433.42056"/>
+  <Angle type1="c3" type2="oh" type3="ho" angle="1.87204015569" k="410.257936"/>
+  <Angle type1="ca" type2="oh" type3="ho" angle="1.89507850182" k="424.358016"/>
+  <Angle type1="cc" type2="oh" type3="ho" angle="1.86959669474" k="432.014736"/>
+  <Angle type1="cd" type2="oh" type3="ho" angle="1.86959669474" k="432.014736"/>
+  <Angle type1="ce" type2="oh" type3="ho" angle="1.86453523991" k="431.680016"/>
+  <Angle type1="cf" type2="oh" type3="ho" angle="1.86453523991" k="431.680016"/>
+  <Angle type1="c" type2="oh" type3="ho" angle="1.859648318" k="431.931056"/>
+  <Angle type1="cl" type2="oh" type3="ho" angle="1.78721715404" k="423.429168"/>
+  <Angle type1="cx" type2="oh" type3="ho" angle="1.85301606684" k="429.914368"/>
+  <Angle type1="cy" type2="oh" type3="ho" angle="1.87954507147" k="412.450352"/>
+  <Angle type1="f" type2="oh" type3="ho" angle="1.68947871593" k="540.9912"/>
+  <Angle type1="ho" type2="oh" type3="ho" angle="1.85860112045" k="352.945504"/>
+  <Angle type1="ho" type2="oh" type3="i" angle="1.8846065263" k="317.808272"/>
+  <Angle type1="ho" type2="oh" type3="n1" angle="1.88163946658" k="556.254432"/>
+  <Angle type1="ho" type2="oh" type3="n2" angle="1.79925992588" k="535.443216"/>
+  <Angle type1="ho" type2="oh" type3="n3" angle="1.78477369309" k="529.133744"/>
+  <Angle type1="ho" type2="oh" type3="n4" angle="1.8610445814" k="523.384928"/>
+  <Angle type1="ho" type2="oh" type3="n" angle="1.76784399935" k="534.773776"/>
+  <Angle type1="ho" type2="oh" type3="na" angle="1.82160014031" k="531.685984"/>
+  <Angle type1="ho" type2="oh" type3="nh" angle="1.79367487227" k="527.359728"/>
+  <Angle type1="ho" type2="oh" type3="no" angle="1.78320289676" k="532.53952"/>
+  <Angle type1="ho" type2="oh" type3="o" angle="1.76051361649" k="497.326976"/>
+  <Angle type1="ho" type2="oh" type3="oh" angle="1.72298903757" k="519.27624"/>
+  <Angle type1="ho" type2="oh" type3="os" angle="1.73974419839" k="521.502128"/>
+  <Angle type1="ho" type2="oh" type3="p2" angle="1.91026286631" k="490.088656"/>
+  <Angle type1="ho" type2="oh" type3="p3" angle="1.93103228441" k="472.264816"/>
+  <Angle type1="ho" type2="oh" type3="p4" angle="1.92317830277" k="484.833552"/>
+  <Angle type1="ho" type2="oh" type3="p5" angle="1.9212584406" k="493.686896"/>
+  <Angle type1="ho" type2="oh" type3="py" angle="1.92841429053" k="492.33128"/>
+  <Angle type1="ho" type2="oh" type3="s4" angle="1.86488430576" k="369.773552"/>
+  <Angle type1="ho" type2="oh" type3="s" angle="1.74794724587" k="353.481056"/>
+  <Angle type1="ho" type2="oh" type3="s6" angle="1.87204015569" k="384.568176"/>
+  <Angle type1="ho" type2="oh" type3="sh" angle="1.85423779732" k="371.781872"/>
+  <Angle type1="ho" type2="oh" type3="ss" angle="1.86942216181" k="371.263056"/>
+  <Angle type1="ho" type2="oh" type3="sy" angle="1.85737938997" k="382.174928"/>
+  <Angle type1="br" type2="os" type3="br" angle="1.93085775148" k="564.304448"/>
+  <Angle type1="c1" type2="os" type3="c1" angle="2.00747770564" k="595.818336"/>
+  <Angle type1="c1" type2="os" type3="c3" angle="1.97902883884" k="573.358624"/>
+  <Angle type1="c2" type2="os" type3="c2" angle="1.97466551571" k="582.4128"/>
+  <Angle type1="c2" type2="os" type3="c3" angle="2.01742608238" k="560.597424"/>
+  <Angle type1="c2" type2="os" type3="ca" angle="2.06297917586" k="567.710224"/>
+  <Angle type1="c2" type2="os" type3="n2" angle="2.06175744538" k="702.602384"/>
+  <Angle type1="c2" type2="os" type3="na" angle="1.8125244282" k="736.994864"/>
+  <Angle type1="c2" type2="os" type3="os" angle="1.79367487227" k="734.551408"/>
+  <Angle type1="c2" type2="os" type3="p5" angle="2.20557257575" k="688.786816"/>
+  <Angle type1="c2" type2="os" type3="ss" angle="1.88722452018" k="557.384112"/>
+  <Angle type1="c3" type2="os" type3="c3" angle="1.96314634264" k="554.739824"/>
+  <Angle type1="c3" type2="os" type3="ca" angle="2.05879038565" k="553.149904"/>
+  <Angle type1="c3" type2="os" type3="cc" angle="2.04849294307" k="555.902976"/>
+  <Angle type1="c3" type2="os" type3="cd" angle="2.04849294307" k="555.902976"/>
+  <Angle type1="c3" type2="os" type3="ce" angle="2.02615272864" k="557.333904"/>
+  <Angle type1="c3" type2="os" type3="cf" angle="2.02615272864" k="557.333904"/>
+  <Angle type1="c3" type2="os" type3="cl" angle="1.92858882345" k="601.090176"/>
+  <Angle type1="c3" type2="os" type3="cy" angle="1.9504054391" k="555.108016"/>
+  <Angle type1="c3" type2="os" type3="i" angle="1.98443935952" k="499.762064"/>
+  <Angle type1="c3" type2="os" type3="n1" angle="1.98094870101" k="719.388592"/>
+  <Angle type1="c3" type2="os" type3="n2" angle="1.90642314195" k="712.267424"/>
+  <Angle type1="c3" type2="os" type3="n3" angle="1.91689511747" k="700.794896"/>
+  <Angle type1="c3" type2="os" type3="n4" angle="1.92858882345" k="703.45592"/>
+  <Angle type1="c3" type2="os" type3="n" angle="1.91427712359" k="709.02064"/>
+  <Angle type1="c3" type2="os" type3="na" angle="1.93696640386" k="696.318016"/>
+  <Angle type1="c3" type2="os" type3="nc" angle="1.96750966577" k="701.171456"/>
+  <Angle type1="c3" type2="os" type3="nd" angle="1.96750966577" k="701.171456"/>
+  <Angle type1="c3" type2="os" type3="nh" angle="1.91619698576" k="707.112736"/>
+  <Angle type1="c3" type2="os" type3="no" angle="1.9877554851" k="692.887136"/>
+  <Angle type1="c3" type2="os" type3="o" angle="1.79768912955" k="707.17968"/>
+  <Angle type1="c3" type2="os" type3="oh" angle="1.88687545433" k="702.61912"/>
+  <Angle type1="c3" type2="os" type3="os" angle="1.87396001787" k="702.552176"/>
+  <Angle type1="c3" type2="os" type3="p2" angle="2.01533168728" k="720.668896"/>
+  <Angle type1="c3" type2="os" type3="p3" angle="2.05093640402" k="685.699024"/>
+  <Angle type1="c3" type2="os" type3="p4" angle="2.05041280524" k="696.694576"/>
+  <Angle type1="c3" type2="os" type3="p5" angle="2.08636658783" k="696.644368"/>
+  <Angle type1="c3" type2="os" type3="py" angle="2.08689018661" k="695.489584"/>
+  <Angle type1="c3" type2="os" type3="s4" angle="1.97588724618" k="540.338496"/>
+  <Angle type1="c3" type2="os" type3="s6" angle="2.02231300429" k="549.635344"/>
+  <Angle type1="c3" type2="os" type3="s" angle="1.91200819556" k="524.598288"/>
+  <Angle type1="c3" type2="os" type3="sh" angle="1.9690804621" k="546.070576"/>
+  <Angle type1="c3" type2="os" type3="ss" angle="1.9898498802" k="535.786304"/>
+  <Angle type1="ca" type2="os" type3="ca" angle="2.09247524022" k="561.651792"/>
+  <Angle type1="ca" type2="os" type3="cc" angle="1.97361831816" k="579.910768"/>
+  <Angle type1="ca" type2="os" type3="cd" angle="1.97361831816" k="579.910768"/>
+  <Angle type1="ca" type2="os" type3="n3" angle="1.95808488781" k="707.790544"/>
+  <Angle type1="ca" type2="os" type3="na" angle="1.88914438236" k="719.631264"/>
+  <Angle type1="ca" type2="os" type3="nc" angle="1.90799393828" k="727.923952"/>
+  <Angle type1="ca" type2="os" type3="nd" angle="1.90799393828" k="727.923952"/>
+  <Angle type1="ca" type2="os" type3="p5" angle="2.14989657261" k="696.159024"/>
+  <Angle type1="ca" type2="os" type3="s6" angle="2.04517681749" k="554.279584"/>
+  <Angle type1="c" type2="os" type3="c2" angle="2.06332824171" k="570.011424"/>
+  <Angle type1="c" type2="os" type3="c3" angle="2.02423286646" k="559.869408"/>
+  <Angle type1="c" type2="os" type3="c" angle="2.10556520961" k="564.522016"/>
+  <Angle type1="c" type2="os" type3="ca" angle="2.11446638879" k="560.999088"/>
+  <Angle type1="c" type2="os" type3="cc" angle="2.08776285124" k="566.170512"/>
+  <Angle type1="cc" type2="os" type3="cc" angle="1.86261537773" k="598.621616"/>
+  <Angle type1="cc" type2="os" type3="cd" angle="2.07135675627" k="567.660016"/>
+  <Angle type1="c" type2="os" type3="cd" angle="2.08776285124" k="566.170512"/>
+  <Angle type1="cc" type2="os" type3="na" angle="1.94883464278" k="710.225632"/>
+  <Angle type1="cc" type2="os" type3="nc" angle="1.89141331039" k="733.020064"/>
+  <Angle type1="cc" type2="os" type3="os" angle="1.89315863964" k="714.476576"/>
+  <Angle type1="cc" type2="os" type3="ss" angle="2.08723925246" k="529.803184"/>
+  <Angle type1="c" type2="os" type3="cy" angle="1.58999494857" k="629.85936"/>
+  <Angle type1="cd" type2="os" type3="cd" angle="1.86261537773" k="598.621616"/>
+  <Angle type1="cd" type2="os" type3="na" angle="1.94883464278" k="710.225632"/>
+  <Angle type1="cd" type2="os" type3="nd" angle="1.89141331039" k="733.020064"/>
+  <Angle type1="cd" type2="os" type3="os" angle="1.89315863964" k="714.476576"/>
+  <Angle type1="cd" type2="os" type3="ss" angle="2.08723925246" k="529.803184"/>
+  <Angle type1="cl" type2="os" type3="cl" angle="1.93312667951" k="674.184656"/>
+  <Angle type1="c" type2="os" type3="n2" angle="1.95686315734" k="721.480592"/>
+  <Angle type1="c" type2="os" type3="n" angle="1.95895755244" k="719.037136"/>
+  <Angle type1="c" type2="os" type3="oh" angle="1.92858882345" k="711.455728"/>
+  <Angle type1="c" type2="os" type3="os" angle="1.9233528357" k="709.6064"/>
+  <Angle type1="c" type2="os" type3="p5" angle="2.13157061546" k="700.811632"/>
+  <Angle type1="c" type2="os" type3="sy" angle="1.98077416809" k="545.417872"/>
+  <Angle type1="cx" type2="os" type3="cx" angle="1.07826441188" k="745.814736"/>
+  <Angle type1="cx" type2="os" type3="n" angle="1.04702301827" k="956.889168"/>
+  <Angle type1="cx" type2="os" type3="os" angle="0.986460093227" k="966.662992"/>
+  <Angle type1="cy" type2="os" type3="cy" angle="1.60325945088" k="610.69664"/>
+  <Angle type1="f" type2="os" type3="f" angle="1.80292511731" k="939.701296"/>
+  <Angle type1="f" type2="os" type3="os" angle="1.91113553093" k="886.204672"/>
+  <Angle type1="i" type2="os" type3="i" angle="2.01882234578" k="544.112464"/>
+  <Angle type1="n1" type2="os" type3="n1" angle="2.05582332592" k="928.981888"/>
+  <Angle type1="n2" type2="os" type3="n2" angle="1.86453523991" k="911.794016"/>
+  <Angle type1="n2" type2="os" type3="s6" angle="1.94255145747" k="707.229888"/>
+  <Angle type1="n3" type2="os" type3="n3" angle="1.83050131949" k="895.25048"/>
+  <Angle type1="n4" type2="os" type3="n4" angle="2.00154358619" k="867.954064"/>
+  <Angle type1="na" type2="os" type3="na" angle="1.91270632726" k="873.736352"/>
+  <Angle type1="na" type2="os" type3="ss" angle="1.82107654153" k="699.589904"/>
+  <Angle type1="nc" type2="os" type3="nc" angle="1.96785873162" k="887.660704"/>
+  <Angle type1="nc" type2="os" type3="ss" angle="1.93679187094" k="684.025424"/>
+  <Angle type1="nd" type2="os" type3="nd" angle="1.96785873162" k="887.660704"/>
+  <Angle type1="nd" type2="os" type3="ss" angle="1.93679187094" k="684.025424"/>
+  <Angle type1="nh" type2="os" type3="nh" angle="1.89001704698" k="896.790192"/>
+  <Angle type1="n" type2="os" type3="n" angle="1.89036611284" k="900.781728"/>
+  <Angle type1="no" type2="os" type3="no" angle="1.95232530128" k="878.76552"/>
+  <Angle type1="n" type2="os" type3="s6" angle="1.98321762904" k="698.761472"/>
+  <Angle type1="o" type2="os" type3="o" angle="2.00154358619" k="820.055632"/>
+  <Angle type1="p2" type2="os" type3="p2" angle="2.09474416824" k="940.789136"/>
+  <Angle type1="p2" type2="os" type3="p5" angle="1.8825121312" k="979.081104"/>
+  <Angle type1="p3" type2="os" type3="p3" angle="2.11568811927" k="879.426592"/>
+  <Angle type1="p3" type2="os" type3="py" angle="1.84271862426" k="957.75944"/>
+  <Angle type1="p5" type2="os" type3="p5" angle="2.20347818064" k="893.593616"/>
+  <Angle type1="s4" type2="os" type3="s4" angle="1.948311044" k="550.589296"/>
+  <Angle type1="s6" type2="os" type3="s6" angle="2.07816354035" k="556.01176"/>
+  <Angle type1="sh" type2="os" type3="sh" angle="2.07606914525" k="540.146032"/>
+  <Angle type1="s" type2="os" type3="s" angle="2.06088478075" k="503.276624"/>
+  <Angle type1="ss" type2="os" type3="ss" angle="2.01829874701" k="537.208864"/>
+  <Angle type1="br" type2="p2" type3="br" angle="1.89542756767" k="421.471056"/>
+  <Angle type1="br" type2="p2" type3="c2" angle="1.78582089064" k="412.70976"/>
+  <Angle type1="br" type2="p2" type3="n2" angle="1.80344871609" k="516.966672"/>
+  <Angle type1="br" type2="p2" type3="o" angle="1.93504654169" k="501.4524"/>
+  <Angle type1="br" type2="p2" type3="p2" angle="2.01515715435" k="531.861712"/>
+  <Angle type1="br" type2="p2" type3="s" angle="1.9289378893" k="424.374752"/>
+  <Angle type1="c1" type2="p2" type3="c1" angle="1.72857409118" k="414.408464"/>
+  <Angle type1="c1" type2="p2" type3="c2" angle="1.76784399935" k="421.127968"/>
+  <Angle type1="c1" type2="p2" type3="n2" angle="1.77657064561" k="534.347008"/>
+  <Angle type1="c1" type2="p2" type3="o" angle="1.878323341" k="530.790608"/>
+  <Angle type1="c1" type2="p2" type3="p2" angle="1.73730073744" k="570.890064"/>
+  <Angle type1="c1" type2="p2" type3="s" angle="1.84830367786" k="433.010528"/>
+  <Angle type1="c2" type2="p2" type3="c2" angle="1.82386906833" k="427.947888"/>
+  <Angle type1="c2" type2="p2" type3="c3" angle="1.77849050778" k="408.157568"/>
+  <Angle type1="c2" type2="p2" type3="ca" angle="1.77936317241" k="410.140784"/>
+  <Angle type1="c2" type2="p2" type3="cl" angle="1.79280220765" k="454.533024"/>
+  <Angle type1="c2" type2="p2" type3="f" angle="1.80589217704" k="566.97384"/>
+  <Angle type1="c2" type2="p2" type3="hp" angle="1.69628550001" k="311.95904"/>
+  <Angle type1="c2" type2="p2" type3="i" angle="1.77918863948" k="368.27568"/>
+  <Angle type1="c2" type2="p2" type3="n2" angle="1.74323485689" k="558.379904"/>
+  <Angle type1="c2" type2="p2" type3="n3" angle="1.77674517853" k="542.731744"/>
+  <Angle type1="c2" type2="p2" type3="n4" angle="1.71496052301" k="504.983696"/>
+  <Angle type1="c2" type2="p2" type3="n" angle="1.80257605146" k="528.472672"/>
+  <Angle type1="c2" type2="p2" type3="na" angle="1.81496788915" k="523.995792"/>
+  <Angle type1="c2" type2="p2" type3="nh" angle="1.83556277432" k="532.522784"/>
+  <Angle type1="c2" type2="p2" type3="no" angle="1.70989906818" k="541.74432"/>
+  <Angle type1="c2" type2="p2" type3="o" angle="2.0099211666" k="533.568784"/>
+  <Angle type1="c2" type2="p2" type3="oh" angle="1.79576926738" k="546.246304"/>
+  <Angle type1="c2" type2="p2" type3="os" angle="1.78233023214" k="557.124704"/>
+  <Angle type1="c2" type2="p2" type3="p2" angle="1.73764980329" k="586.253712"/>
+  <Angle type1="c2" type2="p2" type3="p3" angle="1.73258834845" k="515.326544"/>
+  <Angle type1="c2" type2="p2" type3="p4" angle="1.69192217688" k="516.18008"/>
+  <Angle type1="c2" type2="p2" type3="p5" angle="1.70361588287" k="514.2136"/>
+  <Angle type1="c2" type2="p2" type3="s4" angle="1.66068078327" k="404.291552"/>
+  <Angle type1="c2" type2="p2" type3="s6" angle="1.66696396858" k="405.069776"/>
+  <Angle type1="c2" type2="p2" type3="s" angle="1.84184595963" k="445.746624"/>
+  <Angle type1="c2" type2="p2" type3="sh" angle="1.77133465785" k="424.55048"/>
+  <Angle type1="c2" type2="p2" type3="ss" angle="1.77691971146" k="424.642528"/>
+  <Angle type1="c3" type2="p2" type3="c3" angle="1.73311194723" k="394.894288"/>
+  <Angle type1="c3" type2="p2" type3="n2" angle="1.75964095186" k="520.765744"/>
+  <Angle type1="c3" type2="p2" type3="o" angle="1.86261537773" k="515.142448"/>
+  <Angle type1="c3" type2="p2" type3="os" angle="1.76871666397" k="522.656912"/>
+  <Angle type1="c3" type2="p2" type3="p2" angle="1.7537068324" k="554.572464"/>
+  <Angle type1="c3" type2="p2" type3="s" angle="1.84446395351" k="422.860144"/>
+  <Angle type1="ca" type2="p2" type3="ca" angle="1.74009326424" k="397.321008"/>
+  <Angle type1="ca" type2="p2" type3="n2" angle="1.75964095186" k="523.6276"/>
+  <Angle type1="ca" type2="p2" type3="n" angle="1.57027272802" k="538.472432"/>
+  <Angle type1="ca" type2="p2" type3="na" angle="1.5570082257" k="538.623056"/>
+  <Angle type1="ca" type2="p2" type3="o" angle="1.86540790453" k="517.903888"/>
+  <Angle type1="ca" type2="p2" type3="s" angle="1.88373386168" k="420.307904"/>
+  <Angle type1="c" type2="p2" type3="c2" angle="1.69820536219" k="411.270464"/>
+  <Angle type1="c" type2="p2" type3="c" angle="1.57254165605" k="404.751792"/>
+  <Angle type1="ce" type2="p2" type3="o" angle="1.87518174834" k="522.004208"/>
+  <Angle type1="ce" type2="p2" type3="s" angle="1.84202049255" k="428.307712"/>
+  <Angle type1="cf" type2="p2" type3="o" angle="1.87518174834" k="522.004208"/>
+  <Angle type1="cf" type2="p2" type3="s" angle="1.84202049255" k="428.307712"/>
+  <Angle type1="cl" type2="p2" type3="cl" angle="1.89717289692" k="492.925408"/>
+  <Angle type1="cl" type2="p2" type3="n2" angle="1.80432138071" k="572.03648"/>
+  <Angle type1="cl" type2="p2" type3="o" angle="1.92981055393" k="558.363168"/>
+  <Angle type1="cl" type2="p2" type3="p2" angle="1.79960899173" k="617.750864"/>
+  <Angle type1="cl" type2="p2" type3="s" angle="1.92178203937" k="466.959504"/>
+  <Angle type1="f" type2="p2" type3="f" angle="1.86924762889" k="740.9864"/>
+  <Angle type1="f" type2="p2" type3="n2" angle="1.80763750629" k="725.79848"/>
+  <Angle type1="f" type2="p2" type3="o" angle="1.93050868563" k="725.279664"/>
+  <Angle type1="f" type2="p2" type3="p2" angle="1.80606670996" k="752.802016"/>
+  <Angle type1="f" type2="p2" type3="s" angle="2.00206718496" k="560.145552"/>
+  <Angle type1="hp" type2="p2" type3="hp" angle="1.72368716927" k="231.324992"/>
+  <Angle type1="hp" type2="p2" type3="n1" angle="1.66120438205" k="393.036592"/>
+  <Angle type1="hp" type2="p2" type3="n2" angle="1.66748756736" k="405.68064"/>
+  <Angle type1="hp" type2="p2" type3="ne" angle="1.74707458125" k="403.873152"/>
+  <Angle type1="hp" type2="p2" type3="nf" angle="1.74707458125" k="403.873152"/>
+  <Angle type1="hp" type2="p2" type3="o" angle="1.84271862426" k="402.843888"/>
+  <Angle type1="hp" type2="p2" type3="p2" angle="1.77814144193" k="399.956928"/>
+  <Angle type1="hp" type2="p2" type3="p4" angle="1.64951067606" k="342.703072"/>
+  <Angle type1="hp" type2="p2" type3="p5" angle="1.55456476475" k="352.83672"/>
+  <Angle type1="hp" type2="p2" type3="pe" angle="1.69733269756" k="393.697664"/>
+  <Angle type1="hp" type2="p2" type3="pf" angle="1.69733269756" k="393.697664"/>
+  <Angle type1="hp" type2="p2" type3="s4" angle="1.57062179387" k="272.185936"/>
+  <Angle type1="hp" type2="p2" type3="s" angle="1.78931154914" k="312.770736"/>
+  <Angle type1="hp" type2="p2" type3="s6" angle="1.53815866978" k="276.403408"/>
+  <Angle type1="i" type2="p2" type3="i" angle="1.81793494888" k="400.291648"/>
+  <Angle type1="i" type2="p2" type3="n2" angle="1.77622157975" k="460.4492"/>
+  <Angle type1="i" type2="p2" type3="o" angle="1.91131006386" k="440.776032"/>
+  <Angle type1="i" type2="p2" type3="p2" angle="1.79123141132" k="509.418736"/>
+  <Angle type1="i" type2="p2" type3="s" angle="1.93033415271" k="382.45944"/>
+  <Angle type1="n1" type2="p2" type3="n1" angle="1.50482288107" k="734.66856"/>
+  <Angle type1="n2" type2="p2" type3="n2" angle="1.71042266695" k="720.44296"/>
+  <Angle type1="n2" type2="p2" type3="n3" angle="1.75265963485" k="697.029296"/>
+  <Angle type1="n2" type2="p2" type3="n4" angle="1.63048658721" k="655.833632"/>
+  <Angle type1="n2" type2="p2" type3="na" angle="1.78075943581" k="673.272544"/>
+  <Angle type1="n2" type2="p2" type3="nh" angle="1.77796690901" k="690.000176"/>
+  <Angle type1="n2" type2="p2" type3="no" angle="1.71251706206" k="689.171744"/>
+  <Angle type1="n2" type2="p2" type3="o" angle="2.01306275925" k="683.448032"/>
+  <Angle type1="n2" type2="p2" type3="oh" angle="1.91497525529" k="675.531904"/>
+  <Angle type1="n2" type2="p2" type3="os" angle="1.78529729186" k="712.125168"/>
+  <Angle type1="n2" type2="p2" type3="p3" angle="1.73677713866" k="648.68736"/>
+  <Angle type1="n2" type2="p2" type3="p4" angle="1.77552344805" k="634.687696"/>
+  <Angle type1="n2" type2="p2" type3="p5" angle="1.63502444327" k="661.130576"/>
+  <Angle type1="n2" type2="p2" type3="s4" angle="1.70745560723" k="502.105104"/>
+  <Angle type1="n2" type2="p2" type3="s6" angle="1.71286612791" k="503.326832"/>
+  <Angle type1="n2" type2="p2" type3="s" angle="1.9711748572" k="548.028688"/>
+  <Angle type1="n2" type2="p2" type3="sh" angle="1.75964095186" k="539.033088"/>
+  <Angle type1="n2" type2="p2" type3="ss" angle="1.77604704683" k="537.56032"/>
+  <Angle type1="n3" type2="p2" type3="n3" angle="1.85528499487" k="664.820864"/>
+  <Angle type1="n3" type2="p2" type3="o" angle="1.86453523991" k="693.364112"/>
+  <Angle type1="n3" type2="p2" type3="p2" angle="1.75545216166" k="730.158208"/>
+  <Angle type1="n3" type2="p2" type3="s" angle="1.84568568398" k="557.400848"/>
+  <Angle type1="n4" type2="p2" type3="n4" angle="1.54985237577" k="625.508"/>
+  <Angle type1="n4" type2="p2" type3="o" angle="1.76906572982" k="638.587184"/>
+  <Angle type1="n4" type2="p2" type3="p2" angle="1.68476632695" k="690.075488"/>
+  <Angle type1="n4" type2="p2" type3="s" angle="1.83224664874" k="517.209344"/>
+  <Angle type1="na" type2="p2" type3="na" angle="1.85179433637" k="635.390608"/>
+  <Angle type1="na" type2="p2" type3="o" angle="1.87553081419" k="670.686832"/>
+  <Angle type1="na" type2="p2" type3="s" angle="1.88757358603" k="539.719264"/>
+  <Angle type1="ne" type2="p2" type3="o" angle="1.87989413732" k="717.840512"/>
+  <Angle type1="ne" type2="p2" type3="s" angle="1.84132236085" k="572.463248"/>
+  <Angle type1="nf" type2="p2" type3="o" angle="1.87989413732" k="717.840512"/>
+  <Angle type1="nf" type2="p2" type3="s" angle="1.84132236085" k="572.463248"/>
+  <Angle type1="nh" type2="p2" type3="nh" angle="1.81514242207" k="668.527888"/>
+  <Angle type1="nh" type2="p2" type3="o" angle="1.88687545433" k="686.912384"/>
+  <Angle type1="nh" type2="p2" type3="p2" angle="1.88024320317" k="703.91616"/>
+  <Angle type1="nh" type2="p2" type3="s" angle="1.91322992604" k="546.212832"/>
+  <Angle type1="n" type2="p2" type3="n2" angle="1.7252579656" k="687.80776"/>
+  <Angle type1="n" type2="p2" type3="o" angle="1.833991978" k="682.485712"/>
+  <Angle type1="no" type2="p2" type3="no" angle="1.71391332546" k="664.6284"/>
+  <Angle type1="no" type2="p2" type3="o" angle="1.83032678657" k="681.841376"/>
+  <Angle type1="no" type2="p2" type3="p2" angle="1.89490396889" k="690.510624"/>
+  <Angle type1="no" type2="p2" type3="s" angle="1.90345608223" k="539.091664"/>
+  <Angle type1="n" type2="p2" type3="p2" angle="1.78233023214" k="712.936864"/>
+  <Angle type1="n" type2="p2" type3="s" angle="1.96070288169" k="531.886816"/>
+  <Angle type1="oh" type2="p2" type3="oh" angle="1.74707458125" k="701.90784"/>
+  <Angle type1="oh" type2="p2" type3="p2" angle="1.8818139995" k="712.108432"/>
+  <Angle type1="oh" type2="p2" type3="s" angle="1.91549885406" k="552.631088"/>
+  <Angle type1="o" type2="p2" type3="o" angle="2.09369697069" k="693.054496"/>
+  <Angle type1="o" type2="p2" type3="oh" angle="1.92789069175" k="692.067072"/>
+  <Angle type1="o" type2="p2" type3="os" angle="1.8990927591" k="711.715136"/>
+  <Angle type1="o" type2="p2" type3="p2" angle="1.99368960455" k="710.267472"/>
+  <Angle type1="o" type2="p2" type3="p3" angle="1.86209177895" k="630.645952"/>
+  <Angle type1="o" type2="p2" type3="p4" angle="1.82160014031" k="630.219184"/>
+  <Angle type1="o" type2="p2" type3="p5" angle="1.82369453541" k="629.583216"/>
+  <Angle type1="o" type2="p2" type3="pe" angle="2.54748257621" k="608.1444"/>
+  <Angle type1="o" type2="p2" type3="pf" angle="2.54748257621" k="608.1444"/>
+  <Angle type1="o" type2="p2" type3="s4" angle="1.8603464497" k="483.62856"/>
+  <Angle type1="o" type2="p2" type3="s6" angle="1.83329384629" k="489.302064"/>
+  <Angle type1="o" type2="p2" type3="s" angle="2.04936560769" k="548.924064"/>
+  <Angle type1="o" type2="p2" type3="sh" angle="1.91288086019" k="523.769856"/>
+  <Angle type1="os" type2="p2" type3="os" angle="1.71565865471" k="733.974016"/>
+  <Angle type1="os" type2="p2" type3="p2" angle="1.77081105907" k="743.655792"/>
+  <Angle type1="o" type2="p2" type3="ss" angle="1.91288086019" k="524.866064"/>
+  <Angle type1="os" type2="p2" type3="s" angle="1.89315863964" k="563.325392"/>
+  <Angle type1="p2" type2="p2" type3="n2" angle="1.69995069144" k="753.596976"/>
+  <Angle type1="p2" type2="p2" type3="p3" angle="1.77552344805" k="695.389168"/>
+  <Angle type1="p2" type2="p2" type3="p4" angle="1.77988677118" k="688.167584"/>
+  <Angle type1="p2" type2="p2" type3="p5" angle="1.73363554601" k="697.046032"/>
+  <Angle type1="p2" type2="p2" type3="s4" angle="1.67080369293" k="551.375888"/>
+  <Angle type1="p2" type2="p2" type3="s6" angle="1.67464341729" k="552.639456"/>
+  <Angle type1="p2" type2="p2" type3="s" angle="1.94220239162" k="583.391856"/>
+  <Angle type1="p2" type2="p2" type3="sh" angle="1.98862814972" k="543.37608"/>
+  <Angle type1="p3" type2="p2" type3="p3" angle="1.76278254451" k="649.674784"/>
+  <Angle type1="p3" type2="p2" type3="s" angle="1.97710897666" k="514.565056"/>
+  <Angle type1="p4" type2="p2" type3="s" angle="1.8132225599" k="532.33032"/>
+  <Angle type1="p5" type2="p2" type3="p5" angle="1.56032435128" k="681.665648"/>
+  <Angle type1="p5" type2="p2" type3="s" angle="1.76644773594" k="539.141872"/>
+  <Angle type1="pe" type2="p2" type3="s" angle="1.8561576595" k="582.70568"/>
+  <Angle type1="pf" type2="p2" type3="s" angle="1.8561576595" k="582.70568"/>
+  <Angle type1="s4" type2="p2" type3="s4" angle="1.48876585195" k="421.797408"/>
+  <Angle type1="s6" type2="p2" type3="s6" angle="1.71391332546" k="394.919392"/>
+  <Angle type1="sh" type2="p2" type3="sh" angle="1.71914931321" k="436.131792"/>
+  <Angle type1="s" type2="p2" type3="s" angle="1.86052098263" k="466.315168"/>
+  <Angle type1="s" type2="p2" type3="s4" angle="1.83765716942" k="410.458768"/>
+  <Angle type1="s" type2="p2" type3="s6" angle="1.86628056916" k="408.718224"/>
+  <Angle type1="s" type2="p2" type3="sh" angle="1.93260308073" k="430.767904"/>
+  <Angle type1="s" type2="p2" type3="ss" angle="1.99211880823" k="424.960512"/>
+  <Angle type1="ss" type2="p2" type3="ss" angle="1.7086773377" k="438.575248"/>
+  <Angle type1="br" type2="p3" type3="br" angle="1.80711390751" k="427.588064"/>
+  <Angle type1="br" type2="p3" type3="hp" angle="1.68179926722" k="276.010112"/>
+  <Angle type1="c1" type2="p3" type3="c1" angle="1.75405589825" k="406.785216"/>
+  <Angle type1="c1" type2="p3" type3="f" angle="1.69122404518" k="554.949024"/>
+  <Angle type1="c1" type2="p3" type3="hp" angle="1.70466308042" k="291.030672"/>
+  <Angle type1="c2" type2="p3" type3="c2" angle="1.77622157975" k="394.542832"/>
+  <Angle type1="c2" type2="p3" type3="hp" angle="1.70780467308" k="285.122864"/>
+  <Angle type1="c3" type2="p3" type3="c3" angle="1.73398461186" k="394.116064"/>
+  <Angle type1="c3" type2="p3" type3="ca" angle="1.77918863948" k="392.450832"/>
+  <Angle type1="c3" type2="p3" type3="cl" angle="1.74340938982" k="454.742224"/>
+  <Angle type1="c3" type2="p3" type3="f" angle="1.70693200845" k="538.52264"/>
+  <Angle type1="c3" type2="p3" type3="hp" angle="1.70134695484" k="282.578992"/>
+  <Angle type1="c3" type2="p3" type3="n2" angle="1.6851153928" k="512.966768"/>
+  <Angle type1="c3" type2="p3" type3="n3" angle="1.76993839445" k="504.657344"/>
+  <Angle type1="c3" type2="p3" type3="n4" angle="1.69192217688" k="496.68264"/>
+  <Angle type1="c3" type2="p3" type3="n" angle="1.77622157975" k="498.90016"/>
+  <Angle type1="c3" type2="p3" type3="na" angle="1.74829631172" k="503.862384"/>
+  <Angle type1="c3" type2="p3" type3="nh" angle="1.82386906833" k="497.14288"/>
+  <Angle type1="c3" type2="p3" type3="no" angle="1.69262030858" k="501.427296"/>
+  <Angle type1="c3" type2="p3" type3="o" angle="1.9490091757" k="502.37288"/>
+  <Angle type1="c3" type2="p3" type3="oh" angle="1.71408785838" k="519.100512"/>
+  <Angle type1="c3" type2="p3" type3="os" angle="1.73712620451" k="515.945776"/>
+  <Angle type1="c3" type2="p3" type3="p3" angle="1.74323485689" k="490.1556"/>
+  <Angle type1="c3" type2="p3" type3="p5" angle="1.76103721526" k="487.829296"/>
+  <Angle type1="c3" type2="p3" type3="s4" angle="1.72578156437" k="399.622208"/>
+  <Angle type1="c3" type2="p3" type3="s6" angle="1.76592413717" k="396.26664"/>
+  <Angle type1="c3" type2="p3" type3="sh" angle="1.72281450464" k="394.392208"/>
+  <Angle type1="c3" type2="p3" type3="ss" angle="1.73433367771" k="394.442416"/>
+  <Angle type1="ca" type2="p3" type3="ca" angle="1.74288579104" k="400.107552"/>
+  <Angle type1="ca" type2="p3" type3="hp" angle="1.70169602069" k="286.696048"/>
+  <Angle type1="c" type2="p3" type3="c3" angle="1.69401657199" k="396.065808"/>
+  <Angle type1="c" type2="p3" type3="c" angle="1.76103721526" k="385.93216"/>
+  <Angle type1="c" type2="p3" type3="hp" angle="1.6851153928" k="280.779872"/>
+  <Angle type1="cl" type2="p3" type3="cl" angle="1.7945475369" k="522.472816"/>
+  <Angle type1="cl" type2="p3" type3="f" angle="1.73136661798" k="609.056512"/>
+  <Angle type1="cl" type2="p3" type3="hp" angle="1.68075206967" k="320.561344"/>
+  <Angle type1="c" type2="p3" type3="os" angle="1.41930174772" k="565.986416"/>
+  <Angle type1="cx" type2="p3" type3="hp" angle="1.6615534479" k="284.813248"/>
+  <Angle type1="f" type2="p3" type3="f" angle="1.69995069144" k="756.324944"/>
+  <Angle type1="f" type2="p3" type3="hp" angle="1.68267193185" k="407.220352"/>
+  <Angle type1="f" type2="p3" type3="n3" angle="1.75580122751" k="696.987456"/>
+  <Angle type1="f" type2="p3" type3="os" angle="1.73189021675" k="715.539312"/>
+  <Angle type1="f" type2="p3" type3="p3" angle="1.69646003294" k="650.57016"/>
+  <Angle type1="hp" type2="p3" type3="hp" angle="1.66190251375" k="222.906784"/>
+  <Angle type1="hp" type2="p3" type3="i" angle="1.67883220749" k="249.475184"/>
+  <Angle type1="hp" type2="p3" type3="n1" angle="1.6228071385" k="395.145328"/>
+  <Angle type1="hp" type2="p3" type3="n2" angle="1.71530958886" k="367.497456"/>
+  <Angle type1="hp" type2="p3" type3="n3" angle="1.64863801143" k="380.459488"/>
+  <Angle type1="hp" type2="p3" type3="n4" angle="1.62682139578" k="358.334496"/>
+  <Angle type1="hp" type2="p3" type3="n" angle="1.66068078327" k="372.509888"/>
+  <Angle type1="hp" type2="p3" type3="na" angle="1.69768176341" k="369.723344"/>
+  <Angle type1="hp" type2="p3" type3="nh" angle="1.64235482613" k="381.187504"/>
+  <Angle type1="hp" type2="p3" type3="no" angle="1.62420340191" k="364.484976"/>
+  <Angle type1="hp" type2="p3" type3="o" angle="1.76313161036" k="402.099136"/>
+  <Angle type1="hp" type2="p3" type3="oh" angle="1.67464341729" k="386.191568"/>
+  <Angle type1="hp" type2="p3" type3="os" angle="1.69907802682" k="383.823424"/>
+  <Angle type1="hp" type2="p3" type3="p2" angle="1.72979582165" k="339.69896"/>
+  <Angle type1="hp" type2="p3" type3="p3" angle="1.6671385015" k="336.1844"/>
+  <Angle type1="hp" type2="p3" type3="p4" angle="1.67464341729" k="335.113296"/>
+  <Angle type1="hp" type2="p3" type3="p5" angle="1.66748756736" k="336.301552"/>
+  <Angle type1="hp" type2="p3" type3="s4" angle="1.66661490273" k="277.94312"/>
+  <Angle type1="hp" type2="p3" type3="s6" angle="1.62228353973" k="283.022496"/>
+  <Angle type1="hp" type2="p3" type3="sh" angle="1.6442746883" k="274.035264"/>
+  <Angle type1="hp" type2="p3" type3="ss" angle="1.65125600531" k="274.855328"/>
+  <Angle type1="i" type2="p3" type3="i" angle="1.83695903772" k="410.165888"/>
+  <Angle type1="n1" type2="p3" type3="n1" angle="1.5784757755" k="725.103936"/>
+  <Angle type1="n2" type2="p3" type3="n2" angle="1.80571764411" k="637.97632"/>
+  <Angle type1="n3" type2="p3" type3="n3" angle="1.98618468877" k="620.252896"/>
+  <Angle type1="n3" type2="p3" type3="o" angle="1.86924762889" k="675.766208"/>
+  <Angle type1="n3" type2="p3" type3="oh" angle="1.71670585226" k="677.213872"/>
+  <Angle type1="n4" type2="p3" type3="n4" angle="1.75457949703" k="607.26576"/>
+  <Angle type1="na" type2="p3" type3="na" angle="1.85388873147" k="630.344704"/>
+  <Angle type1="nh" type2="p3" type3="nh" angle="1.90432874685" k="633.440864"/>
+  <Angle type1="n" type2="p3" type3="n" angle="1.82526533174" k="632.394864"/>
+  <Angle type1="n" type2="p3" type3="o" angle="1.83242118167" k="672.008976"/>
+  <Angle type1="no" type2="p3" type3="no" angle="1.71618225349" k="626.01008"/>
+  <Angle type1="oh" type2="p3" type3="oh" angle="1.82352000248" k="667.783136"/>
+  <Angle type1="o" type2="p3" type3="o" angle="2.13244328009" k="683.556816"/>
+  <Angle type1="o" type2="p3" type3="p3" angle="2.03749736878" k="586.814368"/>
+  <Angle type1="o" type2="p3" type3="p5" angle="1.878323341" k="611.433024"/>
+  <Angle type1="o" type2="p3" type3="s4" angle="1.93207948196" k="495.862576"/>
+  <Angle type1="o" type2="p3" type3="s6" angle="1.86156818018" k="507.318368"/>
+  <Angle type1="os" type2="p3" type3="os" angle="1.74114046179" k="684.46056"/>
+  <Angle type1="p2" type2="p3" type3="p2" angle="1.80781203922" k="641.53272"/>
+  <Angle type1="p3" type2="p3" type3="p3" angle="1.83800623528" k="618.420304"/>
+  <Angle type1="p4" type2="p3" type3="p4" angle="1.7294467558" k="636.963792"/>
+  <Angle type1="p5" type2="p3" type3="p5" angle="1.72962128873" k="637.792224"/>
+  <Angle type1="s4" type2="p3" type3="s4" angle="1.71496052301" k="412.391776"/>
+  <Angle type1="s6" type2="p3" type3="s6" angle="1.7065829426" k="415.395888"/>
+  <Angle type1="sh" type2="p3" type3="sh" angle="1.8776252093" k="385.80664"/>
+  <Angle type1="s" type2="p3" type3="s" angle="2.29196637372" k="359.65664"/>
+  <Angle type1="ss" type2="p3" type3="ss" angle="1.90659767488" k="384.84432"/>
+  <Angle type1="br" type2="p4" type3="br" angle="1.92701802713" k="425.5128"/>
+  <Angle type1="br" type2="p4" type3="o" angle="2.17817090649" k="480.766704"/>
+  <Angle type1="c2" type2="p4" type3="c2" angle="1.8188076135" k="392.467568"/>
+  <Angle type1="c2" type2="p4" type3="hp" angle="1.73660260573" k="286.361328"/>
+  <Angle type1="c2" type2="p4" type3="o" angle="1.98251949734" k="506.406256"/>
+  <Angle type1="c3" type2="p4" type3="c3" angle="1.78983514792" k="392.032432"/>
+  <Angle type1="c3" type2="p4" type3="n2" angle="1.80065618928" k="504.163632"/>
+  <Angle type1="c3" type2="p4" type3="n3" angle="1.78669355527" k="509.410368"/>
+  <Angle type1="c3" type2="p4" type3="n4" angle="1.73782433621" k="484.448624"/>
+  <Angle type1="c3" type2="p4" type3="n" angle="1.80222698561" k="502.7076"/>
+  <Angle type1="c3" type2="p4" type3="na" angle="2.05372893082" k="488.883664"/>
+  <Angle type1="c3" type2="p4" type3="nh" angle="1.79402393812" k="507.284896"/>
+  <Angle type1="c3" type2="p4" type3="no" angle="1.74183859349" k="493.37728"/>
+  <Angle type1="c3" type2="p4" type3="o" angle="2.01882234578" k="498.43992"/>
+  <Angle type1="c3" type2="p4" type3="oh" angle="1.72019651077" k="525.811648"/>
+  <Angle type1="c3" type2="p4" type3="os" angle="1.71059719988" k="527.85344"/>
+  <Angle type1="c3" type2="p4" type3="p2" angle="1.90712127365" k="475.411184"/>
+  <Angle type1="c3" type2="p4" type3="p3" angle="1.80693937459" k="482.523984"/>
+  <Angle type1="c3" type2="p4" type3="p4" angle="1.78233023214" k="514.933248"/>
+  <Angle type1="c3" type2="p4" type3="p5" angle="1.81776041595" k="477.754224"/>
+  <Angle type1="c3" type2="p4" type3="sh" angle="1.74829631172" k="394.977968"/>
+  <Angle type1="c3" type2="p4" type3="ss" angle="1.76609867009" k="394.358736"/>
+  <Angle type1="ca" type2="p4" type3="ca" angle="1.88094133487" k="389.346304"/>
+  <Angle type1="ca" type2="p4" type3="o" angle="1.94848557693" k="514.121552"/>
+  <Angle type1="cl" type2="p4" type3="cl" angle="1.80659030874" k="520.732272"/>
+  <Angle type1="cl" type2="p4" type3="o" angle="2.03383217735" k="558.664416"/>
+  <Angle type1="hp" type2="p4" type3="hp" angle="1.7315411509" k="228.580288"/>
+  <Angle type1="hp" type2="p4" type3="n1" angle="1.74375845567" k="382.434336"/>
+  <Angle type1="hp" type2="p4" type3="o" angle="1.90851753706" k="395.162064"/>
+  <Angle type1="hp" type2="p4" type3="p3" angle="1.72717782777" k="329.138544"/>
+  <Angle type1="hp" type2="p4" type3="s" angle="1.9240509674" k="251.424928"/>
+  <Angle type1="i" type2="p4" type3="i" angle="1.97606177911" k="431.445712"/>
+  <Angle type1="i" type2="p4" type3="o" angle="1.92370190155" k="498.60728"/>
+  <Angle type1="n1" type2="p4" type3="n1" angle="1.75597576043" k="679.289136"/>
+  <Angle type1="n1" type2="p4" type3="o" angle="1.99997278986" k="667.615776"/>
+  <Angle type1="n2" type2="p4" type3="n2" angle="1.78966061499" k="655.699744"/>
+  <Angle type1="n2" type2="p4" type3="o" angle="2.0992820243" k="640.712656"/>
+  <Angle type1="n3" type2="p4" type3="o" angle="1.97693444373" k="667.155536"/>
+  <Angle type1="n4" type2="p4" type3="o" angle="1.87814880807" k="621.123168"/>
+  <Angle type1="na" type2="p4" type3="o" angle="1.93033415271" k="709.029008"/>
+  <Angle type1="nh" type2="p4" type3="nh" angle="1.66329877715" k="687.322416"/>
+  <Angle type1="nh" type2="p4" type3="o" angle="2.02213847136" k="657.381712"/>
+  <Angle type1="n" type2="p4" type3="o" angle="2.05931398443" k="644.386208"/>
+  <Angle type1="no" type2="p4" type3="o" angle="2.00171811911" k="618.863808"/>
+  <Angle type1="oh" type2="p4" type3="oh" angle="1.67045462708" k="713.020544"/>
+  <Angle type1="o" type2="p4" type3="o" angle="2.04587494919" k="703.020784"/>
+  <Angle type1="o" type2="p4" type3="oh" angle="2.04884200892" k="669.331216"/>
+  <Angle type1="o" type2="p4" type3="os" angle="2.0362756383" k="672.644944"/>
+  <Angle type1="o" type2="p4" type3="p2" angle="2.1179570473" k="584.555008"/>
+  <Angle type1="o" type2="p4" type3="p3" angle="1.98967534727" k="593.483664"/>
+  <Angle type1="o" type2="p4" type3="p4" angle="2.0320868481" k="635.248352"/>
+  <Angle type1="o" type2="p4" type3="p5" angle="1.91567338699" k="599.332896"/>
+  <Angle type1="o" type2="p4" type3="s4" angle="1.95808488781" k="459.118688"/>
+  <Angle type1="o" type2="p4" type3="s6" angle="1.9877554851" k="452.114672"/>
+  <Angle type1="o" type2="p4" type3="s" angle="1.9683823304" k="479.293936"/>
+  <Angle type1="o" type2="p4" type3="sh" angle="2.06105931368" k="474.71664"/>
+  <Angle type1="os" type2="p4" type3="os" angle="1.75126337145" k="698.502064"/>
+  <Angle type1="o" type2="p4" type3="ss" angle="2.02702539327" k="480.959168"/>
+  <Angle type1="p2" type2="p4" type3="p2" angle="1.93225401488" k="612.838848"/>
+  <Angle type1="p3" type2="p4" type3="p3" angle="2.00677957394" k="591.316352"/>
+  <Angle type1="p4" type2="p4" type3="p4" angle="1.87413455079" k="666.628352"/>
+  <Angle type1="p5" type2="p4" type3="p5" angle="1.8811158678" k="605.014768"/>
+  <Angle type1="s4" type2="p4" type3="s4" angle="1.67970487212" k="386.333824"/>
+  <Angle type1="s6" type2="p4" type3="s6" angle="1.78651902234" k="371.639616"/>
+  <Angle type1="sh" type2="p4" type3="sh" angle="1.7245598339" k="405.797792"/>
+  <Angle type1="s" type2="p4" type3="s" angle="1.85528499487" k="385.589072"/>
+  <Angle type1="ss" type2="p4" type3="ss" angle="1.82229827201" k="396.827296"/>
+  <Angle type1="br" type2="p5" type3="br" angle="1.80432138071" k="434.734336"/>
+  <Angle type1="br" type2="p5" type3="o" angle="2.00101998741" k="496.406496"/>
+  <Angle type1="br" type2="p5" type3="oh" angle="1.79629286615" k="520.523072"/>
+  <Angle type1="c1" type2="p5" type3="c1" angle="1.79576926738" k="410.517344"/>
+  <Angle type1="c1" type2="p5" type3="o" angle="2.02056767503" k="517.443648"/>
+  <Angle type1="c1" type2="p5" type3="oh" angle="1.79402393812" k="533.618992"/>
+  <Angle type1="c2" type2="p5" type3="c2" angle="1.85982285093" k="379.65616"/>
+  <Angle type1="c2" type2="p5" type3="o" angle="1.91148459678" k="508.615408"/>
+  <Angle type1="c2" type2="p5" type3="oh" angle="1.77482531635" k="516.071296"/>
+  <Angle type1="c2" type2="p5" type3="os" angle="1.69506376954" k="528.096112"/>
+  <Angle type1="c3" type2="p5" type3="c3" angle="1.85004900711" k="385.438448"/>
+  <Angle type1="c3" type2="p5" type3="hp" angle="1.80222698561" k="276.671184"/>
+  <Angle type1="c3" type2="p5" type3="n3" angle="1.82212373908" k="507.510832"/>
+  <Angle type1="c3" type2="p5" type3="o" angle="1.96349540849" k="506.6824"/>
+  <Angle type1="c3" type2="p5" type3="oh" angle="1.79227860887" k="517.862048"/>
+  <Angle type1="c3" type2="p5" type3="os" angle="1.75876828723" k="522.799168"/>
+  <Angle type1="c3" type2="p5" type3="p4" angle="1.85476139609" k="472.909152"/>
+  <Angle type1="c3" type2="p5" type3="s" angle="1.99665666428" k="390.551296"/>
+  <Angle type1="c3" type2="p5" type3="ss" angle="1.84900180956" k="383.706272"/>
+  <Angle type1="ca" type2="p5" type3="ca" angle="1.8832102629" k="391.45504"/>
+  <Angle type1="ca" type2="p5" type3="o" angle="1.98932628142" k="512.648784"/>
+  <Angle type1="ca" type2="p5" type3="oh" angle="1.77622157975" k="528.472672"/>
+  <Angle type1="ca" type2="p5" type3="os" angle="1.81077909894" k="523.426768"/>
+  <Angle type1="c" type2="p5" type3="c" angle="1.81793494888" k="380.082928"/>
+  <Angle type1="cl" type2="p5" type3="cl" angle="1.80990643432" k="520.255296"/>
+  <Angle type1="cl" type2="p5" type3="o" angle="1.96611340237" k="569.124416"/>
+  <Angle type1="cl" type2="p5" type3="oh" angle="1.78791528574" k="587.877104"/>
+  <Angle type1="c" type2="p5" type3="o" angle="1.86924762889" k="510.213696"/>
+  <Angle type1="c" type2="p5" type3="oh" angle="1.78233023214" k="511.385216"/>
+  <Angle type1="f" type2="p5" type3="f" angle="1.60954263619" k="773.261776"/>
+  <Angle type1="f" type2="p5" type3="o" angle="1.95599049271" k="712.40968"/>
+  <Angle type1="f" type2="p5" type3="oh" angle="1.77988677118" k="718.284016"/>
+  <Angle type1="f" type2="p5" type3="os" angle="1.78494822601" k="717.30496"/>
+  <Angle type1="f" type2="p5" type3="s" angle="2.04901654184" k="515.452064"/>
+  <Angle type1="hp" type2="p5" type3="hp" angle="1.75492856288" k="216.028288"/>
+  <Angle type1="hp" type2="p5" type3="n1" angle="1.76836759812" k="392.107744"/>
+  <Angle type1="hp" type2="p5" type3="o" angle="2.0085249032" k="380.183344"/>
+  <Angle type1="hp" type2="p5" type3="oh" angle="1.77273092125" k="384.727168"/>
+  <Angle type1="hp" type2="p5" type3="s" angle="2.08043246838" k="266.788576"/>
+  <Angle type1="i" type2="p5" type3="i" angle="1.87046935936" k="401.772784"/>
+  <Angle type1="i" type2="p5" type3="o" angle="2.02336020184" k="436.374464"/>
+  <Angle type1="i" type2="p5" type3="oh" angle="1.78477369309" k="468.44064"/>
+  <Angle type1="n1" type2="p5" type3="n1" angle="1.7723818554" k="723.053776"/>
+  <Angle type1="n1" type2="p5" type3="o" angle="1.98583562292" k="700.878576"/>
+  <Angle type1="n2" type2="p5" type3="n2" angle="1.85598312657" k="694.20928"/>
+  <Angle type1="n2" type2="p5" type3="o" angle="1.98147229979" k="694.493792"/>
+  <Angle type1="n2" type2="p5" type3="oh" angle="1.78721715404" k="703.899424"/>
+  <Angle type1="n3" type2="p5" type3="n3" angle="1.80414684779" k="674.33528"/>
+  <Angle type1="n3" type2="p5" type3="nh" angle="1.81234989527" k="672.527792"/>
+  <Angle type1="n3" type2="p5" type3="o" angle="2.00084545449" k="672.921088"/>
+  <Angle type1="n3" type2="p5" type3="oh" angle="1.83242118167" k="679.883264"/>
+  <Angle type1="n3" type2="p5" type3="os" angle="1.78425009431" k="689.037856"/>
+  <Angle type1="n3" type2="p5" type3="s" angle="2.03435577612" k="502.548608"/>
+  <Angle type1="n4" type2="p5" type3="n4" angle="1.78372649554" k="618.746656"/>
+  <Angle type1="n4" type2="p5" type3="o" angle="1.91602245284" k="644.83808"/>
+  <Angle type1="n4" type2="p5" type3="oh" angle="1.71880024736" k="664.477776"/>
+  <Angle type1="n4" type2="p5" type3="os" angle="1.65020880776" k="678.176192"/>
+  <Angle type1="na" type2="p5" type3="na" angle="1.89490396889" k="640.5704"/>
+  <Angle type1="na" type2="p5" type3="o" angle="1.97972697054" k="664.603296"/>
+  <Angle type1="na" type2="p5" type3="oh" angle="1.78145756751" k="679.280768"/>
+  <Angle type1="na" type2="p5" type3="os" angle="1.79873632711" k="676.05072"/>
+  <Angle type1="nh" type2="p5" type3="nh" angle="1.73677713866" k="686.711552"/>
+  <Angle type1="nh" type2="p5" type3="o" angle="2.00468517884" k="671.916928"/>
+  <Angle type1="nh" type2="p5" type3="oh" angle="1.79611833323" k="686.401936"/>
+  <Angle type1="nh" type2="p5" type3="os" angle="1.8360863731" k="678.929312"/>
+  <Angle type1="n" type2="p5" type3="n3" angle="1.82055294276" k="661.61592"/>
+  <Angle type1="n" type2="p5" type3="n" angle="1.79925992588" k="656.570016"/>
+  <Angle type1="n" type2="p5" type3="o" angle="1.95791035489" k="667.741296"/>
+  <Angle type1="n" type2="p5" type3="oh" angle="1.78791528574" k="677.582064"/>
+  <Angle type1="no" type2="p5" type3="no" angle="1.66993102831" k="638.085104"/>
+  <Angle type1="no" type2="p5" type3="o" angle="1.96785873162" k="635.231616"/>
+  <Angle type1="no" type2="p5" type3="oh" angle="1.7688911969" k="654.059616"/>
+  <Angle type1="no" type2="p5" type3="os" angle="1.77499984928" k="652.963408"/>
+  <Angle type1="n" type2="p5" type3="os" angle="1.7537068324" k="684.192784"/>
+  <Angle type1="oh" type2="p5" type3="oh" angle="1.79227860887" k="699.48112"/>
+  <Angle type1="oh" type2="p5" type3="os" angle="1.77918863948" k="702.091936"/>
+  <Angle type1="oh" type2="p5" type3="p2" angle="1.80693937459" k="628.386592"/>
+  <Angle type1="oh" type2="p5" type3="p3" angle="1.81217536235" k="619.290576"/>
+  <Angle type1="oh" type2="p5" type3="p4" angle="1.77657064561" k="619.499776"/>
+  <Angle type1="oh" type2="p5" type3="p5" angle="1.75318323363" k="670.301904"/>
+  <Angle type1="oh" type2="p5" type3="s4" angle="1.80187791976" k="518.004304"/>
+  <Angle type1="oh" type2="p5" type3="s6" angle="1.77116012492" k="522.481184"/>
+  <Angle type1="oh" type2="p5" type3="s" angle="1.94255145747" k="519.40176"/>
+  <Angle type1="oh" type2="p5" type3="sh" angle="1.76993839445" k="514.205232"/>
+  <Angle type1="oh" type2="p5" type3="ss" angle="1.8167132184" k="500.523552"/>
+  <Angle type1="o" type2="p5" type3="o" angle="2.02109127381" k="715.54768"/>
+  <Angle type1="o" type2="p5" type3="oh" angle="2.01079383122" k="685.347568"/>
+  <Angle type1="o" type2="p5" type3="os" angle="2.01515715435" k="684.661392"/>
+  <Angle type1="o" type2="p5" type3="p2" angle="2.00014732279" k="601.592256"/>
+  <Angle type1="o" type2="p5" type3="p3" angle="2.0155062202" k="590.646912"/>
+  <Angle type1="o" type2="p5" type3="p4" angle="2.00119452034" k="586.51312"/>
+  <Angle type1="o" type2="p5" type3="p5" angle="1.97990150346" k="638.930272"/>
+  <Angle type1="o" type2="p5" type3="s4" angle="1.92387643447" k="508.1468"/>
+  <Angle type1="o" type2="p5" type3="s6" angle="1.9504054391" k="504.682448"/>
+  <Angle type1="o" type2="p5" type3="s" angle="2.04098802728" k="516.322336"/>
+  <Angle type1="o" type2="p5" type3="sh" angle="1.99944919108" k="489.427584"/>
+  <Angle type1="os" type2="p5" type3="os" angle="1.77744331023" k="702.485232"/>
+  <Angle type1="os" type2="p5" type3="p3" angle="1.80938283554" k="619.77592"/>
+  <Angle type1="os" type2="p5" type3="p5" angle="1.82352000248" k="657.26456"/>
+  <Angle type1="os" type2="p5" type3="s4" angle="1.78931154914" k="519.836896"/>
+  <Angle type1="os" type2="p5" type3="s6" angle="1.77831597486" k="521.435184"/>
+  <Angle type1="o" type2="p5" type3="ss" angle="1.99560946673" k="482.339888"/>
+  <Angle type1="os" type2="p5" type3="s" angle="2.04430415286" k="506.330944"/>
+  <Angle type1="os" type2="p5" type3="sh" angle="1.78110850166" k="512.606944"/>
+  <Angle type1="os" type2="p5" type3="ss" angle="1.78861341744" k="504.448144"/>
+  <Angle type1="p2" type2="p5" type3="p2" angle="1.86994576059" k="622.679616"/>
+  <Angle type1="p3" type2="p5" type3="p3" angle="1.83660997187" k="618.93912"/>
+  <Angle type1="p4" type2="p5" type3="p4" angle="1.77360358588" k="623.08128"/>
+  <Angle type1="p5" type2="p5" type3="p5" angle="1.96733513285" k="644.310896"/>
+  <Angle type1="s6" type2="p5" type3="s6" angle="1.83573730725" k="407.781008"/>
+  <Angle type1="sh" type2="p5" type3="sh" angle="1.82491626589" k="400.735152"/>
+  <Angle type1="sh" type2="p5" type3="ss" angle="1.86977122766" k="392.484304"/>
+  <Angle type1="s" type2="p5" type3="s" angle="1.9919442753" k="412.893856"/>
+  <Angle type1="ss" type2="p5" type3="ss" angle="1.91305539311" k="384.810848"/>
+  <Angle type1="cd" type2="pc" type3="n" angle="1.58475896081" k="552.421888"/>
+  <Angle type1="cd" type2="pc" type3="na" angle="1.57393791945" k="555.601728"/>
+  <Angle type1="cc" type2="pd" type3="n" angle="1.58475896081" k="552.421888"/>
+  <Angle type1="cc" type2="pd" type3="na" angle="1.57393791945" k="555.601728"/>
+  <Angle type1="c2" type2="pe" type3="ca" angle="1.77046199322" k="410.768384"/>
+  <Angle type1="c2" type2="pe" type3="ce" angle="1.79786366248" k="409.094784"/>
+  <Angle type1="c2" type2="pe" type3="cg" angle="1.81566602085" k="432.131888"/>
+  <Angle type1="c2" type2="pe" type3="n2" angle="1.64305295783" k="581.140864"/>
+  <Angle type1="c2" type2="pe" type3="ne" angle="1.72263997172" k="541.091616"/>
+  <Angle type1="c2" type2="pe" type3="o" angle="2.0099211666" k="527.903648"/>
+  <Angle type1="c2" type2="pe" type3="p2" angle="1.8818139995" k="545.861376"/>
+  <Angle type1="c2" type2="pe" type3="pe" angle="1.79751459663" k="516.037824"/>
+  <Angle type1="c2" type2="pe" type3="px" angle="1.69942709267" k="547.635392"/>
+  <Angle type1="c2" type2="pe" type3="py" angle="1.6879079196" k="545.5936"/>
+  <Angle type1="c2" type2="pe" type3="s" angle="1.94010799652" k="433.981216"/>
+  <Angle type1="c2" type2="pe" type3="sx" angle="1.65998265157" k="406.868896"/>
+  <Angle type1="c2" type2="pe" type3="sy" angle="1.66783663321" k="399.136864"/>
+  <Angle type1="ca" type2="pe" type3="n2" angle="1.78075943581" k="529.384784"/>
+  <Angle type1="ca" type2="pe" type3="o" angle="1.86540790453" k="519.0252"/>
+  <Angle type1="ca" type2="pe" type3="p2" angle="1.75911735309" k="545.752592"/>
+  <Angle type1="ca" type2="pe" type3="pf" angle="1.74009326424" k="518.757424"/>
+  <Angle type1="ca" type2="pe" type3="s" angle="1.88373386168" k="423.203232"/>
+  <Angle type1="c" type2="pe" type3="c2" angle="1.69820536219" k="408.040416"/>
+  <Angle type1="ce" type2="pe" type3="n2" angle="1.75492856288" k="535.552"/>
+  <Angle type1="ce" type2="pe" type3="o" angle="1.87518174834" k="519.937312"/>
+  <Angle type1="ce" type2="pe" type3="p2" angle="1.73764980329" k="550.681344"/>
+  <Angle type1="ce" type2="pe" type3="s" angle="1.84202049255" k="429.378816"/>
+  <Angle type1="cg" type2="pe" type3="n2" angle="1.77657064561" k="572.505088"/>
+  <Angle type1="cg" type2="pe" type3="o" angle="1.878323341" k="559.743888"/>
+  <Angle type1="cg" type2="pe" type3="p2" angle="1.82701066099" k="561.95304"/>
+  <Angle type1="cg" type2="pe" type3="s" angle="1.89542756767" k="446.742416"/>
+  <Angle type1="n2" type2="pe" type3="n2" angle="1.88739905311" k="714.777824"/>
+  <Angle type1="n2" type2="pe" type3="ne" angle="1.86401164113" k="677.406336"/>
+  <Angle type1="n2" type2="pe" type3="o" angle="2.01393542388" k="696.200864"/>
+  <Angle type1="n2" type2="pe" type3="p2" angle="1.94778744523" k="691.857872"/>
+  <Angle type1="n2" type2="pe" type3="pe" angle="1.90939020168" k="637.532816"/>
+  <Angle type1="n2" type2="pe" type3="px" angle="1.92509816495" k="658.22688"/>
+  <Angle type1="n2" type2="pe" type3="py" angle="1.63502444327" k="708.376304"/>
+  <Angle type1="n2" type2="pe" type3="s" angle="2.00433611299" k="554.354896"/>
+  <Angle type1="n2" type2="pe" type3="sx" angle="1.70745560723" k="508.849712"/>
+  <Angle type1="n2" type2="pe" type3="sy" angle="1.71286612791" k="498.48176"/>
+  <Angle type1="ne" type2="pe" type3="o" angle="1.9240509674" k="669.749616"/>
+  <Angle type1="ne" type2="pe" type3="p2" angle="1.82352000248" k="690.744928"/>
+  <Angle type1="ne" type2="pe" type3="s" angle="1.90572501025" k="544.890688"/>
+  <Angle type1="o" type2="pe" type3="o" angle="2.09369697069" k="687.129952"/>
+  <Angle type1="o" type2="pe" type3="p2" angle="1.99368960455" k="686.00864"/>
+  <Angle type1="o" type2="pe" type3="pe" angle="2.54748257621" k="552.764976"/>
+  <Angle type1="o" type2="pe" type3="px" angle="1.82160014031" k="678.092512"/>
+  <Angle type1="o" type2="pe" type3="py" angle="1.82369453541" k="672.050816"/>
+  <Angle type1="o" type2="pe" type3="s" angle="2.04936560769" k="550.472144"/>
+  <Angle type1="o" type2="pe" type3="sx" angle="1.8603464497" k="487.971552"/>
+  <Angle type1="o" type2="pe" type3="sy" angle="1.83329384629" k="482.172528"/>
+  <Angle type1="p2" type2="pe" type3="pe" angle="1.71461145716" k="711.53104"/>
+  <Angle type1="p2" type2="pe" type3="px" angle="1.88984251406" k="695.690416"/>
+  <Angle type1="p2" type2="pe" type3="py" angle="1.93504654169" k="683.464768"/>
+  <Angle type1="p2" type2="pe" type3="s" angle="1.94220239162" k="571.592976"/>
+  <Angle type1="p2" type2="pe" type3="sx" angle="1.67080369293" k="548.514032"/>
+  <Angle type1="p2" type2="pe" type3="sy" angle="1.67464341729" k="540.079088"/>
+  <Angle type1="pe" type2="pe" type3="s" angle="1.88338479583" k="539.334336"/>
+  <Angle type1="px" type2="pe" type3="s" angle="1.878323341" k="556.120544"/>
+  <Angle type1="py" type2="pe" type3="s" angle="1.89769649569" k="549.601872"/>
+  <Angle type1="s" type2="pe" type3="s" angle="3.11436551726" k="363.288352"/>
+  <Angle type1="s" type2="pe" type3="sx" angle="1.89054064576" k="408.575968"/>
+  <Angle type1="s" type2="pe" type3="sy" angle="1.86628056916" k="404.76016"/>
+  <Angle type1="c2" type2="pf" type3="ca" angle="1.77046199322" k="410.768384"/>
+  <Angle type1="c2" type2="pf" type3="cf" angle="1.79786366248" k="409.094784"/>
+  <Angle type1="c2" type2="pf" type3="ch" angle="1.81566602085" k="432.131888"/>
+  <Angle type1="c2" type2="pf" type3="n2" angle="1.64305295783" k="581.140864"/>
+  <Angle type1="c2" type2="pf" type3="nf" angle="1.72263997172" k="541.091616"/>
+  <Angle type1="c2" type2="pf" type3="o" angle="2.0099211666" k="527.903648"/>
+  <Angle type1="c2" type2="pf" type3="p2" angle="1.8818139995" k="545.861376"/>
+  <Angle type1="c2" type2="pf" type3="pf" angle="1.79751459663" k="516.037824"/>
+  <Angle type1="c2" type2="pf" type3="px" angle="1.69942709267" k="547.635392"/>
+  <Angle type1="c2" type2="pf" type3="py" angle="1.6879079196" k="545.5936"/>
+  <Angle type1="c2" type2="pf" type3="s" angle="1.94010799652" k="433.981216"/>
+  <Angle type1="c2" type2="pf" type3="sx" angle="1.65998265157" k="406.868896"/>
+  <Angle type1="c2" type2="pf" type3="sy" angle="1.66783663321" k="399.136864"/>
+  <Angle type1="ca" type2="pf" type3="n2" angle="1.78075943581" k="529.384784"/>
+  <Angle type1="ca" type2="pf" type3="o" angle="1.86540790453" k="519.0252"/>
+  <Angle type1="ca" type2="pf" type3="p2" angle="1.75911735309" k="545.752592"/>
+  <Angle type1="ca" type2="pf" type3="pe" angle="1.74009326424" k="518.757424"/>
+  <Angle type1="ca" type2="pf" type3="s" angle="1.88373386168" k="423.203232"/>
+  <Angle type1="c" type2="pf" type3="c2" angle="1.69820536219" k="408.040416"/>
+  <Angle type1="cf" type2="pf" type3="n2" angle="1.75492856288" k="535.552"/>
+  <Angle type1="cf" type2="pf" type3="o" angle="1.87518174834" k="519.937312"/>
+  <Angle type1="cf" type2="pf" type3="p2" angle="1.73764980329" k="550.681344"/>
+  <Angle type1="cf" type2="pf" type3="s" angle="1.84202049255" k="429.378816"/>
+  <Angle type1="ch" type2="pf" type3="n2" angle="1.77657064561" k="572.505088"/>
+  <Angle type1="ch" type2="pf" type3="o" angle="1.878323341" k="559.743888"/>
+  <Angle type1="ch" type2="pf" type3="p2" angle="1.82701066099" k="561.95304"/>
+  <Angle type1="ch" type2="pf" type3="s" angle="1.89542756767" k="446.742416"/>
+  <Angle type1="n2" type2="pf" type3="n2" angle="1.88739905311" k="714.777824"/>
+  <Angle type1="n2" type2="pf" type3="nf" angle="1.86401164113" k="677.406336"/>
+  <Angle type1="n2" type2="pf" type3="o" angle="2.01393542388" k="696.200864"/>
+  <Angle type1="n2" type2="pf" type3="p2" angle="1.94778744523" k="691.857872"/>
+  <Angle type1="n2" type2="pf" type3="pf" angle="1.90939020168" k="637.532816"/>
+  <Angle type1="n2" type2="pf" type3="px" angle="1.92509816495" k="658.22688"/>
+  <Angle type1="n2" type2="pf" type3="py" angle="1.63502444327" k="708.376304"/>
+  <Angle type1="n2" type2="pf" type3="s" angle="2.00433611299" k="554.354896"/>
+  <Angle type1="n2" type2="pf" type3="sx" angle="1.70745560723" k="508.849712"/>
+  <Angle type1="n2" type2="pf" type3="sy" angle="1.71286612791" k="498.48176"/>
+  <Angle type1="nf" type2="pf" type3="o" angle="1.9240509674" k="669.749616"/>
+  <Angle type1="nf" type2="pf" type3="p2" angle="1.82352000248" k="690.744928"/>
+  <Angle type1="nf" type2="pf" type3="s" angle="1.90572501025" k="544.890688"/>
+  <Angle type1="o" type2="pf" type3="o" angle="2.09369697069" k="687.129952"/>
+  <Angle type1="o" type2="pf" type3="p2" angle="1.99368960455" k="686.00864"/>
+  <Angle type1="o" type2="pf" type3="pf" angle="2.54748257621" k="552.764976"/>
+  <Angle type1="o" type2="pf" type3="px" angle="1.82160014031" k="678.092512"/>
+  <Angle type1="o" type2="pf" type3="py" angle="1.82369453541" k="672.050816"/>
+  <Angle type1="o" type2="pf" type3="s" angle="2.04936560769" k="550.472144"/>
+  <Angle type1="o" type2="pf" type3="sx" angle="1.8603464497" k="487.971552"/>
+  <Angle type1="o" type2="pf" type3="sy" angle="1.83329384629" k="482.172528"/>
+  <Angle type1="p2" type2="pf" type3="pf" angle="1.71461145716" k="711.53104"/>
+  <Angle type1="p2" type2="pf" type3="px" angle="1.88984251406" k="695.690416"/>
+  <Angle type1="p2" type2="pf" type3="py" angle="1.93504654169" k="683.464768"/>
+  <Angle type1="p2" type2="pf" type3="s" angle="1.94220239162" k="571.592976"/>
+  <Angle type1="p2" type2="pf" type3="sx" angle="1.67080369293" k="548.514032"/>
+  <Angle type1="p2" type2="pf" type3="sy" angle="1.67464341729" k="540.079088"/>
+  <Angle type1="pf" type2="pf" type3="s" angle="1.88338479583" k="539.334336"/>
+  <Angle type1="px" type2="pf" type3="s" angle="1.878323341" k="556.120544"/>
+  <Angle type1="py" type2="pf" type3="s" angle="1.89769649569" k="549.601872"/>
+  <Angle type1="s" type2="pf" type3="s" angle="3.11436551726" k="363.288352"/>
+  <Angle type1="s" type2="pf" type3="sx" angle="1.89054064576" k="408.575968"/>
+  <Angle type1="s" type2="pf" type3="sy" angle="1.86628056916" k="404.76016"/>
+  <Angle type1="c3" type2="px" type3="ca" angle="1.82893052316" k="390.350464"/>
+  <Angle type1="c3" type2="px" type3="ce" angle="1.83015225364" k="390.643344"/>
+  <Angle type1="c3" type2="px" type3="cf" angle="1.83015225364" k="390.643344"/>
+  <Angle type1="c3" type2="px" type3="ne" angle="1.78826435159" k="510.247168"/>
+  <Angle type1="c3" type2="px" type3="nf" angle="1.78826435159" k="510.247168"/>
+  <Angle type1="c3" type2="px" type3="o" angle="1.98601015584" k="504.648976"/>
+  <Angle type1="c3" type2="px" type3="pe" angle="1.84533661813" k="511.66136"/>
+  <Angle type1="c3" type2="px" type3="pf" angle="1.84533661813" k="511.66136"/>
+  <Angle type1="c3" type2="px" type3="py" angle="1.79960899173" k="486.950656"/>
+  <Angle type1="c3" type2="px" type3="sx" angle="1.73747527036" k="380.677056"/>
+  <Angle type1="c3" type2="px" type3="sy" angle="1.80484497949" k="372.62704"/>
+  <Angle type1="ca" type2="px" type3="ca" angle="1.81776041595" k="391.932016"/>
+  <Angle type1="ca" type2="px" type3="o" angle="1.87622894589" k="519.962416"/>
+  <Angle type1="c" type2="px" type3="c3" angle="1.77534891513" k="387.496976"/>
+  <Angle type1="ce" type2="px" type3="ce" angle="1.8188076135" k="392.676768"/>
+  <Angle type1="ce" type2="px" type3="o" angle="1.98601015584" k="506.205424"/>
+  <Angle type1="cf" type2="px" type3="cf" angle="1.8188076135" k="392.676768"/>
+  <Angle type1="cf" type2="px" type3="o" angle="1.98601015584" k="506.205424"/>
+  <Angle type1="c" type2="px" type3="o" angle="1.99787839476" k="487.804192"/>
+  <Angle type1="ne" type2="px" type3="ne" angle="1.80152885391" k="661.984112"/>
+  <Angle type1="ne" type2="px" type3="o" angle="1.9919442753" k="663.423408"/>
+  <Angle type1="nf" type2="px" type3="nf" angle="1.80152885391" k="661.984112"/>
+  <Angle type1="nf" type2="px" type3="o" angle="1.9919442753" k="663.423408"/>
+  <Angle type1="o" type2="px" type3="pe" angle="2.03330857857" k="642.972016"/>
+  <Angle type1="o" type2="px" type3="pf" angle="2.03330857857" k="642.972016"/>
+  <Angle type1="o" type2="px" type3="py" angle="1.99316600578" k="597.374784"/>
+  <Angle type1="o" type2="px" type3="sx" angle="1.96890592917" k="459.65424"/>
+  <Angle type1="o" type2="px" type3="sy" angle="1.98164683271" k="456.775648"/>
+  <Angle type1="pe" type2="px" type3="pe" angle="1.93225401488" k="666.025856"/>
+  <Angle type1="pf" type2="px" type3="pf" angle="1.93225401488" k="666.025856"/>
+  <Angle type1="py" type2="px" type3="py" angle="1.8811158678" k="615.4664"/>
+  <Angle type1="sx" type2="px" type3="sx" angle="1.67970487212" k="387.890272"/>
+  <Angle type1="sy" type2="px" type3="sy" angle="1.78651902234" k="374.944976"/>
+  <Angle type1="c3" type2="py" type3="n4" angle="1.81217536235" k="479.243728"/>
+  <Angle type1="c3" type2="py" type3="na" angle="1.86558243746" k="496.590592"/>
+  <Angle type1="c3" type2="py" type3="o" angle="2.03645017123" k="497.410656"/>
+  <Angle type1="c3" type2="py" type3="oh" angle="1.7481217788" k="524.179888"/>
+  <Angle type1="c3" type2="py" type3="os" angle="1.83940249868" k="510.765984"/>
+  <Angle type1="c3" type2="py" type3="px" angle="1.85476139609" k="478.8588"/>
+  <Angle type1="c3" type2="py" type3="py" angle="1.91689511747" k="473.04304"/>
+  <Angle type1="c3" type2="py" type3="sx" angle="1.85633219242" k="365.648128"/>
+  <Angle type1="ca" type2="py" type3="ca" angle="1.87710161052" k="387.555552"/>
+  <Angle type1="ca" type2="py" type3="o" angle="1.99543493381" k="507.39368"/>
+  <Angle type1="ca" type2="py" type3="oh" angle="1.79542020153" k="521.594176"/>
+  <Angle type1="ca" type2="py" type3="os" angle="1.76906572982" k="525.200784"/>
+  <Angle type1="c" type2="py" type3="c3" angle="1.9261453625" k="374.878032"/>
+  <Angle type1="c" type2="py" type3="c" angle="1.81863308058" k="383.020096"/>
+  <Angle type1="ce" type2="py" type3="ce" angle="1.85947378507" k="391.672608"/>
+  <Angle type1="ce" type2="py" type3="o" angle="1.99037347897" k="510.255536"/>
+  <Angle type1="ce" type2="py" type3="oh" angle="1.82858145731" k="518.790896"/>
+  <Angle type1="ce" type2="py" type3="os" angle="1.83050131949" k="518.246976"/>
+  <Angle type1="cf" type2="py" type3="cf" angle="1.85947378507" k="391.672608"/>
+  <Angle type1="cf" type2="py" type3="o" angle="1.99037347897" k="510.255536"/>
+  <Angle type1="cf" type2="py" type3="oh" angle="1.82858145731" k="518.790896"/>
+  <Angle type1="cf" type2="py" type3="os" angle="1.83050131949" k="518.246976"/>
+  <Angle type1="c" type2="py" type3="o" angle="1.98967534727" k="497.536176"/>
+  <Angle type1="c" type2="py" type3="oh" angle="1.80152885391" k="511.2848"/>
+  <Angle type1="c" type2="py" type3="os" angle="1.74550378492" k="519.184192"/>
+  <Angle type1="n3" type2="py" type3="ne" angle="1.89822009447" k="664.494512"/>
+  <Angle type1="n4" type2="py" type3="o" angle="2.01725154946" k="609.751056"/>
+  <Angle type1="n4" type2="py" type3="py" angle="0.961676417849" k="827.837872"/>
+  <Angle type1="na" type2="py" type3="o" angle="2.13628300444" k="640.419776"/>
+  <Angle type1="na" type2="py" type3="py" angle="0.888023523415" k="885.652384"/>
+  <Angle type1="ne" type2="py" type3="ne" angle="2.06280464293" k="656.067936"/>
+  <Angle type1="ne" type2="py" type3="o" angle="1.97588724618" k="693.79088"/>
+  <Angle type1="ne" type2="py" type3="oh" angle="1.82735972684" k="694.58584"/>
+  <Angle type1="ne" type2="py" type3="os" angle="1.89001704698" k="682.485712"/>
+  <Angle type1="nf" type2="py" type3="nf" angle="2.06280464293" k="656.067936"/>
+  <Angle type1="nf" type2="py" type3="o" angle="1.97588724618" k="693.79088"/>
+  <Angle type1="nf" type2="py" type3="oh" angle="1.82735972684" k="694.58584"/>
+  <Angle type1="nf" type2="py" type3="os" angle="1.89001704698" k="682.485712"/>
+  <Angle type1="oh" type2="py" type3="oh" angle="1.77465078343" k="702.384816"/>
+  <Angle type1="oh" type2="py" type3="pe" angle="1.82980318779" k="663.389936"/>
+  <Angle type1="oh" type2="py" type3="pf" angle="1.82980318779" k="663.389936"/>
+  <Angle type1="oh" type2="py" type3="px" angle="1.82037840983" k="621.290528"/>
+  <Angle type1="oh" type2="py" type3="py" angle="1.75318323363" k="636.361296"/>
+  <Angle type1="oh" type2="py" type3="sx" angle="1.76173534696" k="480.465456"/>
+  <Angle type1="oh" type2="py" type3="sy" angle="1.770985592" k="494.155504"/>
+  <Angle type1="o" type2="py" type3="oh" angle="2.02161487259" k="683.021264"/>
+  <Angle type1="o" type2="py" type3="os" angle="2.02440739939" k="681.958528"/>
+  <Angle type1="o" type2="py" type3="pe" angle="1.99944919108" k="643.800448"/>
+  <Angle type1="o" type2="py" type3="pf" angle="1.99944919108" k="643.800448"/>
+  <Angle type1="o" type2="py" type3="px" angle="1.94377318795" k="605.157024"/>
+  <Angle type1="o" type2="py" type3="py" angle="2.10190001818" k="585.291392"/>
+  <Angle type1="os" type2="py" type3="os" angle="1.77709424438" k="700.90368"/>
+  <Angle type1="os" type2="py" type3="py" angle="1.82543986466" k="623.524784"/>
+  <Angle type1="os" type2="py" type3="sx" angle="1.81269896112" k="473.595328"/>
+  <Angle type1="os" type2="py" type3="sy" angle="1.78233023214" k="492.481904"/>
+  <Angle type1="o" type2="py" type3="sx" angle="2.06926236116" k="445.09392"/>
+  <Angle type1="o" type2="py" type3="sy" angle="1.9497073074" k="474.373552"/>
+  <Angle type1="pe" type2="py" type3="pe" angle="1.86994576059" k="670.343744"/>
+  <Angle type1="pf" type2="py" type3="pf" angle="1.86994576059" k="670.343744"/>
+  <Angle type1="py" type2="py" type3="py" angle="1.966986067" k="605.458272"/>
+  <Angle type1="py" type2="py" type3="sx" angle="1.07407562168" k="627.633472"/>
+  <Angle type1="sy" type2="py" type3="sy" angle="1.83556277432" k="381.254448"/>
+  <Angle type1="c1" type2="s2" type3="o" angle="2.04639854796" k="788.842992"/>
+  <Angle type1="c2" type2="s2" type3="n2" angle="1.93452294291" k="820.884064"/>
+  <Angle type1="c2" type2="s2" type3="o" angle="2.00189265204" k="793.821952"/>
+  <Angle type1="cl" type2="s2" type3="n1" angle="2.0542525296" k="778.006432"/>
+  <Angle type1="f" type2="s2" type3="n1" angle="2.04028989558" k="1028.519248"/>
+  <Angle type1="n1" type2="s2" type3="o" angle="1.89298410671" k="1071.078896"/>
+  <Angle type1="n2" type2="s2" type3="o" angle="2.11533905342" k="986.737824"/>
+  <Angle type1="o" type2="s2" type3="o" angle="2.02754899204" k="991.172864"/>
+  <Angle type1="o" type2="s2" type3="s" angle="2.06472450511" k="764.483744"/>
+  <Angle type1="s" type2="s2" type3="s" angle="2.00782677149" k="625.725568"/>
+  <Angle type1="br" type2="s4" type3="br" angle="1.7107717328" k="624.997552"/>
+  <Angle type1="br" type2="s4" type3="c3" angle="1.6228071385" k="606.152816"/>
+  <Angle type1="br" type2="s4" type3="o" angle="1.95599049271" k="703.029152"/>
+  <Angle type1="c1" type2="s4" type3="c1" angle="1.63275551524" k="645.055648"/>
+  <Angle type1="c1" type2="s4" type3="o" angle="1.9261453625" k="790.240448"/>
+  <Angle type1="c2" type2="s4" type3="c2" angle="1.78529729186" k="611.976944"/>
+  <Angle type1="c2" type2="s4" type3="c3" angle="1.65719012477" k="622.236112"/>
+  <Angle type1="c2" type2="s4" type3="o" angle="1.86907309596" k="797.80512"/>
+  <Angle type1="c3" type2="s4" type3="c3" angle="1.67761047702" k="606.997984"/>
+  <Angle type1="c3" type2="s4" type3="ca" angle="1.65806278939" k="617.566768"/>
+  <Angle type1="c3" type2="s4" type3="f" angle="1.60046692408" k="836.431808"/>
+  <Angle type1="c3" type2="s4" type3="hs" angle="1.58126830231" k="444.834512"/>
+  <Angle type1="c3" type2="s4" type3="i" angle="1.58004657183" k="537.259072"/>
+  <Angle type1="c3" type2="s4" type3="n2" angle="1.58109376938" k="826.331632"/>
+  <Angle type1="c3" type2="s4" type3="n3" angle="1.67150182463" k="776.960432"/>
+  <Angle type1="c3" type2="s4" type3="n" angle="1.67673781239" k="773.027472"/>
+  <Angle type1="c3" type2="s4" type3="n4" angle="1.61390595932" k="744.065824"/>
+  <Angle type1="c3" type2="s4" type3="na" angle="1.62437793483" k="780.290896"/>
+  <Angle type1="c3" type2="s4" type3="nh" angle="1.69436563784" k="772.759696"/>
+  <Angle type1="c3" type2="s4" type3="no" angle="1.56259327931" k="750.710016"/>
+  <Angle type1="c3" type2="s4" type3="o" angle="1.8624408448" k="776.977168"/>
+  <Angle type1="c3" type2="s4" type3="oh" angle="1.5756832487" k="811.896832"/>
+  <Angle type1="c3" type2="s4" type3="os" angle="1.57184352435" k="813.587168"/>
+  <Angle type1="c3" type2="s4" type3="p2" angle="1.64706721511" k="761.638624"/>
+  <Angle type1="c3" type2="s4" type3="p3" angle="1.68494085988" k="778.575456"/>
+  <Angle type1="c3" type2="s4" type3="p4" angle="1.69995069144" k="734.635088"/>
+  <Angle type1="c3" type2="s4" type3="p5" angle="1.73101755213" k="779.587984"/>
+  <Angle type1="c3" type2="s4" type3="s4" angle="1.56206968053" k="631.49112"/>
+  <Angle type1="c3" type2="s4" type3="s" angle="1.72298903757" k="602.044128"/>
+  <Angle type1="c3" type2="s4" type3="s6" angle="1.70134695484" k="605.098448"/>
+  <Angle type1="c3" type2="s4" type3="sh" angle="1.65212866994" k="596.872704"/>
+  <Angle type1="c3" type2="s4" type3="ss" angle="1.66347331008" k="595.224208"/>
+  <Angle type1="ca" type2="s4" type3="ca" angle="1.66172798082" k="624.386688"/>
+  <Angle type1="ca" type2="s4" type3="o" angle="1.8610445814" k="790.683952"/>
+  <Angle type1="c" type2="s4" type3="c3" angle="1.65928451987" k="603.684256"/>
+  <Angle type1="c" type2="s4" type3="c" angle="1.51546938951" k="625.148176"/>
+  <Angle type1="cl" type2="s4" type3="cl" angle="1.70483761335" k="775.236624"/>
+  <Angle type1="cl" type2="s4" type3="o" angle="1.89088971161" k="841.301984"/>
+  <Angle type1="c" type2="s4" type3="o" angle="1.85301606684" k="766.483696"/>
+  <Angle type1="cx" type2="s4" type3="cx" angle="0.851720674973" k="855.862304"/>
+  <Angle type1="cx" type2="s4" type3="o" angle="1.91986217719" k="767.906256"/>
+  <Angle type1="f" type2="s4" type3="f" angle="1.61809474952" k="1147.411792"/>
+  <Angle type1="f" type2="s4" type3="o" angle="1.86418617406" k="1081.68952"/>
+  <Angle type1="f" type2="s4" type3="s" angle="1.87622894589" k="759.864608"/>
+  <Angle type1="hs" type2="s4" type3="hs" angle="1.51843644924" k="357.372176"/>
+  <Angle type1="hs" type2="s4" type3="n1" angle="1.57969750598" k="604.83904"/>
+  <Angle type1="hs" type2="s4" type3="o" angle="1.92457456617" k="582.965088"/>
+  <Angle type1="i" type2="s4" type3="i" angle="1.69803082927" k="569.199728"/>
+  <Angle type1="i" type2="s4" type3="o" angle="1.98810455095" k="584.831152"/>
+  <Angle type1="n1" type2="s4" type3="n1" angle="1.64095856273" k="1067.706592"/>
+  <Angle type1="n1" type2="s4" type3="o" angle="1.92143297352" k="1027.908384"/>
+  <Angle type1="n2" type2="s4" type3="n2" angle="1.57376338652" k="1117.345568"/>
+  <Angle type1="n2" type2="s4" type3="o" angle="1.87745067637" k="1055.313584"/>
+  <Angle type1="n3" type2="s4" type3="n3" angle="1.59156574489" k="1019.632432"/>
+  <Angle type1="n3" type2="s4" type3="o" angle="1.92736709298" k="986.009808"/>
+  <Angle type1="n4" type2="s4" type3="n4" angle="1.65125600531" k="890.572768"/>
+  <Angle type1="n4" type2="s4" type3="o" angle="1.83102491827" k="925.408752"/>
+  <Angle type1="na" type2="s4" type3="na" angle="1.79943445881" k="938.287104"/>
+  <Angle type1="na" type2="s4" type3="o" angle="1.91549885406" k="974.010096"/>
+  <Angle type1="nh" type2="s4" type3="nh" angle="1.60989170204" k="1016.937936"/>
+  <Angle type1="nh" type2="s4" type3="o" angle="1.87692707759" k="1001.289776"/>
+  <Angle type1="n" type2="s4" type3="n" angle="1.59348560707" k="1011.122176"/>
+  <Angle type1="n" type2="s4" type3="o" angle="1.87518174834" k="994.235552"/>
+  <Angle type1="no" type2="s4" type3="no" angle="1.45560459616" k="937.13232"/>
+  <Angle type1="no" type2="s4" type3="o" angle="1.80781203922" k="921.927664"/>
+  <Angle type1="oh" type2="s4" type3="oh" angle="1.75126337145" k="1005.616032"/>
+  <Angle type1="o" type2="s4" type3="o" angle="1.99159520945" k="1063.11256"/>
+  <Angle type1="o" type2="s4" type3="oh" angle="1.92160750645" k="1010.2268"/>
+  <Angle type1="o" type2="s4" type3="os" angle="1.88879531651" k="1020.368816"/>
+  <Angle type1="o" type2="s4" type3="p2" angle="1.86348804235" k="925.551008"/>
+  <Angle type1="o" type2="s4" type3="p3" angle="1.8589501863" k="968.880512"/>
+  <Angle type1="o" type2="s4" type3="p4" angle="1.80397231486" k="916.053328"/>
+  <Angle type1="o" type2="s4" type3="p5" angle="1.69209670981" k="1036.184336"/>
+  <Angle type1="o" type2="s4" type3="s4" angle="1.82474173296" k="764.308016"/>
+  <Angle type1="o" type2="s4" type3="s" angle="1.95860848659" k="738.994816"/>
+  <Angle type1="o" type2="s4" type3="s6" angle="1.79489660275" k="770.642592"/>
+  <Angle type1="o" type2="s4" type3="sh" angle="1.87640347882" k="725.622752"/>
+  <Angle type1="os" type2="s4" type3="os" angle="1.64183122735" k="1040.803472"/>
+  <Angle type1="o" type2="s4" type3="ss" angle="1.91096099801" k="719.656368"/>
+  <Angle type1="p2" type2="s4" type3="p2" angle="1.6165239532" k="994.854784"/>
+  <Angle type1="p3" type2="s4" type3="p3" angle="1.67045462708" k="1026.9628"/>
+  <Angle type1="p5" type2="s4" type3="p5" angle="1.63816603592" k="1060.928512"/>
+  <Angle type1="s4" type2="s4" type3="s4" angle="1.57376338652" k="644.58704"/>
+  <Angle type1="s4" type2="s4" type3="s6" angle="1.57376338652" k="644.58704"/>
+  <Angle type1="s6" type2="s4" type3="s6" angle="1.63223191647" k="632.938784"/>
+  <Angle type1="sh" type2="s4" type3="sh" angle="1.79350033935" k="579.308272"/>
+  <Angle type1="sh" type2="s4" type3="ss" angle="1.79140594425" k="579.910768"/>
+  <Angle type1="s" type2="s4" type3="s" angle="1.88635185556" k="589.90216"/>
+  <Angle type1="ss" type2="s4" type3="ss" angle="1.66626583688" k="601.567152"/>
+  <Angle type1="br" type2="s6" type3="br" angle="1.77273092125" k="649.197808"/>
+  <Angle type1="br" type2="s6" type3="c3" angle="1.72770142655" k="615.206992"/>
+  <Angle type1="br" type2="s6" type3="f" angle="1.75580122751" k="791.453808"/>
+  <Angle type1="br" type2="s6" type3="o" angle="1.8776252093" k="758.902288"/>
+  <Angle type1="c1" type2="s6" type3="c1" angle="1.74515471907" k="632.629168"/>
+  <Angle type1="c1" type2="s6" type3="o" angle="1.8846065263" k="815.093408"/>
+  <Angle type1="c2" type2="s6" type3="c2" angle="1.79332580642" k="610.604592"/>
+  <Angle type1="c2" type2="s6" type3="c3" angle="1.8160150867" k="598.487728"/>
+  <Angle type1="c2" type2="s6" type3="o" angle="1.86017191678" k="807.570576"/>
+  <Angle type1="c3" type2="s6" type3="c3" angle="1.81217536235" k="591.458608"/>
+  <Angle type1="c3" type2="s6" type3="ca" angle="1.80065618928" k="599.927024"/>
+  <Angle type1="c3" type2="s6" type3="cy" angle="1.65247773579" k="611.817952"/>
+  <Angle type1="c3" type2="s6" type3="f" angle="1.67377075266" k="821.059792"/>
+  <Angle type1="c3" type2="s6" type3="hs" angle="1.75615029336" k="427.420704"/>
+  <Angle type1="c3" type2="s6" type3="i" angle="1.7058848109" k="516.816048"/>
+  <Angle type1="c3" type2="s6" type3="n2" angle="1.96314634264" k="756.642928"/>
+  <Angle type1="c3" type2="s6" type3="n3" angle="1.77971223826" k="774.073472"/>
+  <Angle type1="c3" type2="s6" type3="n" angle="1.80536857826" k="759.789296"/>
+  <Angle type1="c3" type2="s6" type3="n4" angle="1.73485727648" k="734.107904"/>
+  <Angle type1="c3" type2="s6" type3="na" angle="1.79437300398" k="761.312272"/>
+  <Angle type1="c3" type2="s6" type3="nh" angle="1.82072747568" k="760.600992"/>
+  <Angle type1="c3" type2="s6" type3="no" angle="1.73782433621" k="719.781888"/>
+  <Angle type1="c3" type2="s6" type3="o" angle="1.89560210059" k="784.106704"/>
+  <Angle type1="c3" type2="s6" type3="oh" angle="1.72333810342" k="793.637856"/>
+  <Angle type1="c3" type2="s6" type3="os" angle="1.68284646477" k="805.33632"/>
+  <Angle type1="c3" type2="s6" type3="p2" angle="1.8582520546" k="721.932464"/>
+  <Angle type1="c3" type2="s6" type3="p3" angle="1.80467044656" k="757.898128"/>
+  <Angle type1="c3" type2="s6" type3="p4" angle="1.81723681718" k="708.275888"/>
+  <Angle type1="c3" type2="s6" type3="p5" angle="1.80571764411" k="766.751472"/>
+  <Angle type1="c3" type2="s6" type3="s4" angle="1.71216799621" k="605.726048"/>
+  <Angle type1="c3" type2="s6" type3="s" angle="1.82386906833" k="594.864384"/>
+  <Angle type1="c3" type2="s6" type3="s6" angle="1.77936317241" k="594.178208"/>
+  <Angle type1="c3" type2="s6" type3="sh" angle="1.77744331023" k="589.098832"/>
+  <Angle type1="c3" type2="s6" type3="ss" angle="1.78843888452" k="585.358336"/>
+  <Angle type1="ca" type2="s6" type3="ca" angle="1.79908539296" k="607.240656"/>
+  <Angle type1="ca" type2="s6" type3="o" angle="1.8167132184" k="814.817264"/>
+  <Angle type1="c" type2="s6" type3="c3" angle="1.76697133472" k="588.454496"/>
+  <Angle type1="c" type2="s6" type3="c" angle="1.74218765934" k="583.057136"/>
+  <Angle type1="cc" type2="s6" type3="o" angle="1.81095363187" k="800.005904"/>
+  <Angle type1="cl" type2="s6" type3="cl" angle="1.76714586764" k="761.44616"/>
+  <Angle type1="cl" type2="s6" type3="f" angle="1.72787595947" k="883.468336"/>
+  <Angle type1="cl" type2="s6" type3="o" angle="1.87657801174" k="847.167952"/>
+  <Angle type1="c" type2="s6" type3="o" angle="1.88443199338" k="765.605056"/>
+  <Angle type1="c" type2="s6" type3="os" angle="1.78233023214" k="765.29544"/>
+  <Angle type1="cx" type2="s6" type3="cx" angle="0.954695100841" k="850.883344"/>
+  <Angle type1="cy" type2="s6" type3="o" angle="1.9289378893" k="762.927296"/>
+  <Angle type1="f" type2="s6" type3="f" angle="1.56573487196" k="1151.244336"/>
+  <Angle type1="f" type2="s6" type3="o" angle="1.85947378507" k="1089.488496"/>
+  <Angle type1="hs" type2="s6" type3="hs" angle="1.72822502532" k="338.920736"/>
+  <Angle type1="hs" type2="s6" type3="n1" angle="1.69768176341" k="646.059808"/>
+  <Angle type1="hs" type2="s6" type3="o" angle="1.87937053855" k="605.04824"/>
+  <Angle type1="i" type2="s6" type3="i" angle="1.7322392826" k="563.551328"/>
+  <Angle type1="i" type2="s6" type3="o" angle="1.89926729202" k="593.550608"/>
+  <Angle type1="n1" type2="s6" type3="n1" angle="1.6671385015" k="1234.338576"/>
+  <Angle type1="n1" type2="s6" type3="o" angle="1.87657801174" k="1147.913872"/>
+  <Angle type1="n2" type2="s6" type3="n2" angle="1.72106917539" k="1107.103136"/>
+  <Angle type1="n2" type2="s6" type3="o" angle="2.07868713913" k="1038.728208"/>
+  <Angle type1="n2" type2="s6" type3="oh" angle="1.86680416793" k="1034.74504"/>
+  <Angle type1="n2" type2="s6" type3="os" angle="1.80205245268" k="1057.556208"/>
+  <Angle type1="n3" type2="s6" type3="n3" angle="1.71810211566" k="1029.548512"/>
+  <Angle type1="n3" type2="s6" type3="o" angle="1.87500721542" k="1044.276192"/>
+  <Angle type1="n3" type2="s6" type3="os" angle="1.73939513254" k="1038.21776"/>
+  <Angle type1="n4" type2="s6" type3="n4" angle="1.77761784316" k="884.346976"/>
+  <Angle type1="n4" type2="s6" type3="o" angle="1.79629286615" k="963.349264"/>
+  <Angle type1="na" type2="s6" type3="na" angle="1.71112079866" k="1001.457136"/>
+  <Angle type1="na" type2="s6" type3="o" angle="1.84690741446" k="1030.77024"/>
+  <Angle type1="nh" type2="s6" type3="nh" angle="1.65038334069" k="1034.862192"/>
+  <Angle type1="nh" type2="s6" type3="o" angle="1.87116749106" k="1034.711568"/>
+  <Angle type1="n" type2="s6" type3="n" angle="1.81793494888" k="973.90968"/>
+  <Angle type1="n" type2="s6" type3="o" angle="1.86785136548" k="1026.703392"/>
+  <Angle type1="no" type2="s6" type3="no" angle="1.5992451936" k="903.108032"/>
+  <Angle type1="no" type2="s6" type3="o" angle="1.87500721542" k="917.542832"/>
+  <Angle type1="n" type2="s6" type3="os" angle="1.73189021675" k="1024.812224"/>
+  <Angle type1="oh" type2="s6" type3="oh" angle="1.75126337145" k="1043.272032"/>
+  <Angle type1="oh" type2="s6" type3="os" angle="1.68965324886" k="1066.032992"/>
+  <Angle type1="oh" type2="s6" type3="p2" angle="1.91410259066" k="909.55976"/>
+  <Angle type1="o" type2="s6" type3="o" angle="2.09526776702" k="1072.7776"/>
+  <Angle type1="o" type2="s6" type3="oh" angle="1.88582825678" k="1057.070864"/>
+  <Angle type1="o" type2="s6" type3="os" angle="1.89472943597" k="1059.631472"/>
+  <Angle type1="o" type2="s6" type3="p2" angle="1.86069551555" k="931.391872"/>
+  <Angle type1="o" type2="s6" type3="p3" angle="1.86872403011" k="973.474544"/>
+  <Angle type1="o" type2="s6" type3="p4" angle="1.84428942058" k="898.631152"/>
+  <Angle type1="o" type2="s6" type3="p5" angle="1.86121911433" k="991.708416"/>
+  <Angle type1="o" type2="s6" type3="s4" angle="1.88233759828" k="754.785232"/>
+  <Angle type1="o" type2="s6" type3="s" angle="1.92492363202" k="760.542416"/>
+  <Angle type1="o" type2="s6" type3="s6" angle="1.85127073759" k="761.094704"/>
+  <Angle type1="o" type2="s6" type3="sh" angle="1.86418617406" k="748.986208"/>
+  <Angle type1="os" type2="s6" type3="os" angle="1.72263997172" k="1059.748624"/>
+  <Angle type1="o" type2="s6" type3="ss" angle="1.87500721542" k="743.471696"/>
+  <Angle type1="p3" type2="s6" type3="p3" angle="1.92282923692" k="961.809552"/>
+  <Angle type1="p5" type2="s6" type3="p5" angle="1.82369453541" k="1005.515616"/>
+  <Angle type1="s4" type2="s6" type3="s4" angle="1.78006130411" k="606.085872"/>
+  <Angle type1="s4" type2="s6" type3="s6" angle="1.57376338652" k="644.58704"/>
+  <Angle type1="s6" type2="s6" type3="s6" angle="1.80275058438" k="602.261696"/>
+  <Angle type1="sh" type2="s6" type3="sh" angle="1.8575539229" k="585.433648"/>
+  <Angle type1="sh" type2="s6" type3="ss" angle="1.79140594425" k="594.722128"/>
+  <Angle type1="s" type2="s6" type3="s" angle="1.90834300413" k="597.424992"/>
+  <Angle type1="ss" type2="s6" type3="ss" angle="1.77709424438" k="595.709552"/>
+  <Angle type1="br" type2="sh" type3="hs" angle="1.66923289661" k="416.651088"/>
+  <Angle type1="c1" type2="sh" type3="hs" angle="1.67534154899" k="465.09344"/>
+  <Angle type1="c2" type2="sh" type3="hs" angle="1.68930418301" k="441.646304"/>
+  <Angle type1="c3" type2="sh" type3="hs" angle="1.68249739892" k="429.788848"/>
+  <Angle type1="ca" type2="sh" type3="hs" angle="1.66678943565" k="444.851248"/>
+  <Angle type1="cc" type2="sh" type3="hs" angle="1.65823732232" k="448.449488"/>
+  <Angle type1="c" type2="sh" type3="hs" angle="1.64881254436" k="443.855456"/>
+  <Angle type1="f" type2="sh" type3="hs" angle="1.68424272817" k="597.64256"/>
+  <Angle type1="hs" type2="sh" type3="hs" angle="1.62315620435" k="352.75304"/>
+  <Angle type1="hs" type2="sh" type3="i" angle="1.68319553062" k="369.430464"/>
+  <Angle type1="hs" type2="sh" type3="n1" angle="1.63205738354" k="609.140192"/>
+  <Angle type1="hs" type2="sh" type3="n2" angle="1.67237448926" k="567.467552"/>
+  <Angle type1="hs" type2="sh" type3="n" angle="1.66836023198" k="570.806384"/>
+  <Angle type1="hs" type2="sh" type3="n3" angle="1.67516701606" k="566.7228"/>
+  <Angle type1="hs" type2="sh" type3="n4" angle="1.62542513238" k="556.120544"/>
+  <Angle type1="hs" type2="sh" type3="na" angle="1.69960162559" k="567.383872"/>
+  <Angle type1="hs" type2="sh" type3="nh" angle="1.76470240669" k="560.187392"/>
+  <Angle type1="hs" type2="sh" type3="no" angle="1.62193447388" k="558.572368"/>
+  <Angle type1="hs" type2="sh" type3="o" angle="1.90642314195" k="564.865104"/>
+  <Angle type1="hs" type2="sh" type3="oh" angle="1.72159277417" k="571.375408"/>
+  <Angle type1="hs" type2="sh" type3="os" angle="1.71304066083" k="578.35432"/>
+  <Angle type1="hs" type2="sh" type3="p2" angle="1.72997035458" k="552.990912"/>
+  <Angle type1="hs" type2="sh" type3="p3" angle="1.67219995634" k="520.020992"/>
+  <Angle type1="hs" type2="sh" type3="p4" angle="1.64444922123" k="528.757184"/>
+  <Angle type1="hs" type2="sh" type3="p5" angle="1.64968520899" k="536.489216"/>
+  <Angle type1="hs" type2="sh" type3="s" angle="1.79542020153" k="395.279216"/>
+  <Angle type1="hs" type2="sh" type3="s4" angle="1.60849543864" k="405.956784"/>
+  <Angle type1="hs" type2="sh" type3="s6" angle="1.63764243715" k="414.291312"/>
+  <Angle type1="hs" type2="sh" type3="sh" angle="1.72909768995" k="413.144896"/>
+  <Angle type1="hs" type2="sh" type3="ss" angle="1.7308430192" k="411.128208"/>
+  <Angle type1="br" type2="ss" type3="br" angle="1.79629286615" k="648.14344"/>
+  <Angle type1="br" type2="ss" type3="c3" angle="1.72839955825" k="614.529184"/>
+  <Angle type1="c1" type2="ss" type3="c1" angle="1.71565865471" k="650.201968"/>
+  <Angle type1="c1" type2="ss" type3="c3" angle="1.77779237608" k="609.508384"/>
+  <Angle type1="c2" type2="ss" type3="c2" angle="1.73764980329" k="628.880304"/>
+  <Angle type1="c2" type2="ss" type3="c3" angle="1.75178697023" k="607.249024"/>
+  <Angle type1="c2" type2="ss" type3="cy" angle="1.55177223795" k="643.16448"/>
+  <Angle type1="c2" type2="ss" type3="n2" angle="1.86331350943" k="777.571296"/>
+  <Angle type1="c2" type2="ss" type3="na" angle="1.75423043118" k="784.575312"/>
+  <Angle type1="c2" type2="ss" type3="os" angle="1.56660753659" k="836.96736"/>
+  <Angle type1="c2" type2="ss" type3="ss" angle="1.61024076789" k="633.817424"/>
+  <Angle type1="c3" type2="ss" type3="c3" angle="1.73206474968" k="594.554768"/>
+  <Angle type1="c3" type2="ss" type3="ca" angle="1.78198116629" k="595.34136"/>
+  <Angle type1="c3" type2="ss" type3="cc" angle="1.75649935921" k="603.383008"/>
+  <Angle type1="c3" type2="ss" type3="cd" angle="1.75649935921" k="603.383008"/>
+  <Angle type1="c3" type2="ss" type3="cl" angle="1.73485727648" k="669.716144"/>
+  <Angle type1="c3" type2="ss" type3="cy" angle="1.64532188586" k="608.345232"/>
+  <Angle type1="c3" type2="ss" type3="f" angle="1.70152148777" k="801.394992"/>
+  <Angle type1="c3" type2="ss" type3="i" angle="1.74532925199" k="568.630704"/>
+  <Angle type1="c3" type2="ss" type3="n1" angle="1.71810211566" k="790.215344"/>
+  <Angle type1="c3" type2="ss" type3="n2" angle="1.67691234532" k="791.972624"/>
+  <Angle type1="c3" type2="ss" type3="n3" angle="1.72490889975" k="768.659376"/>
+  <Angle type1="c3" type2="ss" type3="n" angle="1.75056523975" k="762.57584"/>
+  <Angle type1="c3" type2="ss" type3="n4" angle="1.70675747553" k="755.529984"/>
+  <Angle type1="c3" type2="ss" type3="na" angle="1.6858135245" k="775.830752"/>
+  <Angle type1="c3" type2="ss" type3="nh" angle="1.75632482628" k="764.4168"/>
+  <Angle type1="c3" type2="ss" type3="no" angle="1.72124370832" k="749.128464"/>
+  <Angle type1="c3" type2="ss" type3="o" angle="1.86732776671" k="772.885216"/>
+  <Angle type1="c3" type2="ss" type3="oh" angle="1.71530958886" k="777.362096"/>
+  <Angle type1="c3" type2="ss" type3="os" angle="1.71408785838" k="774.717808"/>
+  <Angle type1="c3" type2="ss" type3="p2" angle="1.71757851689" k="798.968272"/>
+  <Angle type1="c3" type2="ss" type3="p3" angle="1.72263997172" k="760.52568"/>
+  <Angle type1="c3" type2="ss" type3="p4" angle="1.71321519376" k="766.751472"/>
+  <Angle type1="c3" type2="ss" type3="p5" angle="1.74637644955" k="756.165952"/>
+  <Angle type1="c3" type2="ss" type3="s4" angle="1.68197380015" k="591.11552"/>
+  <Angle type1="c3" type2="ss" type3="s" angle="1.77849050778" k="589.19088"/>
+  <Angle type1="c3" type2="ss" type3="s6" angle="1.68878058423" k="599.10696"/>
+  <Angle type1="c3" type2="ss" type3="sh" angle="1.77901410656" k="593.182416"/>
+  <Angle type1="c3" type2="ss" type3="ss" angle="1.80449591364" k="587.918944"/>
+  <Angle type1="ca" type2="ss" type3="ca" angle="1.72490889975" k="615.391088"/>
+  <Angle type1="ca" type2="ss" type3="cc" angle="1.56154608176" k="651.181024"/>
+  <Angle type1="ca" type2="ss" type3="cd" angle="1.56154608176" k="651.181024"/>
+  <Angle type1="ca" type2="ss" type3="cl" angle="1.76365520914" k="671.398112"/>
+  <Angle type1="ca" type2="ss" type3="n" angle="1.58807508639" k="815.269136"/>
+  <Angle type1="ca" type2="ss" type3="na" angle="1.73346101308" k="778.952016"/>
+  <Angle type1="ca" type2="ss" type3="nc" angle="1.65387399919" k="819.335984"/>
+  <Angle type1="ca" type2="ss" type3="nd" angle="1.65387399919" k="819.335984"/>
+  <Angle type1="ca" type2="ss" type3="ss" angle="1.83486464262" k="589.3164"/>
+  <Angle type1="c" type2="ss" type3="c2" angle="1.61320782762" k="640.453248"/>
+  <Angle type1="c" type2="ss" type3="c3" angle="1.73066848628" k="601.056704"/>
+  <Angle type1="c" type2="ss" type3="c" angle="1.76976386152" k="600.98976"/>
+  <Angle type1="c" type2="ss" type3="cc" angle="1.65614292722" k="628.72968"/>
+  <Angle type1="cc" type2="ss" type3="cc" angle="1.574985117" k="652.963408"/>
+  <Angle type1="cc" type2="ss" type3="cd" angle="1.58406082911" k="651.088976"/>
+  <Angle type1="cc" type2="ss" type3="n" angle="1.63327911402" k="809.8132"/>
+  <Angle type1="cc" type2="ss" type3="na" angle="1.73363554601" k="784.58368"/>
+  <Angle type1="cc" type2="ss" type3="nc" angle="1.62699592871" k="832.99256"/>
+  <Angle type1="cc" type2="ss" type3="os" angle="1.7245598339" k="792.834528"/>
+  <Angle type1="cc" type2="ss" type3="ss" angle="1.63711883837" k="626.503792"/>
+  <Angle type1="cd" type2="ss" type3="cd" angle="1.574985117" k="652.963408"/>
+  <Angle type1="cd" type2="ss" type3="n" angle="1.63327911402" k="809.8132"/>
+  <Angle type1="cd" type2="ss" type3="na" angle="1.73363554601" k="784.58368"/>
+  <Angle type1="cd" type2="ss" type3="nd" angle="1.62699592871" k="832.99256"/>
+  <Angle type1="cd" type2="ss" type3="os" angle="1.7245598339" k="792.834528"/>
+  <Angle type1="cd" type2="ss" type3="ss" angle="1.63711883837" k="626.503792"/>
+  <Angle type1="cl" type2="ss" type3="cl" angle="1.80414684779" k="753.596976"/>
+  <Angle type1="cx" type2="ss" type3="cx" angle="0.842994028713" k="855.351856"/>
+  <Angle type1="f" type2="ss" type3="f" angle="1.71565865471" k="1084.986512"/>
+  <Angle type1="f" type2="ss" type3="ss" angle="1.89019157991" k="754.157632"/>
+  <Angle type1="i" type2="ss" type3="i" angle="1.85511046194" k="607.901728"/>
+  <Angle type1="n1" type2="ss" type3="n1" angle="1.69227124273" k="1077.513888"/>
+  <Angle type1="n2" type2="ss" type3="n2" angle="1.6886060513" k="1048.7196"/>
+  <Angle type1="n3" type2="ss" type3="n3" angle="1.78616995649" k="979.6836"/>
+  <Angle type1="n4" type2="ss" type3="n4" angle="1.76609867009" k="937.165792"/>
+  <Angle type1="na" type2="ss" type3="na" angle="1.79437300398" k="972.420176"/>
+  <Angle type1="nc" type2="ss" type3="nc" angle="1.71024813403" k="1061.288336"/>
+  <Angle type1="nd" type2="ss" type3="nd" angle="1.71024813403" k="1061.288336"/>
+  <Angle type1="nh" type2="ss" type3="nh" angle="1.88303572998" k="962.244688"/>
+  <Angle type1="n" type2="ss" type3="n" angle="1.79943445881" k="974.763216"/>
+  <Angle type1="no" type2="ss" type3="no" angle="1.8575539229" k="905.810896"/>
+  <Angle type1="oh" type2="ss" type3="oh" angle="1.8195057452" k="991.139392"/>
+  <Angle type1="o" type2="ss" type3="o" angle="2.08217779763" k="1037.933248"/>
+  <Angle type1="o" type2="ss" type3="p5" angle="1.85720485705" k="956.50424"/>
+  <Angle type1="o" type2="ss" type3="s6" angle="1.83940249868" k="748.793744"/>
+  <Angle type1="os" type2="ss" type3="os" angle="1.79751459663" k="987.817296"/>
+  <Angle type1="o" type2="ss" type3="ss" angle="1.966986067" k="738.291904"/>
+  <Angle type1="p2" type2="ss" type3="p2" angle="1.73695167158" k="1069.09568"/>
+  <Angle type1="p3" type2="ss" type3="p3" angle="1.7744762505" k="980.43672"/>
+  <Angle type1="p5" type2="ss" type3="p5" angle="1.52489416747" k="1059.330224"/>
+  <Angle type1="s4" type2="ss" type3="s4" angle="1.67691234532" k="599.659248"/>
+  <Angle type1="s4" type2="ss" type3="s6" angle="1.76732040057" k="590.513024"/>
+  <Angle type1="s6" type2="ss" type3="s6" angle="1.77691971146" k="595.743024"/>
+  <Angle type1="sh" type2="ss" type3="sh" angle="1.87692707759" k="593.952272"/>
+  <Angle type1="sh" type2="ss" type3="ss" angle="1.85929925215" k="595.92712"/>
+  <Angle type1="s" type2="ss" type3="s" angle="2.00782677149" k="568.220672"/>
+  <Angle type1="ss" type2="ss" type3="ss" angle="1.88373386168" k="591.224304"/>
+  <Angle type1="c3" type2="sx" type3="ca" angle="1.68668618913" k="604.362064"/>
+  <Angle type1="c3" type2="sx" type3="cc" angle="1.66120438205" k="611.315872"/>
+  <Angle type1="c3" type2="sx" type3="ce" angle="1.66312424423" k="609.700848"/>
+  <Angle type1="c3" type2="sx" type3="cf" angle="1.66312424423" k="609.700848"/>
+  <Angle type1="c3" type2="sx" type3="ne" angle="1.57184352435" k="781.253216"/>
+  <Angle type1="c3" type2="sx" type3="nf" angle="1.57184352435" k="781.253216"/>
+  <Angle type1="c3" type2="sx" type3="o" angle="1.87657801174" k="769.370656"/>
+  <Angle type1="c3" type2="sx" type3="pe" angle="1.64619455048" k="765.981616"/>
+  <Angle type1="c3" type2="sx" type3="pf" angle="1.64619455048" k="765.981616"/>
+  <Angle type1="c3" type2="sx" type3="px" angle="1.68354459647" k="739.279328"/>
+  <Angle type1="c3" type2="sx" type3="py" angle="1.66975649538" k="738.149648"/>
+  <Angle type1="c3" type2="sx" type3="sx" angle="1.5964526668" k="562.547168"/>
+  <Angle type1="c3" type2="sx" type3="sy" angle="1.66626583688" k="576.546832"/>
+  <Angle type1="ca" type2="sx" type3="ca" angle="1.67115275878" k="609.968624"/>
+  <Angle type1="ca" type2="sx" type3="o" angle="1.87012029351" k="775.897696"/>
+  <Angle type1="c" type2="sx" type3="c3" angle="1.61809474952" k="606.981248"/>
+  <Angle type1="c" type2="sx" type3="c" angle="1.51581845536" k="620.102272"/>
+  <Angle type1="cc" type2="sx" type3="o" angle="1.82927958902" k="789.043824"/>
+  <Angle type1="ce" type2="sx" type3="ce" angle="1.65736465769" k="614.721648"/>
+  <Angle type1="ce" type2="sx" type3="o" angle="1.88896984943" k="774.056736"/>
+  <Angle type1="cf" type2="sx" type3="cf" angle="1.65736465769" k="614.721648"/>
+  <Angle type1="cf" type2="sx" type3="o" angle="1.88896984943" k="774.056736"/>
+  <Angle type1="c" type2="sx" type3="o" angle="1.85301606684" k="760.77672"/>
+  <Angle type1="ne" type2="sx" type3="ne" angle="1.85790298875" k="900.798464"/>
+  <Angle type1="ne" type2="sx" type3="o" angle="1.91654605161" k="954.813904"/>
+  <Angle type1="nf" type2="sx" type3="nf" angle="1.85790298875" k="900.798464"/>
+  <Angle type1="nf" type2="sx" type3="o" angle="1.91654605161" k="954.813904"/>
+  <Angle type1="o" type2="sx" type3="pe" angle="1.8575539229" k="935.58424"/>
+  <Angle type1="o" type2="sx" type3="pf" angle="1.8575539229" k="935.58424"/>
+  <Angle type1="o" type2="sx" type3="px" angle="1.82858145731" k="913.308624"/>
+  <Angle type1="o" type2="sx" type3="py" angle="1.9046778127" k="888.30504"/>
+  <Angle type1="o" type2="sx" type3="sx" angle="1.82648706221" k="667.465152"/>
+  <Angle type1="o" type2="sx" type3="sy" angle="1.80484497949" k="712.309264"/>
+  <Angle type1="pe" type2="sx" type3="pe" angle="1.6165239532" k="1004.95496"/>
+  <Angle type1="pf" type2="sx" type3="pf" angle="1.6165239532" k="1004.95496"/>
+  <Angle type1="py" type2="sx" type3="py" angle="1.20829144116" k="1115.563184"/>
+  <Angle type1="sx" type2="sx" type3="sx" angle="1.48178453494" k="577.885712"/>
+  <Angle type1="sy" type2="sx" type3="sy" angle="1.63223191647" k="583.818624"/>
+  <Angle type1="c3" type2="sy" type3="ca" angle="1.8139206916" k="593.66776"/>
+  <Angle type1="c3" type2="sy" type3="cc" angle="1.77936317241" k="600.546256"/>
+  <Angle type1="c3" type2="sy" type3="ce" angle="1.80693937459" k="595.266048"/>
+  <Angle type1="c3" type2="sy" type3="cf" angle="1.80693937459" k="595.266048"/>
+  <Angle type1="c3" type2="sy" type3="ne" angle="1.78355196261" k="772.935424"/>
+  <Angle type1="c3" type2="sy" type3="nf" angle="1.78355196261" k="772.935424"/>
+  <Angle type1="c3" type2="sy" type3="o" angle="1.88233759828" k="784.851456"/>
+  <Angle type1="c3" type2="sy" type3="pe" angle="1.85057260589" k="715.29664"/>
+  <Angle type1="c3" type2="sy" type3="pf" angle="1.85057260589" k="715.29664"/>
+  <Angle type1="c3" type2="sy" type3="px" angle="1.80851017092" k="714.761088"/>
+  <Angle type1="c3" type2="sy" type3="py" angle="1.80449591364" k="731.982432"/>
+  <Angle type1="c3" type2="sy" type3="sx" angle="1.82631252929" k="553.099696"/>
+  <Angle type1="c3" type2="sy" type3="sy" angle="1.75894282016" k="564.555488"/>
+  <Angle type1="ca" type2="sy" type3="ca" angle="1.82282187078" k="595.190736"/>
+  <Angle type1="ca" type2="sy" type3="cc" angle="1.83416651092" k="594.50456"/>
+  <Angle type1="ca" type2="sy" type3="n3" angle="1.78791528574" k="771.872688"/>
+  <Angle type1="ca" type2="sy" type3="n" angle="1.83905343283" k="757.128272"/>
+  <Angle type1="ca" type2="sy" type3="ne" angle="1.79786366248" k="774.366352"/>
+  <Angle type1="ca" type2="sy" type3="nh" angle="1.84132236085" k="757.0948"/>
+  <Angle type1="ca" type2="sy" type3="o" angle="1.89106424454" k="788.901568"/>
+  <Angle type1="ca" type2="sy" type3="oh" angle="1.76801853227" k="785.202912"/>
+  <Angle type1="ca" type2="sy" type3="os" angle="1.6228071385" k="809.604"/>
+  <Angle type1="c" type2="sy" type3="c3" angle="1.76714586764" k="589.098832"/>
+  <Angle type1="c" type2="sy" type3="c" angle="1.74201312642" k="584.647056"/>
+  <Angle type1="cc" type2="sy" type3="n3" angle="1.78948608207" k="773.236672"/>
+  <Angle type1="cc" type2="sy" type3="o" angle="1.88303572998" k="792.884736"/>
+  <Angle type1="cd" type2="sy" type3="n3" angle="1.78948608207" k="773.236672"/>
+  <Angle type1="cd" type2="sy" type3="nh" angle="1.69646003294" k="790.466384"/>
+  <Angle type1="cd" type2="sy" type3="o" angle="1.88303572998" k="792.884736"/>
+  <Angle type1="ce" type2="sy" type3="ce" angle="1.7938494052" k="600.914448"/>
+  <Angle type1="ce" type2="sy" type3="o" angle="1.89158784331" k="789.713264"/>
+  <Angle type1="cf" type2="sy" type3="cf" angle="1.7938494052" k="600.914448"/>
+  <Angle type1="cf" type2="sy" type3="o" angle="1.89158784331" k="789.713264"/>
+  <Angle type1="c" type2="sy" type3="o" angle="1.87587988004" k="767.68032"/>
+  <Angle type1="n2" type2="sy" type3="o" angle="2.15600522499" k="1019.858368"/>
+  <Angle type1="n3" type2="sy" type3="ne" angle="1.77901410656" k="1004.486352"/>
+  <Angle type1="n3" type2="sy" type3="o" angle="1.86977122766" k="1032.828768"/>
+  <Angle type1="na" type2="sy" type3="na" angle="1.71112079866" k="998.963472"/>
+  <Angle type1="nc" type2="sy" type3="nc" angle="1.71112079866" k="1109.462912"/>
+  <Angle type1="nd" type2="sy" type3="nd" angle="1.71112079866" k="1109.462912"/>
+  <Angle type1="ne" type2="sy" type3="ne" angle="1.72124370832" k="1028.602928"/>
+  <Angle type1="ne" type2="sy" type3="o" angle="1.91375352481" k="1030.678192"/>
+  <Angle type1="nf" type2="sy" type3="nf" angle="1.72124370832" k="1028.602928"/>
+  <Angle type1="nf" type2="sy" type3="o" angle="1.91375352481" k="1030.678192"/>
+  <Angle type1="nh" type2="sy" type3="o" angle="1.85406326439" k="1029.732608"/>
+  <Angle type1="n" type2="sy" type3="o" angle="1.87692707759" k="1022.52776"/>
+  <Angle type1="o" type2="sy" type3="o" angle="2.11900424485" k="1057.506"/>
+  <Angle type1="o" type2="sy" type3="oh" angle="1.86191724603" k="1054.28432"/>
+  <Angle type1="o" type2="sy" type3="os" angle="1.87657801174" k="1029.791184"/>
+  <Angle type1="o" type2="sy" type3="pe" angle="1.86575697038" k="916.329472"/>
+  <Angle type1="o" type2="sy" type3="pf" angle="1.86575697038" k="916.329472"/>
+  <Angle type1="o" type2="sy" type3="px" angle="1.85301606684" k="904.764896"/>
+  <Angle type1="o" type2="sy" type3="py" angle="1.8617427131" k="930.128304"/>
+  <Angle type1="o" type2="sy" type3="sx" angle="1.85580859365" k="702.585648"/>
+  <Angle type1="o" type2="sy" type3="sy" angle="1.85336513269" k="704.62744"/>
+  <Angle type1="py" type2="sy" type3="py" angle="1.82369453541" k="940.077856"/>
+  <Angle type1="sx" type2="sy" type3="sx" angle="1.78006130411" k="559.049344"/>
+  <Angle type1="sy" type2="sy" type3="sy" angle="1.80275058438" k="556.756512"/>
+  <Angle type1="c2" type2="c1" type3="cf" angle="3.1250120257" k="502.473296"/>
+  <Angle type1="c3" type2="c1" type3="ch" angle="3.11419098433" k="483.0428"/>
+  <Angle type1="nf" type2="c1" type3="s" angle="3.06863789086" k="615.96848"/>
+  <Angle type1="br" type2="c2" type3="cf" angle="2.12109863995" k="537.886672"/>
+  <Angle type1="cd" type2="c2" type3="h4" angle="2.09177710852" k="416.609248"/>
+  <Angle type1="cd" type2="c2" type3="nh" angle="2.14884937506" k="724.350816"/>
+  <Angle type1="cd" type2="c2" type3="o" angle="2.15705242254" k="764.433536"/>
+  <Angle type1="cf" type2="c2" type3="cl" angle="2.15495802744" k="603.391376"/>
+  <Angle type1="cf" type2="c2" type3="h4" angle="2.13471220811" k="415.504672"/>
+  <Angle type1="cf" type2="c2" type3="na" angle="2.1671753322" k="720.551744"/>
+  <Angle type1="cf" type2="c2" type3="nh" angle="2.10678694008" k="734.894496"/>
+  <Angle type1="cf" type2="c2" type3="no" angle="2.08828645001" k="720.459696"/>
+  <Angle type1="cf" type2="c2" type3="o" angle="2.15321269819" k="769.789056"/>
+  <Angle type1="cf" type2="c2" type3="oh" angle="2.14902390798" k="741.162128"/>
+  <Angle type1="cf" type2="c2" type3="os" angle="2.14326432145" k="736.34216"/>
+  <Angle type1="h4" type2="c2" type3="nf" angle="2.08584298906" k="542.731744"/>
+  <Angle type1="h5" type2="c2" type3="nf" angle="2.09177710852" k="541.334288"/>
+  <Angle type1="nf" type2="c2" type3="os" angle="2.07275301967" k="955.734384"/>
+  <Angle type1="nf" type2="c2" type3="ss" angle="2.10329628158" k="687.89144"/>
+  <Angle type1="n" type2="c2" type3="nf" angle="2.18759568445" k="914.814864"/>
+  <Angle type1="ca" type2="c3" type3="cf" angle="1.95843395366" k="549.091424"/>
+  <Angle type1="cd" type2="c3" type3="cx" angle="1.95651409149" k="551.400992"/>
+  <Angle type1="c" type2="c3" type3="cf" angle="1.95284890006" k="548.329936"/>
+  <Angle type1="cd" type2="c3" type3="hx" angle="1.93749000264" k="398.216384"/>
+  <Angle type1="cd" type2="c3" type3="n2" angle="1.92527269787" k="708.18384"/>
+  <Angle type1="cd" type2="c3" type3="n4" angle="2.01725154946" k="681.715856"/>
+  <Angle type1="cd" type2="c3" type3="na" angle="1.97484004863" k="699.958096"/>
+  <Angle type1="cd" type2="c3" type3="p5" angle="2.02859618959" k="665.364784"/>
+  <Angle type1="cf" type2="c3" type3="cf" angle="1.9455185172" k="550.890544"/>
+  <Angle type1="cf" type2="c3" type3="n" angle="1.92370190155" k="705.832432"/>
+  <Angle type1="cf" type2="c3" type3="oh" angle="1.94063159529" k="711.037328"/>
+  <Angle type1="cf" type2="c3" type3="os" angle="1.91113553093" k="714.727616"/>
+  <Angle type1="cf" type2="c3" type3="ss" angle="1.93242854781" k="530.004016"/>
+  <Angle type1="cd" type2="ca" type3="cq" angle="2.16944426023" k="552.37168"/>
+  <Angle type1="cf" type2="ca" type3="na" angle="2.09299883899" k="703.430816"/>
+  <Angle type1="ch" type2="ca" type3="cq" angle="2.12109863995" k="563.33376"/>
+  <Angle type1="cl" type2="ca" type3="cq" angle="2.10120188648" k="600.203168"/>
+  <Angle type1="cq" type2="ca" type3="f" angle="2.08427219273" k="743.337808"/>
+  <Angle type1="cq" type2="ca" type3="h4" angle="2.09596589872" k="405.044672"/>
+  <Angle type1="cq" type2="ca" type3="na" angle="1.89874369324" k="758.68472"/>
+  <Angle type1="cq" type2="ca" type3="nb" angle="2.15687788961" k="722.735792"/>
+  <Angle type1="cq" type2="ca" type3="nh" angle="2.12162223872" k="717.254752"/>
+  <Angle type1="cq" type2="ca" type3="oh" angle="2.10923040104" k="724.861264"/>
+  <Angle type1="cq" type2="ca" type3="ss" angle="1.94028252944" k="551.8696"/>
+  <Angle type1="ca" type2="c" type3="nf" angle="2.00206718496" k="713.70672"/>
+  <Angle type1="br" type2="cd" type3="c" angle="2.02946885422" k="545.225408"/>
+  <Angle type1="br" type2="cd" type3="cd" angle="2.1650809371" k="530.439152"/>
+  <Angle type1="br" type2="cd" type3="cc" angle="2.16822252975" k="532.924448"/>
+  <Angle type1="br" type2="cd" type3="na" angle="2.12197130457" k="674.16792"/>
+  <Angle type1="ca" type2="cd" type3="cf" angle="2.21674268296" k="537.710944"/>
+  <Angle type1="ca" type2="cd" type3="nh" angle="2.13157061546" k="705.029104"/>
+  <Angle type1="cd" type2="c" type3="cf" angle="2.01707701653" k="555.911344"/>
+  <Angle type1="cd" type2="cd" type3="f" angle="2.08025793545" k="739.538736"/>
+  <Angle type1="c" type2="cd" type3="ch" angle="2.05739412225" k="561.040928"/>
+  <Angle type1="cd" type2="cd" type3="sy" angle="2.23838476568" k="511.335008"/>
+  <Angle type1="cc" type2="cd" type3="f" angle="2.11516452049" k="749.52176"/>
+  <Angle type1="cc" type2="cd" type3="no" angle="2.24606421439" k="694.100496"/>
+  <Angle type1="c" type2="cd" type3="f" angle="2.04168615898" k="734.367312"/>
+  <Angle type1="ch" type2="cd" type3="na" angle="2.13994819587" k="710.259104"/>
+  <Angle type1="ch" type2="cd" type3="ss" angle="2.10713600593" k="533.560416"/>
+  <Angle type1="cd" type2="c" type3="h4" angle="2.00416158007" k="398.300064"/>
+  <Angle type1="cl" type2="cd" type3="na" angle="2.11394279002" k="757.396048"/>
+  <Angle type1="cl" type2="cd" type3="ss" angle="2.09177710852" k="601.943712"/>
+  <Angle type1="c" type2="cd" type3="nf" angle="2.09230070729" k="707.121104"/>
+  <Angle type1="cd" type2="c" type3="s" angle="2.20400177942" k="535.644048"/>
+  <Angle type1="cd" type2="c" type3="ss" angle="1.96175007924" k="538.949408"/>
+  <Angle type1="cx" type2="cd" type3="nc" angle="2.2308798499" k="695.774096"/>
+  <Angle type1="cx" type2="cd" type3="os" angle="2.06071024783" k="714.744352"/>
+  <Angle type1="cc" type2="c" type3="cx" angle="2.04954014062" k="548.547504"/>
+  <Angle type1="cc" type2="c" type3="nc" angle="1.98531202414" k="724.116512"/>
+  <Angle type1="cf" type2="c" type3="cx" angle="2.04884200892" k="545.978528"/>
+  <Angle type1="cf" type2="c" type3="h4" angle="2.00520877762" k="394.810608"/>
+  <Angle type1="cf" type2="c" type3="ss" angle="1.92841429053" k="542.196192"/>
+  <Angle type1="na" type2="cd" type3="no" angle="2.17450571506" k="881.259184"/>
+  <Angle type1="na" type2="cd" type3="oh" angle="2.05041280524" k="935.073792"/>
+  <Angle type1="na" type2="cd" type3="sx" angle="2.04238429068" k="666.787344"/>
+  <Angle type1="na" type2="cd" type3="sy" angle="2.10242361695" k="665.314576"/>
+  <Angle type1="nd" type2="cd" type3="no" angle="2.12458929845" k="894.723296"/>
+  <Angle type1="nc" type2="cd" type3="nc" angle="2.23524317303" k="927.400336"/>
+  <Angle type1="nc" type2="cd" type3="nf" angle="2.251649268" k="902.036928"/>
+  <Angle type1="nc" type2="cd" type3="no" angle="2.14239165682" k="905.75232"/>
+  <Angle type1="nc" type2="cd" type3="sh" angle="2.18113796622" k="662.728864"/>
+  <Angle type1="nc" type2="cd" type3="sx" angle="2.2294835865" k="642.394624"/>
+  <Angle type1="nc" type2="cd" type3="sy" angle="2.14727857873" k="663.20584"/>
+  <Angle type1="nf" type2="cd" type3="ss" angle="2.04255882361" k="683.724176"/>
+  <Angle type1="n" type2="cd" type3="n2" angle="2.08427219273" k="945.014976"/>
+  <Angle type1="no" type2="cd" type3="os" angle="2.05163453572" k="912.681024"/>
+  <Angle type1="no" type2="cd" type3="ss" angle="2.11289559246" k="666.871024"/>
+  <Angle type1="ca" type2="cc" type3="cf" angle="2.17991623574" k="558.095392"/>
+  <Angle type1="ca" type2="cc" type3="na" angle="2.15460896159" k="699.782368"/>
+  <Angle type1="cd" type2="cc" type3="cg" angle="2.19544966608" k="561.32544"/>
+  <Angle type1="cd" type2="cc" type3="cy" angle="2.13017435206" k="552.179216"/>
+  <Angle type1="cd" type2="cc" type3="nd" angle="2.16106667982" k="736.961392"/>
+  <Angle type1="cc" type2="cc" type3="cy" angle="2.12999981913" k="543.401184"/>
+  <Angle type1="cf" type2="cc" type3="nc" angle="2.16385920662" k="725.011888"/>
+  <Angle type1="c" type2="cc" type3="h4" angle="2.06280464293" k="394.17464"/>
+  <Angle type1="na" type2="cc" type3="nh" angle="2.04692214674" k="927.124192"/>
+  <Angle type1="na" type2="cc" type3="ss" angle="1.94534398427" k="700.426704"/>
+  <Angle type1="nc" type2="cc" type3="nc" angle="2.19387886976" k="900.421904"/>
+  <Angle type1="oh" type2="cc" type3="os" angle="1.94796197815" k="966.018656"/>
+  <Angle type1="c2" type2="cf" type3="cl" angle="2.09020631219" k="603.16544"/>
+  <Angle type1="c2" type2="cf" type3="h4" angle="2.17380758336" k="411.320672"/>
+  <Angle type1="c2" type2="cf" type3="n1" angle="2.06350277463" k="763.906352"/>
+  <Angle type1="c2" type2="cf" type3="na" angle="2.08025793545" k="729.823488"/>
+  <Angle type1="c2" type2="cf" type3="oh" angle="2.15897228472" k="736.250112"/>
+  <Angle type1="c3" type2="cf" type3="ch" angle="2.04587494919" k="552.396784"/>
+  <Angle type1="c3" type2="cf" type3="ne" angle="2.10626334131" k="706.075104"/>
+  <Angle type1="c3" type2="cf" type3="nh" angle="2.08671565368" k="692.309744"/>
+  <Angle type1="ca" type2="cf" type3="cf" angle="2.08636658783" k="549.643712"/>
+  <Angle type1="ca" type2="cf" type3="cl" angle="1.99997278986" k="604.010608"/>
+  <Angle type1="ca" type2="cf" type3="h4" angle="2.04186069191" k="393.689296"/>
+  <Angle type1="ca" type2="cf" type3="nh" angle="2.01725154946" k="715.179488"/>
+  <Angle type1="ca" type2="cf" type3="os" angle="2.02301113599" k="718.292384"/>
+  <Angle type1="ca" type2="cf" type3="ss" angle="2.05111093694" k="530.347104"/>
+  <Angle type1="c" type2="cf" type3="ca" angle="2.06437543926" k="547.919904"/>
+  <Angle type1="cd" type2="cf" type3="cc" angle="2.27957453603" k="546.087312"/>
+  <Angle type1="c" type2="cf" type3="cf" angle="2.11149932906" k="545.1752"/>
+  <Angle type1="c" type2="cf" type3="ch" angle="2.06681890021" k="556.472"/>
+  <Angle type1="cd" type2="cf" type3="h4" angle="2.01899687871" k="401.12008"/>
+  <Angle type1="c" type2="cf" type3="cl" angle="2.01533168728" k="600.998128"/>
+  <Angle type1="cd" type2="cf" type3="nh" angle="2.06036118198" k="713.782032"/>
+  <Angle type1="c" type2="cf" type3="cy" angle="1.54356919046" k="625.123072"/>
+  <Angle type1="cf" type2="cf" type3="cl" angle="2.04587494919" k="599.291056"/>
+  <Angle type1="cf" type2="cf" type3="oh" angle="2.03941723096" k="725.38008"/>
+  <Angle type1="ce" type2="cf" type3="cy" angle="2.40122398489" k="520.882896"/>
+  <Angle type1="ce" type2="cf" type3="h4" angle="2.14588231533" k="412.868752"/>
+  <Angle type1="ce" type2="cf" type3="n1" angle="2.09334790484" k="757.002752"/>
+  <Angle type1="ce" type2="cf" type3="nh" angle="2.11848064607" k="730.836016"/>
+  <Angle type1="ch" type2="cf" type3="n2" angle="2.11429185587" k="735.137168"/>
+  <Angle type1="c" type2="cf" type3="oh" angle="2.02039314211" k="721.288128"/>
+  <Angle type1="c" type2="cf" type3="os" angle="2.00136905326" k="720.367648"/>
+  <Angle type1="h4" type2="cf" type3="n1" angle="2.03575203953" k="542.773584"/>
+  <Angle type1="h4" type2="cf" type3="nf" angle="2.01847327993" k="520.096304"/>
+  <Angle type1="n2" type2="cf" type3="os" angle="2.05861585273" k="955.75112"/>
+  <Angle type1="n2" type2="cf" type3="ss" angle="2.04604948211" k="682.092416"/>
+  <Angle type1="nf" type2="cf" type3="nh" angle="1.98339216197" k="931.517392"/>
+  <Angle type1="ne" type2="cf" type3="nh" angle="2.08165419885" k="940.077856"/>
+  <Angle type1="ca" type2="ce" type3="cd" angle="2.28428692501" k="540.664848"/>
+  <Angle type1="c" type2="ce" type3="cc" angle="2.0563469247" k="553.057856"/>
+  <Angle type1="c" type2="ce" type3="n2" angle="1.99683119721" k="737.865136"/>
+  <Angle type1="h4" type2="ce" type3="nf" angle="2.1041689462" k="538.22976"/>
+  <Angle type1="c1" type2="ch" type3="cd" angle="3.11733257699" k="492.732944"/>
+  <Angle type1="ch" type2="cg" type3="cg" angle="3.13426227073" k="506.858128"/>
+  <Angle type1="n" type2="c" type3="nf" angle="1.92440003325" k="950.6048"/>
+  <Angle type1="ca" type2="cq" type3="na" angle="2.08566845613" k="723.890576"/>
+  <Angle type1="nb" type2="cq" type3="nb" angle="2.19544966608" k="920.739408"/>
+  <Angle type1="cd" type2="cx" type3="hc" angle="1.9884536168" k="400.099184"/>
+  <Angle type1="cf" type2="cy" type3="h2" angle="2.04901654184" k="383.873632"/>
+  <Angle type1="cf" type2="cy" type3="n" angle="1.5348425442" k="788.22376"/>
+  <Angle type1="cf" type2="cy" type3="ss" angle="2.10381988035" k="505.879072"/>
+  <Angle type1="cd" type2="n2" type3="na" angle="1.90659767488" k="768.123824"/>
+  <Angle type1="cd" type2="n2" type3="nh" angle="2.06769156484" k="742.275072"/>
+  <Angle type1="c3" type2="n4" type3="cd" angle="1.93801360141" k="539.217184"/>
+  <Angle type1="c3" type2="na" type3="cq" angle="2.08776285124" k="547.384352"/>
+  <Angle type1="ca" type2="na" type3="cq" angle="2.10940493396" k="560.94888"/>
+  <Angle type1="cd" type2="na" type3="cf" angle="2.20976136595" k="541.359392"/>
+  <Angle type1="cq" type2="nb" type3="nb" angle="2.11115026321" k="727.329824"/>
+  <Angle type1="c" type2="n" type3="cf" angle="2.29301357127" k="531.008176"/>
+  <Angle type1="ca" type2="nc" type3="nd" angle="1.89088971161" k="774.20736"/>
+  <Angle type1="c2" type2="nf" type3="ch" angle="2.15076923723" k="587.249504"/>
+  <Angle type1="c" type2="nf" type3="sy" angle="2.0320868481" k="548.974272"/>
+  <Angle type1="c3" type2="nh" type3="ce" angle="2.0964894975" k="544.974368"/>
+  <Angle type1="cd" type2="nh" type3="n2" angle="2.09596589872" k="715.497472"/>
+  <Angle type1="cd" type2="nh" type3="sy" angle="2.13837739954" k="526.983168"/>
+  <Angle type1="cf" type2="nh" type3="sy" angle="1.97902883884" k="546.254672"/>
+  <Angle type1="hn" type2="n" type3="nd" angle="2.01445902265" k="521.142304"/>
+  <Angle type1="cd" type2="no" type3="o" angle="2.05058733817" k="734.183216"/>
+  <Angle type1="n3" type2="py" type3="nf" angle="1.89822009447" k="664.494512"/>
+  <Angle type1="cd" type2="s6" type3="o" angle="1.81095363187" k="800.005904"/>
+  <Angle type1="cd" type2="sh" type3="hs" angle="1.65823732232" k="448.449488"/>
+  <Angle type1="c" type2="ss" type3="cd" angle="1.65614292722" k="628.72968"/>
+  <Angle type1="c3" type2="sx" type3="cd" angle="1.66120438205" k="611.315872"/>
+  <Angle type1="cd" type2="sx" type3="o" angle="1.82927958902" k="789.043824"/>
+  <Angle type1="c3" type2="sy" type3="cd" angle="1.77936317241" k="600.546256"/>
+  <Angle type1="ca" type2="sy" type3="cd" angle="1.83416651092" k="594.50456"/>
+  <Angle type1="ca" type2="sy" type3="nf" angle="1.79786366248" k="774.366352"/>
+  <Angle type1="cc" type2="sy" type3="nh" angle="1.69646003294" k="790.466384"/>
+  <Angle type1="n3" type2="sy" type3="nf" angle="1.77901410656" k="1004.486352"/>
+  <Angle type1="cl" type2="py" type3="ne" angle="1.90520141148" k="562.170608"/>
+  <Angle type1="ce" type2="ce" type3="nh" angle="2.03173778225" k="717.857248"/>
+  <Angle type1="cp" type2="ca" type3="os" angle="2.04046442851" k="735.496992"/>
+  <Angle type1="ca" type2="cc" type3="ca" angle="2.1457077824" k="546.26304"/>
+  <Angle type1="h1" type2="c3" type3="i" angle="1.81304802697" k="328.69504"/>
+  <Angle type1="h4" type2="c2" type3="h4" angle="2.05809225395" k="314.293712"/>
+  <Angle type1="c" type2="ss" type3="ss" angle="1.70483761335" k="609.27408"/>
+  <Angle type1="f" type2="py" type3="ne" angle="1.89542756767" k="700.250976"/>
+  <Angle type1="ca" type2="nh" type3="ce" angle="2.2294835865" k="544.062256"/>
+  <Angle type1="ce" type2="cx" type3="cx" angle="2.07030955872" k="538.455696"/>
+  <Angle type1="py" type2="ne" type3="py" angle="2.11900424485" k="929.01536"/>
+  <Angle type1="c" type2="cd" type3="ss" angle="2.12877808866" k="526.857648"/>
+  <Angle type1="s" type2="p5" type3="ss" angle="2.0362756383" k="388.283568"/>
+  <Angle type1="cx" type2="c3" type3="nh" angle="1.81269896112" k="725.940736"/>
+  <Angle type1="cc" type2="cc" type3="cl" angle="2.09422056947" k="602.780512"/>
+  <Angle type1="cd" type2="na" type3="cx" angle="2.0313887164" k="555.96992"/>
+  <Angle type1="h1" type2="cy" type3="nh" angle="1.98723188632" k="499.603072"/>
+  <Angle type1="h5" type2="c" type3="os" angle="1.97379285108" k="535.234016"/>
+  <Angle type1="c2" type2="c3" type3="n4" angle="1.98339216197" k="685.707392"/>
+  <Angle type1="c2" type2="cx" type3="c3" angle="2.0155062202" k="546.2212"/>
+  <Angle type1="c3" type2="c2" type3="cx" angle="2.05721958933" k="542.33008"/>
+  <Angle type1="br" type2="cx" type3="cx" angle="2.07763994157" k="527.175632"/>
+  <Angle type1="cc" type2="cf" type3="ch" angle="2.13401407641" k="570.429824"/>
+  <Angle type1="c3" type2="c3" type3="sx" angle="1.92858882345" k="527.953856"/>
+  <Angle type1="ca" type2="cy" type3="hc" angle="1.99892559231" k="388.6936"/>
+  <Angle type1="cx" type2="c1" type3="n1" angle="3.11104939168" k="620.805184"/>
+  <Angle type1="cl" type2="py" type3="cl" angle="1.77936317241" k="515.201024"/>
+  <Angle type1="c2" type2="ce" type3="cx" angle="2.1422171239" k="555.350688"/>
+  <Angle type1="c3" type2="c" type3="cx" angle="2.02528006401" k="541.53512"/>
+  <Angle type1="cf" type2="cc" type3="os" angle="2.14797671043" k="729.664496"/>
+  <Angle type1="cd" type2="cd" type3="cl" angle="2.09422056947" k="602.780512"/>
+  <Angle type1="c3" type2="py" type3="ca" angle="1.87221468861" k="385.538864"/>
+  <Angle type1="c3" type2="c3" type3="py" angle="1.94726384645" k="674.83736"/>
+  <Angle type1="c3" type2="py" type3="s" angle="1.9870573534" k="387.02"/>
+  <Angle type1="ca" type2="c" type3="cx" angle="2.0535543979" k="543.894896"/>
+  <Angle type1="ce" type2="ce" type3="os" angle="2.01044476537" k="725.974208"/>
+  <Angle type1="c3" type2="n4" type3="cx" angle="2.04709667966" k="524.138048"/>
+  <Angle type1="h4" type2="ce" type3="sy" angle="2.00712863979" k="356.167184"/>
+  <Angle type1="hx" type2="cy" type3="n4" angle="1.93068321856" k="493.519536"/>
+  <Angle type1="cy" type2="no" type3="o" angle="2.0390681651" k="704.225776"/>
+  <Angle type1="cc" type2="cd" type3="cx" angle="2.16682626635" k="554.806768"/>
+  <Angle type1="ca" type2="nb" type3="na" angle="2.07310208552" k="730.141472"/>
+  <Angle type1="cl" type2="c3" type3="cy" angle="1.95284890006" k="595.115424"/>
+  <Angle type1="f" type2="c2" type3="h4" angle="1.95564142686" k="553.819344"/>
+  <Angle type1="ca" type2="py" type3="s" angle="2.02999245299" k="384.902896"/>
+  <Angle type1="cl" type2="c3" type3="cx" angle="1.93312667951" k="599.684352"/>
+  <Angle type1="ca" type2="nh" type3="cy" angle="2.20993589888" k="529.016592"/>
+  <Angle type1="cy" type2="cy" type3="no" angle="2.01463355558" k="668.067648"/>
+  <Angle type1="ce" type2="n1" type3="n1" angle="3.10005381739" k="649.030448"/>
+  <Angle type1="cy" type2="cy" type3="hx" angle="2.02318566891" k="377.22944"/>
+  <Angle type1="ce" type2="n" type3="hn" angle="1.98670828755" k="402.258128"/>
+  <Angle type1="c3" type2="cx" type3="cu" angle="2.11027759859" k="533.702672"/>
+  <Angle type1="cf" type2="cf" type3="ne" angle="2.10818320348" k="724.54328"/>
+  <Angle type1="f" type2="p5" type3="na" angle="1.55788089033" k="742.333648"/>
+  <Angle type1="h4" type2="ce" type3="nh" angle="2.01725154946" k="521.477024"/>
+  <Angle type1="ne" type2="c" type3="s" angle="2.16822252975" k="687.414464"/>
+  <Angle type1="ca" type2="os" type3="py" angle="2.15216550063" k="694.636048"/>
+  <Angle type1="cf" type2="ce" type3="cl" angle="2.12825448988" k="597.39152"/>
+  <Angle type1="cy" type2="cy" type3="n4" angle="1.56974912924" k="756.140848"/>
+  <Angle type1="na" type2="cc" type3="sh" angle="2.14588231533" k="662.946432"/>
+  <Angle type1="nb" type2="na" type3="o" angle="2.06175744538" k="948.855888"/>
+  <Angle type1="c" type2="cx" type3="n3" angle="2.04133709313" k="687.740816"/>
+  <Angle type1="cd" type2="cy" type3="hc" angle="1.87099295814" k="404.191136"/>
+  <Angle type1="f" type2="c3" type3="no" angle="1.88076680195" k="929.525808"/>
+  <Angle type1="ce" type2="cd" type3="na" angle="2.18043983452" k="719.371856"/>
+  <Angle type1="cq" type2="cp" type3="cq" angle="1.885304658" k="583.29144"/>
+  <Angle type1="os" type2="py" type3="s" angle="2.02842165667" k="500.6156"/>
+  <Angle type1="c" type2="c3" type3="cy" angle="1.93522107461" k="547.903168"/>
+  <Angle type1="cy" type2="c2" type3="ha" angle="2.06978595994" k="383.664432"/>
+  <Angle type1="cp" type2="cq" type3="cp" angle="1.885304658" k="583.29144"/>
+  <Angle type1="cx" type2="cu" type3="cx" angle="1.10287355434" k="746.659904"/>
+  <Angle type1="cu" type2="c2" type3="ha" angle="2.12040050825" k="421.864352"/>
+  <Angle type1="cd" type2="ce" type3="cg" angle="2.13401407641" k="570.429824"/>
+  <Angle type1="cf" type2="ne" type3="ne" angle="1.97518911448" k="735.957232"/>
+  <Angle type1="c3" type2="c2" type3="no" angle="2.02353473476" k="692.711408"/>
+  <Angle type1="f" type2="cy" type3="f" angle="1.89472943597" k="1007.13064"/>
+  <Angle type1="c2" type2="cy" type3="hc" angle="1.96873139625" k="393.120272"/>
+  <Angle type1="c3" type2="c2" type3="cy" angle="2.05931398443" k="537.72768"/>
+  <Angle type1="c" type2="ce" type3="h4" angle="2.06088478075" k="390.442512"/>
+  <Angle type1="cf" type2="cc" type3="n" angle="2.16769893098" k="721.346704"/>
+  <Angle type1="cd" type2="cc" type3="i" angle="2.16909519438" k="502.548608"/>
+  <Angle type1="ce" type2="cf" type3="cl" angle="2.12825448988" k="597.39152"/>
+  <Angle type1="cl" type2="c3" type3="p5" angle="1.91148459678" k="774.215728"/>
+  <Angle type1="c2" type2="c3" type3="no" angle="1.87081842521" k="700.753056"/>
+  <Angle type1="ce" type2="nf" type3="nf" angle="1.97518911448" k="735.957232"/>
+  <Angle type1="c1" type2="c3" type3="cx" angle="1.96087741462" k="556.840192"/>
+  <Angle type1="ce" type2="c3" type3="h2" angle="1.95948115121" k="392.425728"/>
+  <Angle type1="na" type2="cd" type3="na" angle="1.86052098263" k="970.110608"/>
+  <Angle type1="cx" type2="cx" type3="n4" angle="1.05243353895" k="947.71784"/>
+  <Angle type1="c1" type2="cx" type3="hc" angle="2.00468517884" k="405.078144"/>
+  <Angle type1="cg" type2="ca" type3="nb" angle="2.03976629681" k="735.145536"/>
+  <Angle type1="ce" type2="c2" type3="f" angle="2.1401227288" k="753.387776"/>
+  <Angle type1="cp" type2="ca" type3="cq" angle="1.94639118182" k="593.826752"/>
+  <Angle type1="cl" type2="py" type3="nf" angle="1.90520141148" k="562.170608"/>
+  <Angle type1="ca" type2="c3" type3="cy" angle="1.96035381584" k="545.869744"/>
+  <Angle type1="ch" type2="cd" type3="nd" angle="2.14727857873" k="711.581248"/>
+  <Angle type1="h1" type2="cy" type3="ss" angle="1.94708931352" k="348.669456"/>
+  <Angle type1="h5" type2="cc" type3="n2" angle="2.15164190186" k="535.351168"/>
+  <Angle type1="cc" type2="na" type3="cy" angle="2.21185576105" k="535.945296"/>
+  <Angle type1="c" type2="c3" type3="no" angle="1.86732776671" k="698.125504"/>
+  <Angle type1="c3" type2="py" type3="c3" angle="1.84516208521" k="385.898688"/>
+  <Angle type1="hx" type2="c3" type3="n3" angle="1.95005637325" k="507.954336"/>
+  <Angle type1="cf" type2="cf" type3="nh" angle="2.03173778225" k="717.857248"/>
+  <Angle type1="c3" type2="n3" type3="py" angle="2.06420090633" k="682.217936"/>
+  <Angle type1="h5" type2="c2" type3="os" angle="1.93644280509" k="541.627168"/>
+  <Angle type1="cc" type2="c3" type3="ce" angle="1.93539560754" k="554.865344"/>
+  <Angle type1="n4" type2="c3" type3="p5" angle="1.85161980344" k="870.723872"/>
+  <Angle type1="ne" type2="cd" type3="ss" angle="2.19911485751" k="665.557248"/>
+  <Angle type1="na" type2="cd" type3="ne" angle="2.13750473492" k="930.948368"/>
+  <Angle type1="cl" type2="c3" type3="h3" angle="1.8790214727" k="407.119936"/>
+  <Angle type1="h5" type2="c" type3="s" angle="2.15565615914" k="368.501616"/>
+  <Angle type1="cf" type2="ce" type3="ss" angle="2.11097573029" k="532.815664"/>
+  <Angle type1="c3" type2="c2" type3="f" angle="1.97710897666" k="733.563984"/>
+  <Angle type1="h4" type2="c2" type3="oh" angle="2.00032185571" k="539.836416"/>
+  <Angle type1="ne" type2="ce" type3="nf" angle="2.23332331085" k="906.020096"/>
+  <Angle type1="cc" type2="n" type3="cd" angle="2.11272105954" k="561.852624"/>
+  <Angle type1="f" type2="py" type3="f" angle="1.70187055362" k="756.375152"/>
+  <Angle type1="n" type2="cc" type3="os" angle="2.07729087572" k="923.944352"/>
+  <Angle type1="cq" type2="cp" type3="nb" angle="2.09456963532" k="719.171024"/>
+  <Angle type1="c" type2="c" type3="s" angle="2.11725891559" k="535.777936"/>
+  <Angle type1="cf" type2="ce" type3="os" angle="2.09840935967" k="739.697728"/>
+  <Angle type1="br" type2="ce" type3="c2" angle="2.1034708145" k="536.966192"/>
+  <Angle type1="cp" type2="nb" type3="na" angle="2.06140837953" k="732.292048"/>
+  <Angle type1="n" type2="s6" type3="oh" angle="1.69820536219" k="1031.60704"/>
+  <Angle type1="cd" type2="c3" type3="h2" angle="1.92806522468" k="398.977872"/>
+  <Angle type1="nb" type2="ca" type3="sy" angle="2.01986954333" k="679.950208"/>
+  <Angle type1="na" type2="sy" type3="o" angle="1.83783170235" k="1028.862336"/>
+  <Angle type1="hx" type2="cx" type3="hx" angle="2.02056767503" k="317.724592"/>
+  <Angle type1="cd" type2="cf" type3="ne" angle="2.13610847152" k="720.878096"/>
+  <Angle type1="h5" type2="c" type3="oh" angle="1.91096099801" k="546.112416"/>
+  <Angle type1="cy" type2="n" type3="cy" angle="1.65020880776" k="597.232528"/>
+  <Angle type1="br" type2="c3" type3="no" angle="1.86680416793" k="679.004624"/>
+  <Angle type1="c2" type2="ss" type3="s4" angle="1.61303329469" k="612.813744"/>
+  <Angle type1="c3" type2="nh" type3="o" angle="2.05128546987" k="715.271536"/>
+  <Angle type1="br" type2="cc" type3="ss" angle="2.09544229994" k="549.543296"/>
+  <Angle type1="c" type2="ce" type3="ss" angle="1.97623631203" k="539.69416"/>
+  <Angle type1="c3" type2="n" type3="n3" angle="2.05180906864" k="687.30568"/>
+  <Angle type1="h5" type2="ca" type3="na" angle="2.02109127381" k="523.175728"/>
+  <Angle type1="n2" type2="nh" type3="oh" angle="2.05756865518" k="889.526768"/>
+  <Angle type1="c2" type2="c3" type3="p5" angle="1.95860848659" k="676.243184"/>
+  <Angle type1="c3" type2="cx" type3="nh" angle="2.03470484197" k="687.188528"/>
+  <Angle type1="c2" type2="cc" type3="ss" angle="2.22494573044" k="524.564816"/>
+  <Angle type1="c" type2="ca" type3="na" angle="2.05617239177" k="705.698544"/>
+  <Angle type1="cl" type2="c2" type3="n2" angle="2.11970237655" k="767.948096"/>
+  <Angle type1="n2" type2="s4" type3="ne" angle="1.8202038769" k="1022.594704"/>
+  <Angle type1="nc" type2="c" type3="s" angle="2.17241131996" k="687.314048"/>
+  <Angle type1="o" type2="sy" type3="ss" angle="1.87779974222" k="712.049856"/>
+  <Angle type1="c2" type2="ce" type3="ss" angle="2.16176481152" k="526.815808"/>
+  <Angle type1="c3" type2="cx" type3="ca" angle="2.04220975776" k="541.694112"/>
+  <Angle type1="cc" type2="cc" type3="nf" angle="2.12371663383" k="730.877856"/>
+  <Angle type1="ca" type2="nd" type3="cd" angle="1.81933121228" k="614.37856"/>
+  <Angle type1="cc" type2="n2" type3="oh" angle="1.97658537788" k="746.910944"/>
+  <Angle type1="ca" type2="os" type3="sy" angle="2.05966305028" k="533.861664"/>
+  <Angle type1="hx" type2="c3" type3="p5" angle="1.87779974222" k="458.148"/>
+  <Angle type1="ca" type2="ce" type3="n" angle="2.07676727695" k="697.38912"/>
+  <Angle type1="h4" type2="ce" type3="sx" angle="2.01184102877" k="349.297056"/>
+  <Angle type1="c3" type2="ce" type3="ne" angle="2.02859618959" k="701.288608"/>
+  <Angle type1="c1" type2="n1" type3="ce" angle="3.086963848" k="516.548272"/>
+  <Angle type1="c3" type2="n2" type3="cd" angle="2.04220975776" k="567.835744"/>
+  <Angle type1="cc" type2="c3" type3="h2" angle="1.92806522468" k="398.977872"/>
+  <Angle type1="ca" type2="ce" type3="cg" angle="2.0327849798" k="562.396544"/>
+  <Angle type1="c2" type2="cc" type3="na" angle="2.15146736893" k="725.823584"/>
+  <Angle type1="ca" type2="c3" type3="s4" angle="1.91148459678" k="534.773776"/>
+  <Angle type1="n2" type2="cf" type3="nf" angle="2.10643787423" k="935.550768"/>
+  <Angle type1="ce" type2="cf" type3="ss" angle="2.11097573029" k="532.815664"/>
+  <Angle type1="c3" type2="cx" type3="ss" angle="1.99246787408" k="523.117152"/>
+  <Angle type1="nh" type2="ce" type3="nh" angle="2.08933364756" k="908.93216"/>
+  <Angle type1="cd" type2="c" type3="ne" angle="1.95860848659" k="728.082944"/>
+  <Angle type1="na" type2="c3" type3="ss" angle="1.80030712343" k="693.481264"/>
+  <Angle type1="cf" type2="cf" type3="os" angle="2.01044476537" k="725.974208"/>
+  <Angle type1="cx" type2="c3" type3="h2" angle="1.9898498802" k="388.844224"/>
+  <Angle type1="cv" type2="ss" type3="cy" angle="1.441991028" k="663.113792"/>
+  <Angle type1="ss" type2="cy" type3="ss" angle="1.6587609211" k="571.500928"/>
+  <Angle type1="ce" type2="cx" type3="os" angle="2.04570041626" k="693.16328"/>
+  <Angle type1="nb" type2="ca" type3="ne" angle="2.11900424485" k="912.337936"/>
+  <Angle type1="br" type2="ca" type3="nb" angle="2.0306905847" k="683.673968"/>
+  <Angle type1="c3" type2="nh" type3="os" angle="1.92631989543" k="706.2592"/>
+  <Angle type1="c2" type2="nh" type3="p5" angle="2.19736952826" k="678.377024"/>
+  <Angle type1="br" type2="ca" type3="cp" angle="2.118655179" k="531.903552"/>
+  <Angle type1="cc" type2="ce" type3="cc" angle="2.02754899204" k="562.530432"/>
+  <Angle type1="c3" type2="nh" type3="s6" angle="2.03313404565" k="534.949504"/>
+  <Angle type1="cx" type2="c3" type3="na" angle="2.00328891544" k="690.786768"/>
+  <Angle type1="ca" type2="os" type3="p3" angle="1.92789069175" k="716.016288"/>
+  <Angle type1="ce" type2="cf" type3="sy" angle="2.15007110553" k="526.280256"/>
+  <Angle type1="ca" type2="n2" type3="n1" angle="2.06786609776" k="773.897744"/>
+  <Angle type1="cd" type2="cd" type3="no" angle="2.19824219289" k="688.678032"/>
+  <Angle type1="na" type2="n2" type3="os" angle="1.82107654153" k="946.069344"/>
+  <Angle type1="ce" type2="c3" type3="f" angle="1.92527269787" k="739.162176"/>
+  <Angle type1="cx" type2="cc" type3="na" angle="2.22023334146" k="684.83712"/>
+  <Angle type1="n" type2="n2" type3="na" angle="1.85074713881" k="952.86416"/>
+  <Angle type1="c3" type2="cf" type3="cc" angle="2.04954014062" k="561.635056"/>
+  <Angle type1="ca" type2="na" type3="cy" angle="2.2350686401" k="532.506048"/>
+  <Angle type1="h1" type2="c3" type3="py" angle="1.90904113583" k="454.574864"/>
+  <Angle type1="cy" type2="s6" type3="cy" angle="1.51442219196" k="631.750528"/>
+  <Angle type1="ce" type2="ce" type3="s4" angle="2.07903620498" k="532.405632"/>
+  <Angle type1="c3" type2="p3" type3="cy" angle="1.8125244282" k="380.258656"/>
+  <Angle type1="h2" type2="cx" type3="os" angle="2.00189265204" k="509.962656"/>
+  <Angle type1="c" type2="c" type3="ce" angle="2.0148080885" k="540.957728"/>
+  <Angle type1="ce" type2="cy" type3="h1" angle="2.01568075313" k="386.953056"/>
+  <Angle type1="cx" type2="c3" type3="ss" angle="1.83992609745" k="542.907472"/>
+  <Angle type1="cg" type2="ce" type3="ss" angle="2.06280464293" k="533.301008"/>
+  <Angle type1="br" type2="cy" type3="cy" angle="2.08165419885" k="517.535696"/>
+  <Angle type1="c" type2="cy" type3="cl" angle="1.95791035489" k="594.914592"/>
+  <Angle type1="c" type2="cx" type3="n" angle="2.10329628158" k="683.699072"/>
+  <Angle type1="br" type2="c3" type3="f" angle="1.91322992604" k="690.301424"/>
+  <Angle type1="c3" type2="n4" type3="cy" angle="1.95703769026" k="531.485152"/>
+  <Angle type1="ce" type2="cv" type3="ss" angle="2.27049882392" k="518.079616"/>
+  <Angle type1="cc" type2="cd" type3="i" angle="2.16909519438" k="503.7536"/>
+  <Angle type1="c2" type2="ss" type3="ca" angle="1.7938494052" k="610.90584"/>
+  <Angle type1="c" type2="cx" type3="ce" angle="2.03924269803" k="543.660592"/>
+  <Angle type1="cy" type2="nh" type3="cy" angle="1.62856672504" k="598.621616"/>
+  <Angle type1="cx" type2="c" type3="h4" angle="2.01376089095" k="390.49272"/>
+  <Angle type1="c" type2="n4" type3="c3" angle="1.89822009447" k="535.292592"/>
+  <Angle type1="f" type2="cy" type3="py" angle="1.97553818033" k="833.41096"/>
+  <Angle type1="n2" type2="c3" type3="ss" angle="1.90921566876" k="673.088448"/>
+  <Angle type1="c3" type2="ss" type3="cf" angle="1.76766946642" k="597.625824"/>
+  <Angle type1="ce" type2="cy" type3="hc" angle="2.00433611299" k="388.057632"/>
+  <Angle type1="br" type2="cc" type3="nc" angle="2.02894525544" k="690.075488"/>
+  <Angle type1="h3" type2="c3" type3="n" angle="1.91776778209" k="512.79104"/>
+  <Angle type1="ca" type2="ne" type3="cd" angle="2.15844868594" k="565.316976"/>
+  <Angle type1="cx" type2="n" type3="cy" angle="2.02824712374" k="543.786112"/>
+  <Angle type1="cl" type2="c3" type3="s4" angle="1.95459422931" k="598.119536"/>
+  <Angle type1="cp" type2="cq" type3="nb" angle="2.09456963532" k="719.171024"/>
+  <Angle type1="cc" type2="cd" type3="o" angle="2.37469498026" k="725.162512"/>
+  <Angle type1="hx" type2="cy" type3="hx" angle="1.93382481121" k="322.988064"/>
+  <Angle type1="cc" type2="na" type3="sy" angle="2.18462862472" k="517.786736"/>
+  <Angle type1="h1" type2="cy" type3="na" angle="1.85668125827" k="525.987376"/>
+  <Angle type1="h4" type2="cf" type3="sy" angle="2.00712863979" k="356.167184"/>
+  <Angle type1="c" type2="p5" type3="c3" angle="1.94220239162" k="371.806976"/>
+  <Angle type1="ca" type2="c" type3="nc" angle="2.04255882361" k="707.480928"/>
+  <Angle type1="c3" type2="os" type3="sy" angle="2.00800130442" k="534.480896"/>
+  <Angle type1="cd" type2="ne" type3="sy" angle="2.10800867056" k="547.610288"/>
+  <Angle type1="cx" type2="ca" type3="nb" angle="2.04028989558" k="717.706624"/>
+  <Angle type1="nc" type2="ss" type3="ss" angle="1.70064882314" k="784.58368"/>
+  <Angle type1="hp" type2="p5" type3="os" angle="1.79908539296" k="381.932256"/>
+  <Angle type1="ca" type2="n" type3="oh" angle="2.01794968116" k="705.372192"/>
+  <Angle type1="c3" type2="s6" type3="ne" angle="1.88827171773" k="764.400064"/>
+  <Angle type1="c1" type2="cx" type3="h1" angle="2.00363798129" k="405.069776"/>
+  <Angle type1="na" type2="c3" type3="oh" angle="1.89525303474" k="918.940288"/>
+  <Angle type1="n" type2="nc" type3="nd" angle="2.09230070729" k="918.580464"/>
+  <Angle type1="c3" type2="na" type3="nb" angle="1.97466551571" k="712.727664"/>
+  <Angle type1="ne" type2="c" type3="os" angle="1.95494329516" k="949.952096"/>
+  <Angle type1="br" type2="ce" type3="ce" angle="2.01096836415" k="543.7108"/>
+  <Angle type1="cc" type2="c2" type3="oh" angle="2.01027023245" k="762.483792"/>
+  <Angle type1="c1" type2="cx" type3="os" angle="2.04954014062" k="707.154576"/>
+  <Angle type1="nc" type2="cc" type3="os" angle="2.12441476553" k="917.484256"/>
+  <Angle type1="br" type2="ce" type3="cf" angle="2.12232037043" k="534.42232"/>
+  <Angle type1="cy" type2="c3" type3="f" angle="1.94569305012" k="730.266992"/>
+  <Angle type1="h5" type2="ce" type3="ne" angle="1.98356669489" k="524.899536"/>
+  <Angle type1="n3" type2="py" type3="n3" angle="1.82491626589" k="660.871168"/>
+  <Angle type1="br" type2="cc" type3="ca" angle="2.21028496473" k="523.267776"/>
+  <Angle type1="f" type2="c3" type3="na" angle="1.92701802713" k="945.927088"/>
+  <Angle type1="cc" type2="c3" type3="s4" angle="1.95476876223" k="530.1128"/>
+  <Angle type1="ce" type2="cf" type3="sx" angle="1.97169845598" k="541.727584"/>
+  <Angle type1="cc" type2="cc" type3="i" angle="2.19544966608" k="499.40224"/>
+  <Angle type1="c" type2="cg" type3="ch" angle="3.08382225535" k="490.799936"/>
+  <Angle type1="ce" type2="c3" type3="hx" angle="1.93522107461" k="395.070016"/>
+  <Angle type1="cd" type2="na" type3="cy" angle="2.21185576105" k="535.945296"/>
+  <Angle type1="br" type2="c3" type3="c2" angle="1.94028252944" k="533.351216"/>
+  <Angle type1="ce" type2="ce" type3="cg" angle="2.00084545449" k="570.78128"/>
+  <Angle type1="cl" type2="cd" type3="nd" angle="2.11690984974" k="758.132432"/>
+  <Angle type1="n" type2="ca" type3="na" angle="2.04500228456" k="913.32536"/>
+  <Angle type1="cx" type2="cd" type3="nd" angle="2.12232037043" k="702.74464"/>
+  <Angle type1="cl" type2="p5" type3="os" angle="1.82439266711" k="581.9944"/>
+  <Angle type1="cx" type2="ss" type3="cy" angle="1.59941972653" k="618.119056"/>
+  <Angle type1="cc" type2="cg" type3="ch" angle="3.09027997358" k="496.573856"/>
+  <Angle type1="cc" type2="sy" type3="oh" angle="1.81723681718" k="776.316096"/>
+  <Angle type1="cq" type2="ca" type3="os" angle="2.04046442851" k="735.496992"/>
+  <Angle type1="ca" type2="cd" type3="ca" angle="2.1457077824" k="546.26304"/>
+  <Angle type1="f" type2="py" type3="nf" angle="1.89542756767" k="700.250976"/>
+  <Angle type1="ca" type2="nh" type3="cf" angle="2.2294835865" k="544.062256"/>
+  <Angle type1="cf" type2="cx" type3="cx" angle="2.07030955872" k="538.455696"/>
+  <Angle type1="py" type2="nf" type3="py" angle="2.11900424485" k="929.01536"/>
+  <Angle type1="c" type2="cc" type3="ss" angle="2.12877808866" k="526.857648"/>
+  <Angle type1="cc" type2="na" type3="cx" angle="2.0313887164" k="555.96992"/>
+  <Angle type1="c2" type2="cf" type3="cx" angle="2.1422171239" k="555.350688"/>
+  <Angle type1="ce" type2="cd" type3="os" angle="2.14797671043" k="729.664496"/>
+  <Angle type1="cd" type2="cc" type3="cx" angle="2.16682626635" k="554.806768"/>
+  <Angle type1="cf" type2="n1" type3="n1" angle="3.10005381739" k="649.030448"/>
+  <Angle type1="cf" type2="n" type3="hn" angle="1.98670828755" k="402.258128"/>
+  <Angle type1="ce" type2="ce" type3="nf" angle="2.10818320348" k="724.54328"/>
+  <Angle type1="cf" type2="no" type3="o" angle="2.06332824171" k="719.848832"/>
+  <Angle type1="h4" type2="cf" type3="nh" angle="2.01725154946" k="521.477024"/>
+  <Angle type1="nf" type2="c" type3="s" angle="2.16822252975" k="687.414464"/>
+  <Angle type1="na" type2="cd" type3="sh" angle="2.14588231533" k="662.946432"/>
+  <Angle type1="cc" type2="cy" type3="hc" angle="1.87099295814" k="404.191136"/>
+  <Angle type1="cf" type2="cc" type3="na" angle="2.18043983452" k="719.371856"/>
+  <Angle type1="c" type2="cf" type3="h4" angle="2.06088478075" k="390.442512"/>
+  <Angle type1="ce" type2="cd" type3="n" angle="2.16769893098" k="721.346704"/>
+  <Angle type1="cf" type2="c3" type3="h2" angle="1.95948115121" k="392.475936"/>
+  <Angle type1="na" type2="cc" type3="na" angle="1.86052098263" k="970.110608"/>
+  <Angle type1="ch" type2="ca" type3="nb" angle="2.03976629681" k="735.145536"/>
+  <Angle type1="cf" type2="c2" type3="f" angle="2.1401227288" k="753.387776"/>
+  <Angle type1="cg" type2="cc" type3="nc" angle="2.14727857873" k="711.581248"/>
+  <Angle type1="h5" type2="cd" type3="n2" angle="2.15164190186" k="535.367904"/>
+  <Angle type1="cd" type2="c3" type3="cf" angle="1.93539560754" k="554.907184"/>
+  <Angle type1="nf" type2="cc" type3="ss" angle="2.19911485751" k="665.557248"/>
+  <Angle type1="na" type2="cc" type3="nf" angle="2.13750473492" k="930.948368"/>
+  <Angle type1="nf" type2="cf" type3="ne" angle="2.23332331085" k="906.020096"/>
+  <Angle type1="n" type2="cd" type3="os" angle="2.07729087572" k="923.944352"/>
+  <Angle type1="ce" type2="cf" type3="os" angle="2.09840935967" k="739.697728"/>
+  <Angle type1="br" type2="cf" type3="c2" angle="2.1034708145" k="536.966192"/>
+  <Angle type1="cq" type2="nb" type3="na" angle="2.06140837953" k="732.292048"/>
+  <Angle type1="cc" type2="ce" type3="nf" angle="2.13610847152" k="720.878096"/>
+  <Angle type1="cf" type2="s4" type3="ss" angle="1.54723438189" k="623.349056"/>
+  <Angle type1="br" type2="cd" type3="ss" angle="2.09544229994" k="549.543296"/>
+  <Angle type1="c" type2="cf" type3="ss" angle="1.97623631203" k="539.69416"/>
+  <Angle type1="c2" type2="cd" type3="ss" angle="2.22494573044" k="524.564816"/>
+  <Angle type1="n2" type2="s4" type3="nf" angle="1.8202038769" k="1022.594704"/>
+  <Angle type1="nd" type2="c" type3="s" angle="2.17241131996" k="687.314048"/>
+  <Angle type1="c2" type2="cf" type3="ss" angle="2.16176481152" k="526.815808"/>
+  <Angle type1="cd" type2="cd" type3="ne" angle="2.12371663383" k="730.877856"/>
+  <Angle type1="ca" type2="nc" type3="cc" angle="1.81933121228" k="614.37856"/>
+  <Angle type1="cd" type2="n2" type3="oh" angle="1.97658537788" k="746.910944"/>
+  <Angle type1="ca" type2="cf" type3="n" angle="2.07676727695" k="697.38912"/>
+  <Angle type1="h4" type2="cf" type3="sx" angle="2.01184102877" k="349.297056"/>
+  <Angle type1="c3" type2="cf" type3="nf" angle="2.02859618959" k="701.338816"/>
+  <Angle type1="c1" type2="n1" type3="cf" angle="3.086963848" k="516.548272"/>
+  <Angle type1="c3" type2="n2" type3="cc" angle="2.04220975776" k="567.835744"/>
+  <Angle type1="ca" type2="cf" type3="ch" angle="2.0327849798" k="562.396544"/>
+  <Angle type1="c2" type2="cd" type3="na" angle="2.15146736893" k="725.823584"/>
+  <Angle type1="n2" type2="ce" type3="ne" angle="2.10643787423" k="935.550768"/>
+  <Angle type1="nh" type2="cf" type3="nh" angle="2.08933364756" k="908.93216"/>
+  <Angle type1="cc" type2="c" type3="nf" angle="1.95860848659" k="728.082944"/>
+  <Angle type1="cf" type2="cx" type3="os" angle="2.04570041626" k="693.16328"/>
+  <Angle type1="nb" type2="ca" type3="nf" angle="2.11900424485" k="912.337936"/>
+  <Angle type1="br" type2="ca" type3="cq" angle="2.118655179" k="531.903552"/>
+  <Angle type1="cd" type2="cf" type3="cd" angle="2.02754899204" k="562.530432"/>
+  <Angle type1="cf" type2="ce" type3="sy" angle="2.15007110553" k="526.280256"/>
+  <Angle type1="cc" type2="cc" type3="no" angle="2.19824219289" k="688.678032"/>
+  <Angle type1="cf" type2="c3" type3="f" angle="1.92527269787" k="739.22912"/>
+  <Angle type1="cx" type2="cd" type3="na" angle="2.22023334146" k="684.83712"/>
+  <Angle type1="c3" type2="ce" type3="cd" angle="2.04954014062" k="561.584848"/>
+  <Angle type1="cf" type2="cf" type3="s4" angle="2.07903620498" k="532.405632"/>
+  <Angle type1="c" type2="c" type3="cf" angle="2.0148080885" k="540.957728"/>
+  <Angle type1="cf" type2="cy" type3="h1" angle="2.01568075313" k="386.953056"/>
+  <Angle type1="ch" type2="cf" type3="ss" angle="2.06280464293" k="533.301008"/>
+  <Angle type1="cf" type2="cv" type3="ss" angle="2.27049882392" k="518.079616"/>
+  <Angle type1="c" type2="cx" type3="cf" angle="2.03924269803" k="543.660592"/>
+  <Angle type1="c3" type2="ss" type3="ce" angle="1.76766946642" k="597.625824"/>
+  <Angle type1="cf" type2="cy" type3="hc" angle="2.00433611299" k="388.057632"/>
+  <Angle type1="br" type2="cd" type3="nd" angle="2.02894525544" k="690.075488"/>
+  <Angle type1="ca" type2="nf" type3="cc" angle="2.15844868594" k="565.316976"/>
+  <Angle type1="cd" type2="cc" type3="o" angle="2.37469498026" k="725.162512"/>
+  <Angle type1="cd" type2="na" type3="sy" angle="2.18462862472" k="517.786736"/>
+  <Angle type1="ca" type2="c" type3="nd" angle="2.04255882361" k="707.480928"/>
+  <Angle type1="cc" type2="nf" type3="sy" angle="2.10800867056" k="547.610288"/>
+  <Angle type1="nd" type2="ss" type3="ss" angle="1.70064882314" k="784.58368"/>
+  <Angle type1="c3" type2="s6" type3="nf" angle="1.88827171773" k="764.400064"/>
+  <Angle type1="n" type2="nd" type3="nc" angle="2.09230070729" k="918.580464"/>
+  <Angle type1="nf" type2="c" type3="os" angle="1.95494329516" k="949.952096"/>
+  <Angle type1="br" type2="cf" type3="cf" angle="2.01096836415" k="543.7108"/>
+  <Angle type1="cd" type2="c2" type3="oh" angle="2.01027023245" k="762.483792"/>
+  <Angle type1="nd" type2="cd" type3="os" angle="2.12441476553" k="917.484256"/>
+  <Angle type1="br" type2="cf" type3="ce" angle="2.12232037043" k="534.42232"/>
+  <Angle type1="h5" type2="cf" type3="nf" angle="1.98356669489" k="524.899536"/>
+  <Angle type1="br" type2="cd" type3="ca" angle="2.21028496473" k="523.267776"/>
+  <Angle type1="cd" type2="c3" type3="s4" angle="1.95476876223" k="530.1128"/>
+  <Angle type1="cf" type2="ce" type3="sx" angle="1.97169845598" k="541.727584"/>
+  <Angle type1="cd" type2="cd" type3="i" angle="2.19544966608" k="500.557024"/>
+  <Angle type1="c" type2="ch" type3="cg" angle="3.08382225535" k="490.799936"/>
+  <Angle type1="cf" type2="c3" type3="hx" angle="1.93522107461" k="395.111856"/>
+  <Angle type1="cf" type2="cf" type3="ch" angle="2.00084545449" k="570.78128"/>
+  <Angle type1="cl" type2="cc" type3="nc" angle="2.11690984974" k="758.132432"/>
+  <Angle type1="cx" type2="cc" type3="nc" angle="2.12232037043" k="702.74464"/>
+  <Angle type1="cd" type2="ch" type3="cg" angle="3.09027997358" k="496.573856"/>
+  <Angle type1="cd" type2="sy" type3="oh" angle="1.81723681718" k="776.316096"/>
+ </HarmonicAngleForce>
+ <PeriodicTorsionForce>
+  <Proper type1="" type2="c" type3="c" type4="" periodicity1="2" phase1="3.14159265359" k1="1.2552"/>
+  <Proper type1="" type2="c" type3="c1" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="c" type3="cg" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="c" type3="ch" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="c" type3="c2" type4="" periodicity1="2" phase1="3.14159265359" k1="9.1002"/>
+  <Proper type1="" type2="c" type3="cu" type4="" periodicity1="2" phase1="3.14159265359" k1="9.1002"/>
+  <Proper type1="" type2="c" type3="cv" type4="" periodicity1="2" phase1="3.14159265359" k1="9.1002"/>
+  <Proper type1="" type2="c" type3="ce" type4="" periodicity1="2" phase1="3.14159265359" k1="9.1002"/>
+  <Proper type1="" type2="c" type3="cf" type4="" periodicity1="2" phase1="3.14159265359" k1="9.1002"/>
+  <Proper type1="" type2="c" type3="c3" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="c" type3="cx" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="c" type3="cy" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="c" type3="ca" type4="" periodicity1="2" phase1="3.14159265359" k1="4.184"/>
+  <Proper type1="" type2="c" type3="cc" type4="" periodicity1="2" phase1="3.14159265359" k1="12.029"/>
+  <Proper type1="" type2="c" type3="cd" type4="" periodicity1="2" phase1="3.14159265359" k1="12.029"/>
+  <Proper type1="" type2="c" type3="n" type4="" periodicity1="2" phase1="3.14159265359" k1="10.46"/>
+  <Proper type1="" type2="c" type3="n2" type4="" periodicity1="2" phase1="3.14159265359" k1="17.3636"/>
+  <Proper type1="" type2="c" type3="nc" type4="" periodicity1="2" phase1="3.14159265359" k1="16.736"/>
+  <Proper type1="" type2="c" type3="nd" type4="" periodicity1="2" phase1="3.14159265359" k1="16.736"/>
+  <Proper type1="" type2="c" type3="ne" type4="" periodicity1="2" phase1="3.14159265359" k1="0.8368"/>
+  <Proper type1="" type2="c" type3="nf" type4="" periodicity1="2" phase1="3.14159265359" k1="0.8368"/>
+  <Proper type1="" type2="c" type3="na" type4="" periodicity1="2" phase1="3.14159265359" k1="6.0668" periodicity2="4" phase2="3.14159265359" k2="1.4644"/>
+  <Proper type1="" type2="c" type3="no" type4="" periodicity1="2" phase1="3.14159265359" k1="1.8828"/>
+  <Proper type1="" type2="c" type3="oh" type4="" periodicity1="2" phase1="3.14159265359" k1="9.6232"/>
+  <Proper type1="" type2="c" type3="os" type4="" periodicity1="2" phase1="3.14159265359" k1="11.2968"/>
+  <Proper type1="" type2="c" type3="p2" type4="" periodicity1="2" phase1="3.14159265359" k1="27.8236"/>
+  <Proper type1="" type2="c" type3="pc" type4="" periodicity1="2" phase1="3.14159265359" k1="8.368"/>
+  <Proper type1="" type2="c" type3="pd" type4="" periodicity1="2" phase1="3.14159265359" k1="8.368"/>
+  <Proper type1="" type2="c" type3="pe" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="c" type3="pf" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="c" type3="p3" type4="" periodicity1="2" phase1="3.14159265359" k1="6.4852"/>
+  <Proper type1="" type2="c" type3="p4" type4="" periodicity1="2" phase1="3.14159265359" k1="5.6484"/>
+  <Proper type1="" type2="c" type3="px" type4="" periodicity1="2" phase1="3.14159265359" k1="5.6484"/>
+  <Proper type1="" type2="c" type3="p5" type4="" periodicity1="2" phase1="0.0" k1="4.184"/>
+  <Proper type1="" type2="c" type3="py" type4="" periodicity1="2" phase1="0.0" k1="4.184"/>
+  <Proper type1="" type2="c" type3="sh" type4="" periodicity1="2" phase1="3.14159265359" k1="9.414"/>
+  <Proper type1="" type2="c" type3="ss" type4="" periodicity1="2" phase1="3.14159265359" k1="12.9704"/>
+  <Proper type1="" type2="c" type3="s4" type4="" periodicity1="2" phase1="3.14159265359" k1="0.8368"/>
+  <Proper type1="" type2="c" type3="sx" type4="" periodicity1="2" phase1="3.14159265359" k1="0.8368"/>
+  <Proper type1="" type2="c" type3="s6" type4="" periodicity1="2" phase1="0.0" k1="2.092"/>
+  <Proper type1="" type2="c" type3="sy" type4="" periodicity1="2" phase1="0.0" k1="2.092"/>
+  <Proper type1="" type2="c1" type3="c1" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="c1" type3="cg" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="c1" type3="ch" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="cg" type3="cg" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="ch" type3="ch" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="cg" type3="ch" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="c1" type3="c2" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="c1" type3="c3" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="c1" type3="ca" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="c1" type3="cc" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="c1" type3="cd" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="c1" type3="ce" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="c1" type3="cf" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="c1" type3="cu" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="c1" type3="cv" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="c1" type3="cx" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="c1" type3="cy" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="c1" type3="n" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="c1" type3="n2" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="c1" type3="n3" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="c1" type3="n4" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="c1" type3="na" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="c1" type3="nb" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="c1" type3="nc" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="c1" type3="nd" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="c1" type3="ne" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="c1" type3="nf" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="c1" type3="nh" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="c1" type3="no" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="c1" type3="oh" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="c1" type3="os" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="c1" type3="p2" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="c1" type3="pb" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="c1" type3="pc" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="c1" type3="pd" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="c1" type3="pe" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="c1" type3="pf" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="c1" type3="p3" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="c1" type3="p4" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="c1" type3="px" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="c1" type3="p5" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="c1" type3="py" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="c1" type3="s2" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="c1" type3="sh" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="c1" type3="ss" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="c1" type3="s4" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="c1" type3="sx" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="c1" type3="s6" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="c1" type3="sy" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="c2" type3="c2" type4="" periodicity1="2" phase1="3.14159265359" k1="27.8236"/>
+  <Proper type1="" type2="c2" type3="ce" type4="" periodicity1="2" phase1="3.14159265359" k1="27.8236"/>
+  <Proper type1="" type2="c2" type3="cf" type4="" periodicity1="2" phase1="3.14159265359" k1="27.8236"/>
+  <Proper type1="" type2="ce" type3="cf" type4="" periodicity1="2" phase1="3.14159265359" k1="27.8236"/>
+  <Proper type1="" type2="ce" type3="ce" type4="" periodicity1="2" phase1="3.14159265359" k1="4.184"/>
+  <Proper type1="" type2="cf" type3="cf" type4="" periodicity1="2" phase1="3.14159265359" k1="4.184"/>
+  <Proper type1="" type2="cc" type3="cd" type4="" periodicity1="2" phase1="3.14159265359" k1="16.736"/>
+  <Proper type1="" type2="cc" type3="cc" type4="" periodicity1="2" phase1="3.14159265359" k1="16.736"/>
+  <Proper type1="" type2="cd" type3="cd" type4="" periodicity1="2" phase1="3.14159265359" k1="16.736"/>
+  <Proper type1="" type2="c2" type3="c3" type4="" periodicity1="2" phase1="0.0" k1="0.0"/>
+  <Proper type1="" type2="c2" type3="ca" type4="" periodicity1="2" phase1="3.14159265359" k1="2.9288"/>
+  <Proper type1="" type2="c2" type3="n" type4="" periodicity1="2" phase1="3.14159265359" k1="2.7196"/>
+  <Proper type1="" type2="c2" type3="n2" type4="" periodicity1="2" phase1="3.14159265359" k1="17.3636"/>
+  <Proper type1="" type2="c2" type3="ne" type4="" periodicity1="2" phase1="3.14159265359" k1="17.3636"/>
+  <Proper type1="" type2="c2" type3="nf" type4="" periodicity1="2" phase1="3.14159265359" k1="17.3636"/>
+  <Proper type1="" type2="ce" type3="ne" type4="" periodicity1="2" phase1="3.14159265359" k1="3.3472"/>
+  <Proper type1="" type2="cf" type3="nf" type4="" periodicity1="2" phase1="3.14159265359" k1="3.3472"/>
+  <Proper type1="" type2="c2" type3="nc" type4="" periodicity1="2" phase1="3.14159265359" k1="19.874"/>
+  <Proper type1="" type2="c2" type3="nd" type4="" periodicity1="2" phase1="3.14159265359" k1="19.874"/>
+  <Proper type1="" type2="cc" type3="nd" type4="" periodicity1="2" phase1="3.14159265359" k1="19.874"/>
+  <Proper type1="" type2="cd" type3="nc" type4="" periodicity1="2" phase1="3.14159265359" k1="19.874"/>
+  <Proper type1="" type2="cc" type3="nc" type4="" periodicity1="2" phase1="3.14159265359" k1="19.874"/>
+  <Proper type1="" type2="cd" type3="nd" type4="" periodicity1="2" phase1="3.14159265359" k1="19.874"/>
+  <Proper type1="" type2="c2" type3="n3" type4="" periodicity1="2" phase1="3.14159265359" k1="1.2552"/>
+  <Proper type1="" type2="c2" type3="n4" type4="" periodicity1="3" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="c2" type3="na" type4="" periodicity1="2" phase1="3.14159265359" k1="2.615"/>
+  <Proper type1="" type2="cc" type3="na" type4="" periodicity1="2" phase1="3.14159265359" k1="7.1128"/>
+  <Proper type1="" type2="cd" type3="na" type4="" periodicity1="2" phase1="3.14159265359" k1="7.1128"/>
+  <Proper type1="" type2="c2" type3="nh" type4="" periodicity1="2" phase1="3.14159265359" k1="2.8242"/>
+  <Proper type1="" type2="c2" type3="no" type4="" periodicity1="2" phase1="3.14159265359" k1="3.138"/>
+  <Proper type1="" type2="c2" type3="oh" type4="" periodicity1="2" phase1="3.14159265359" k1="4.3932"/>
+  <Proper type1="" type2="c2" type3="os" type4="" periodicity1="2" phase1="3.14159265359" k1="4.3932"/>
+  <Proper type1="" type2="c2" type3="p2" type4="" periodicity1="2" phase1="3.14159265359" k1="27.8236"/>
+  <Proper type1="" type2="c2" type3="pe" type4="" periodicity1="2" phase1="3.14159265359" k1="27.8236"/>
+  <Proper type1="" type2="c2" type3="pf" type4="" periodicity1="2" phase1="3.14159265359" k1="27.8236"/>
+  <Proper type1="" type2="ce" type3="pf" type4="" periodicity1="2" phase1="3.14159265359" k1="27.8236"/>
+  <Proper type1="" type2="ce" type3="pe" type4="" periodicity1="2" phase1="3.14159265359" k1="3.9748"/>
+  <Proper type1="" type2="cf" type3="pf" type4="" periodicity1="2" phase1="3.14159265359" k1="3.9748"/>
+  <Proper type1="" type2="c2" type3="pc" type4="" periodicity1="2" phase1="3.14159265359" k1="19.874"/>
+  <Proper type1="" type2="c2" type3="pd" type4="" periodicity1="2" phase1="3.14159265359" k1="19.874"/>
+  <Proper type1="" type2="cc" type3="pc" type4="" periodicity1="2" phase1="3.14159265359" k1="19.874"/>
+  <Proper type1="" type2="cc" type3="pd" type4="" periodicity1="2" phase1="3.14159265359" k1="19.874"/>
+  <Proper type1="" type2="cd" type3="pc" type4="" periodicity1="2" phase1="3.14159265359" k1="19.874"/>
+  <Proper type1="" type2="cd" type3="pd" type4="" periodicity1="2" phase1="3.14159265359" k1="19.874"/>
+  <Proper type1="" type2="c2" type3="p3" type4="" periodicity1="2" phase1="3.14159265359" k1="1.8828"/>
+  <Proper type1="" type2="c2" type3="p4" type4="" periodicity1="2" phase1="3.14159265359" k1="27.8236"/>
+  <Proper type1="" type2="ce" type3="p4" type4="" periodicity1="2" phase1="3.14159265359" k1="27.8236"/>
+  <Proper type1="" type2="cf" type3="p4" type4="" periodicity1="2" phase1="3.14159265359" k1="27.8236"/>
+  <Proper type1="" type2="c2" type3="px" type4="" periodicity1="2" phase1="0.0" k1="1.3598"/>
+  <Proper type1="" type2="ce" type3="px" type4="" periodicity1="2" phase1="0.0" k1="1.3598"/>
+  <Proper type1="" type2="cf" type3="px" type4="" periodicity1="2" phase1="0.0" k1="1.3598"/>
+  <Proper type1="" type2="c2" type3="p5" type4="" periodicity1="2" phase1="3.14159265359" k1="27.8236"/>
+  <Proper type1="" type2="ce" type3="p5" type4="" periodicity1="2" phase1="3.14159265359" k1="27.8236"/>
+  <Proper type1="" type2="cf" type3="p5" type4="" periodicity1="2" phase1="3.14159265359" k1="27.8236"/>
+  <Proper type1="" type2="c2" type3="py" type4="" periodicity1="2" phase1="3.14159265359" k1="5.99706666667"/>
+  <Proper type1="" type2="ce" type3="py" type4="" periodicity1="2" phase1="3.14159265359" k1="5.99706666667"/>
+  <Proper type1="" type2="cf" type3="py" type4="" periodicity1="2" phase1="3.14159265359" k1="5.99706666667"/>
+  <Proper type1="" type2="c2" type3="sh" type4="" periodicity1="2" phase1="3.14159265359" k1="2.092"/>
+  <Proper type1="" type2="c2" type3="ss" type4="" periodicity1="2" phase1="3.14159265359" k1="4.6024"/>
+  <Proper type1="" type2="c2" type3="s4" type4="" periodicity1="2" phase1="3.14159265359" k1="27.8236"/>
+  <Proper type1="" type2="ce" type3="s4" type4="" periodicity1="2" phase1="3.14159265359" k1="27.8236"/>
+  <Proper type1="" type2="cf" type3="s4" type4="" periodicity1="2" phase1="3.14159265359" k1="27.8236"/>
+  <Proper type1="" type2="c2" type3="sx" type4="" periodicity1="2" phase1="0.0" k1="2.5104"/>
+  <Proper type1="" type2="ce" type3="sx" type4="" periodicity1="2" phase1="0.0" k1="2.5104"/>
+  <Proper type1="" type2="cf" type3="sx" type4="" periodicity1="2" phase1="0.0" k1="2.5104"/>
+  <Proper type1="" type2="c2" type3="s6" type4="" periodicity1="2" phase1="3.14159265359" k1="27.8236"/>
+  <Proper type1="" type2="ce" type3="s6" type4="" periodicity1="2" phase1="3.14159265359" k1="27.8236"/>
+  <Proper type1="" type2="cf" type3="s6" type4="" periodicity1="2" phase1="3.14159265359" k1="27.8236"/>
+  <Proper type1="" type2="c2" type3="sy" type4="" periodicity1="2" phase1="3.14159265359" k1="5.29973333333"/>
+  <Proper type1="" type2="ce" type3="sy" type4="" periodicity1="2" phase1="3.14159265359" k1="5.29973333333"/>
+  <Proper type1="" type2="cf" type3="sy" type4="" periodicity1="2" phase1="3.14159265359" k1="5.29973333333"/>
+  <Proper type1="" type2="c3" type3="c3" type4="" periodicity1="3" phase1="0.0" k1="0.650844444444"/>
+  <Proper type1="" type2="cx" type3="cx" type4="" periodicity1="3" phase1="0.0" k1="0.650844444444"/>
+  <Proper type1="" type2="cy" type3="cy" type4="" periodicity1="3" phase1="0.0" k1="0.650844444444"/>
+  <Proper type1="" type2="c3" type3="ca" type4="" periodicity1="2" phase1="0.0" k1="0.0"/>
+  <Proper type1="" type2="c3" type3="n" type4="" periodicity1="2" phase1="0.0" k1="0.0"/>
+  <Proper type1="" type2="cx" type3="n" type4="" periodicity1="2" phase1="0.0" k1="0.0"/>
+  <Proper type1="" type2="cy" type3="n" type4="" periodicity1="2" phase1="0.0" k1="0.0"/>
+  <Proper type1="" type2="c3" type3="n2" type4="" periodicity1="3" phase1="0.0" k1="0.0"/>
+  <Proper type1="" type2="c3" type3="ne" type4="" periodicity1="3" phase1="0.0" k1="0.0"/>
+  <Proper type1="" type2="c3" type3="nf" type4="" periodicity1="3" phase1="0.0" k1="0.0"/>
+  <Proper type1="" type2="c3" type3="n3" type4="" periodicity1="3" phase1="0.0" k1="1.2552"/>
+  <Proper type1="" type2="c3" type3="n4" type4="" periodicity1="3" phase1="0.0" k1="0.650844444444"/>
+  <Proper type1="" type2="c3" type3="na" type4="" periodicity1="2" phase1="0.0" k1="0.0"/>
+  <Proper type1="" type2="c3" type3="nh" type4="" periodicity1="2" phase1="0.0" k1="0.0"/>
+  <Proper type1="" type2="c3" type3="no" type4="" periodicity1="2" phase1="0.0" k1="0.0"/>
+  <Proper type1="" type2="c3" type3="oh" type4="" periodicity1="3" phase1="0.0" k1="0.697333333333"/>
+  <Proper type1="" type2="c3" type3="os" type4="" periodicity1="3" phase1="0.0" k1="1.60386666667"/>
+  <Proper type1="" type2="c3" type3="p2" type4="" periodicity1="2" phase1="3.14159265359" k1="1.11573333333"/>
+  <Proper type1="" type2="c3" type3="pe" type4="" periodicity1="2" phase1="3.14159265359" k1="1.11573333333"/>
+  <Proper type1="" type2="c3" type3="pf" type4="" periodicity1="2" phase1="3.14159265359" k1="1.11573333333"/>
+  <Proper type1="" type2="c3" type3="p3" type4="" periodicity1="3" phase1="0.0" k1="0.557866666667"/>
+  <Proper type1="" type2="c3" type3="p4" type4="" periodicity1="3" phase1="0.0" k1="0.557866666667"/>
+  <Proper type1="" type2="c3" type3="px" type4="" periodicity1="3" phase1="0.0" k1="0.557866666667"/>
+  <Proper type1="" type2="c3" type3="p5" type4="" periodicity1="3" phase1="0.0" k1="0.0929777777778"/>
+  <Proper type1="" type2="c3" type3="py" type4="" periodicity1="3" phase1="0.0" k1="0.0929777777778"/>
+  <Proper type1="" type2="c3" type3="sh" type4="" periodicity1="3" phase1="0.0" k1="1.046"/>
+  <Proper type1="" type2="c3" type3="ss" type4="" periodicity1="3" phase1="0.0" k1="1.39466666667"/>
+  <Proper type1="" type2="c3" type3="s4" type4="" periodicity1="3" phase1="0.0" k1="0.8368"/>
+  <Proper type1="" type2="c3" type3="sx" type4="" periodicity1="3" phase1="0.0" k1="0.8368"/>
+  <Proper type1="" type2="c3" type3="s6" type4="" periodicity1="3" phase1="0.0" k1="0.604355555556"/>
+  <Proper type1="" type2="c3" type3="sy" type4="" periodicity1="3" phase1="0.0" k1="0.604355555556"/>
+  <Proper type1="" type2="c3" type3="cc" type4="" periodicity1="3" phase1="0.0" k1="0.0"/>
+  <Proper type1="" type2="c3" type3="cd" type4="" periodicity1="3" phase1="0.0" k1="0.0"/>
+  <Proper type1="" type2="ca" type3="ca" type4="" periodicity1="2" phase1="3.14159265359" k1="15.167"/>
+  <Proper type1="" type2="ca" type3="cp" type4="" periodicity1="2" phase1="3.14159265359" k1="15.167"/>
+  <Proper type1="" type2="ca" type3="cq" type4="" periodicity1="2" phase1="3.14159265359" k1="15.167"/>
+  <Proper type1="" type2="cp" type3="cp" type4="" periodicity1="2" phase1="3.14159265359" k1="4.184"/>
+  <Proper type1="" type2="cq" type3="cq" type4="" periodicity1="2" phase1="3.14159265359" k1="4.184"/>
+  <Proper type1="" type2="ca" type3="n" type4="" periodicity1="2" phase1="3.14159265359" k1="1.8828"/>
+  <Proper type1="" type2="ca" type3="n2" type4="" periodicity1="3" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="ca" type3="ne" type4="" periodicity1="3" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="ca" type3="nf" type4="" periodicity1="3" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="ca" type3="n4" type4="" periodicity1="2" phase1="0.0" k1="7.322"/>
+  <Proper type1="" type2="ca" type3="na" type4="" periodicity1="2" phase1="3.14159265359" k1="1.2552"/>
+  <Proper type1="" type2="ca" type3="nb" type4="" periodicity1="2" phase1="3.14159265359" k1="20.0832"/>
+  <Proper type1="" type2="ca" type3="nc" type4="" periodicity1="2" phase1="3.14159265359" k1="20.0832"/>
+  <Proper type1="" type2="ca" type3="nd" type4="" periodicity1="2" phase1="3.14159265359" k1="20.0832"/>
+  <Proper type1="" type2="ca" type3="nh" type4="" periodicity1="2" phase1="3.14159265359" k1="4.3932"/>
+  <Proper type1="" type2="cc" type3="nh" type4="" periodicity1="2" phase1="3.14159265359" k1="4.3932"/>
+  <Proper type1="" type2="cd" type3="nh" type4="" periodicity1="2" phase1="3.14159265359" k1="4.3932"/>
+  <Proper type1="" type2="ca" type3="no" type4="" periodicity1="2" phase1="3.14159265359" k1="2.5104"/>
+  <Proper type1="" type2="ca" type3="oh" type4="" periodicity1="2" phase1="3.14159265359" k1="3.7656"/>
+  <Proper type1="" type2="ca" type3="os" type4="" periodicity1="2" phase1="3.14159265359" k1="3.7656"/>
+  <Proper type1="" type2="ca" type3="p2" type4="" periodicity1="2" phase1="3.14159265359" k1="2.5104"/>
+  <Proper type1="" type2="ca" type3="pe" type4="" periodicity1="2" phase1="3.14159265359" k1="2.5104"/>
+  <Proper type1="" type2="ca" type3="pf" type4="" periodicity1="2" phase1="3.14159265359" k1="2.5104"/>
+  <Proper type1="" type2="ca" type3="pc" type4="" periodicity1="2" phase1="3.14159265359" k1="20.0832"/>
+  <Proper type1="" type2="ca" type3="pd" type4="" periodicity1="2" phase1="3.14159265359" k1="20.0832"/>
+  <Proper type1="" type2="ca" type3="p3" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="ca" type3="p4" type4="" periodicity1="2" phase1="3.14159265359" k1="2.1966"/>
+  <Proper type1="" type2="ca" type3="px" type4="" periodicity1="2" phase1="3.14159265359" k1="2.1966"/>
+  <Proper type1="" type2="ca" type3="p5" type4="" periodicity1="2" phase1="3.14159265359" k1="6.13653333333"/>
+  <Proper type1="" type2="ca" type3="py" type4="" periodicity1="2" phase1="3.14159265359" k1="6.13653333333"/>
+  <Proper type1="" type2="ca" type3="sh" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="ca" type3="ss" type4="" periodicity1="2" phase1="3.14159265359" k1="1.6736"/>
+  <Proper type1="" type2="ca" type3="s4" type4="" periodicity1="2" phase1="0.0" k1="1.2552"/>
+  <Proper type1="" type2="ca" type3="sx" type4="" periodicity1="2" phase1="0.0" k1="1.2552"/>
+  <Proper type1="" type2="ca" type3="s6" type4="" periodicity1="2" phase1="3.14159265359" k1="5.4392"/>
+  <Proper type1="" type2="ca" type3="sy" type4="" periodicity1="2" phase1="3.14159265359" k1="5.4392"/>
+  <Proper type1="" type2="n" type3="cc" type4="" periodicity1="2" phase1="3.14159265359" k1="6.9036"/>
+  <Proper type1="" type2="n" type3="cd" type4="" periodicity1="2" phase1="3.14159265359" k1="6.9036"/>
+  <Proper type1="" type2="n" type3="n" type4="" periodicity1="2" phase1="0.0" k1="4.8116"/>
+  <Proper type1="" type2="n" type3="n2" type4="" periodicity1="2" phase1="0.0" k1="1.6736"/>
+  <Proper type1="" type2="n" type3="ne" type4="" periodicity1="2" phase1="0.0" k1="1.6736"/>
+  <Proper type1="" type2="n" type3="nf" type4="" periodicity1="2" phase1="0.0" k1="1.6736"/>
+  <Proper type1="" type2="n" type3="n3" type4="" periodicity1="2" phase1="0.0" k1="4.4978"/>
+  <Proper type1="" type2="n" type3="n4" type4="" periodicity1="2" phase1="0.0" k1="3.9748"/>
+  <Proper type1="" type2="n" type3="na" type4="" periodicity1="2" phase1="0.0" k1="2.9288"/>
+  <Proper type1="" type2="n" type3="nc" type4="" periodicity1="2" phase1="3.14159265359" k1="20.0832"/>
+  <Proper type1="" type2="n" type3="nd" type4="" periodicity1="2" phase1="3.14159265359" k1="20.0832"/>
+  <Proper type1="" type2="n" type3="nh" type4="" periodicity1="2" phase1="0.0" k1="4.6024"/>
+  <Proper type1="" type2="n" type3="no" type4="" periodicity1="2" phase1="3.14159265359" k1="5.753"/>
+  <Proper type1="" type2="n" type3="oh" type4="" periodicity1="2" phase1="0.0" k1="6.276"/>
+  <Proper type1="" type2="n" type3="os" type4="" periodicity1="2" phase1="0.0" k1="4.6024"/>
+  <Proper type1="" type2="n" type3="p2" type4="" periodicity1="2" phase1="3.14159265359" k1="4.184"/>
+  <Proper type1="" type2="n" type3="pe" type4="" periodicity1="2" phase1="3.14159265359" k1="4.184"/>
+  <Proper type1="" type2="n" type3="pf" type4="" periodicity1="2" phase1="3.14159265359" k1="4.184"/>
+  <Proper type1="" type2="n" type3="pc" type4="" periodicity1="2" phase1="3.14159265359" k1="20.0832"/>
+  <Proper type1="" type2="n" type3="pd" type4="" periodicity1="2" phase1="3.14159265359" k1="20.0832"/>
+  <Proper type1="" type2="n" type3="p3" type4="" periodicity1="2" phase1="0.0" k1="9.414"/>
+  <Proper type1="" type2="n" type3="p4" type4="" periodicity1="2" phase1="0.0" k1="1.3598"/>
+  <Proper type1="" type2="n" type3="px" type4="" periodicity1="2" phase1="0.0" k1="1.3598"/>
+  <Proper type1="" type2="n" type3="p5" type4="" periodicity1="2" phase1="3.14159265359" k1="9.2048"/>
+  <Proper type1="" type2="n" type3="py" type4="" periodicity1="2" phase1="3.14159265359" k1="9.2048"/>
+  <Proper type1="" type2="n" type3="sh" type4="" periodicity1="2" phase1="0.0" k1="4.6024"/>
+  <Proper type1="" type2="n" type3="ss" type4="" periodicity1="2" phase1="0.0" k1="6.276"/>
+  <Proper type1="" type2="n" type3="s4" type4="" periodicity1="3" phase1="0.0" k1="6.276"/>
+  <Proper type1="" type2="n" type3="sx" type4="" periodicity1="3" phase1="0.0" k1="6.276"/>
+  <Proper type1="" type2="n" type3="s6" type4="" periodicity1="2" phase1="3.14159265359" k1="4.6024"/>
+  <Proper type1="" type2="n" type3="sy" type4="" periodicity1="2" phase1="3.14159265359" k1="4.6024"/>
+  <Proper type1="" type2="n1" type3="c2" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="n1" type3="c3" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="n1" type3="ca" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="n1" type3="cc" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="n1" type3="cd" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="n1" type3="ce" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="n1" type3="cf" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="n1" type3="cu" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="n1" type3="cv" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="n1" type3="cx" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="n1" type3="cy" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="n1" type3="n" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="n1" type3="n1" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="n1" type3="n2" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="n1" type3="n3" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="n1" type3="n4" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="n1" type3="na" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="n1" type3="nb" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="n1" type3="nc" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="n1" type3="nd" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="n1" type3="ne" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="n1" type3="nf" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="n1" type3="nh" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="n1" type3="no" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="n1" type3="oh" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="n1" type3="os" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="n1" type3="p2" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="n1" type3="pb" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="n1" type3="pc" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="n1" type3="pd" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="n1" type3="pe" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="n1" type3="pf" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="n1" type3="p3" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="n1" type3="p4" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="n1" type3="px" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="n1" type3="p5" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="n1" type3="py" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="n1" type3="s2" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="n1" type3="sh" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="n1" type3="ss" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="n1" type3="s4" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="n1" type3="sx" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="n1" type3="s6" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="n1" type3="sy" type4="" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="" type2="n2" type3="n2" type4="" periodicity1="2" phase1="3.14159265359" k1="12.552" periodicity2="1" phase2="0.0" k2="11.7152"/>
+  <Proper type1="" type2="n2" type3="ne" type4="" periodicity1="2" phase1="3.14159265359" k1="12.552" periodicity2="1" phase2="0.0" k2="11.7152"/>
+  <Proper type1="" type2="n2" type3="nf" type4="" periodicity1="2" phase1="3.14159265359" k1="12.552" periodicity2="1" phase2="0.0" k2="11.7152"/>
+  <Proper type1="" type2="ne" type3="nf" type4="" periodicity1="2" phase1="3.14159265359" k1="12.552" periodicity2="1" phase2="0.0" k2="11.7152"/>
+  <Proper type1="" type2="ne" type3="ne" type4="" periodicity1="2" phase1="3.14159265359" k1="5.0208"/>
+  <Proper type1="" type2="nf" type3="nf" type4="" periodicity1="2" phase1="3.14159265359" k1="5.0208"/>
+  <Proper type1="" type2="nc" type3="nc" type4="" periodicity1="2" phase1="3.14159265359" k1="16.736"/>
+  <Proper type1="" type2="nd" type3="nd" type4="" periodicity1="2" phase1="3.14159265359" k1="16.736"/>
+  <Proper type1="" type2="nc" type3="nd" type4="" periodicity1="2" phase1="3.14159265359" k1="16.736"/>
+  <Proper type1="" type2="n2" type3="nc" type4="" periodicity1="2" phase1="3.14159265359" k1="12.552" periodicity2="1" phase2="0.0" k2="11.7152"/>
+  <Proper type1="" type2="n2" type3="nd" type4="" periodicity1="2" phase1="3.14159265359" k1="12.552" periodicity2="1" phase2="0.0" k2="11.7152"/>
+  <Proper type1="" type2="n2" type3="n3" type4="" periodicity1="2" phase1="3.14159265359" k1="25.5224"/>
+  <Proper type1="" type2="ne" type3="n3" type4="" periodicity1="2" phase1="3.14159265359" k1="25.5224"/>
+  <Proper type1="" type2="nf" type3="n3" type4="" periodicity1="2" phase1="3.14159265359" k1="25.5224"/>
+  <Proper type1="" type2="n2" type3="n4" type4="" periodicity1="2" phase1="3.14159265359" k1="33.472"/>
+  <Proper type1="" type2="ne" type3="n4" type4="" periodicity1="2" phase1="3.14159265359" k1="33.472"/>
+  <Proper type1="" type2="nf" type3="n4" type4="" periodicity1="2" phase1="3.14159265359" k1="33.472"/>
+  <Proper type1="" type2="n2" type3="na" type4="" periodicity1="2" phase1="3.14159265359" k1="7.1128"/>
+  <Proper type1="" type2="ne" type3="na" type4="" periodicity1="2" phase1="3.14159265359" k1="7.1128"/>
+  <Proper type1="" type2="nf" type3="na" type4="" periodicity1="2" phase1="3.14159265359" k1="7.1128"/>
+  <Proper type1="" type2="na" type3="nc" type4="" periodicity1="2" phase1="3.14159265359" k1="20.0832"/>
+  <Proper type1="" type2="na" type3="nd" type4="" periodicity1="2" phase1="3.14159265359" k1="20.0832"/>
+  <Proper type1="" type2="n2" type3="nh" type4="" periodicity1="2" phase1="3.14159265359" k1="11.7152"/>
+  <Proper type1="" type2="ne" type3="nh" type4="" periodicity1="2" phase1="3.14159265359" k1="11.7152"/>
+  <Proper type1="" type2="nf" type3="nh" type4="" periodicity1="2" phase1="3.14159265359" k1="11.7152"/>
+  <Proper type1="" type2="n2" type3="no" type4="" periodicity1="2" phase1="3.14159265359" k1="3.138"/>
+  <Proper type1="" type2="ne" type3="no" type4="" periodicity1="2" phase1="3.14159265359" k1="3.138"/>
+  <Proper type1="" type2="nf" type3="no" type4="" periodicity1="2" phase1="3.14159265359" k1="3.138"/>
+  <Proper type1="" type2="n2" type3="oh" type4="" periodicity1="2" phase1="3.14159265359" k1="13.3888"/>
+  <Proper type1="" type2="ne" type3="oh" type4="" periodicity1="2" phase1="3.14159265359" k1="13.3888"/>
+  <Proper type1="" type2="nf" type3="oh" type4="" periodicity1="2" phase1="3.14159265359" k1="13.3888"/>
+  <Proper type1="" type2="n2" type3="os" type4="" periodicity1="2" phase1="3.14159265359" k1="12.552"/>
+  <Proper type1="" type2="ne" type3="os" type4="" periodicity1="2" phase1="3.14159265359" k1="12.552"/>
+  <Proper type1="" type2="nf" type3="os" type4="" periodicity1="2" phase1="3.14159265359" k1="12.552"/>
+  <Proper type1="" type2="nc" type3="os" type4="" periodicity1="2" phase1="3.14159265359" k1="20.0832"/>
+  <Proper type1="" type2="nc" type3="ss" type4="" periodicity1="2" phase1="3.14159265359" k1="20.0832"/>
+  <Proper type1="" type2="n2" type3="p2" type4="" periodicity1="2" phase1="3.14159265359" k1="22.5936"/>
+  <Proper type1="" type2="n2" type3="pe" type4="" periodicity1="2" phase1="3.14159265359" k1="22.5936"/>
+  <Proper type1="" type2="n2" type3="pf" type4="" periodicity1="2" phase1="3.14159265359" k1="22.5936"/>
+  <Proper type1="" type2="ne" type3="pf" type4="" periodicity1="2" phase1="3.14159265359" k1="22.5936"/>
+  <Proper type1="" type2="n2" type3="pc" type4="" periodicity1="2" phase1="3.14159265359" k1="22.5936"/>
+  <Proper type1="" type2="n2" type3="pd" type4="" periodicity1="2" phase1="3.14159265359" k1="22.5936"/>
+  <Proper type1="" type2="nc" type3="p2" type4="" periodicity1="2" phase1="3.14159265359" k1="22.5936"/>
+  <Proper type1="" type2="nd" type3="p2" type4="" periodicity1="2" phase1="3.14159265359" k1="22.5936"/>
+  <Proper type1="" type2="nc" type3="pc" type4="" periodicity1="2" phase1="3.14159265359" k1="27.6144"/>
+  <Proper type1="" type2="nd" type3="pd" type4="" periodicity1="2" phase1="3.14159265359" k1="27.6144"/>
+  <Proper type1="" type2="nd" type3="pc" type4="" periodicity1="2" phase1="3.14159265359" k1="27.6144"/>
+  <Proper type1="" type2="nc" type3="pd" type4="" periodicity1="2" phase1="3.14159265359" k1="27.6144"/>
+  <Proper type1="" type2="ne" type3="pe" type4="" periodicity1="1" phase1="0.0" k1="2.5104"/>
+  <Proper type1="" type2="nf" type3="pf" type4="" periodicity1="1" phase1="0.0" k1="2.5104"/>
+  <Proper type1="" type2="n2" type3="p3" type4="" periodicity1="2" phase1="3.14159265359" k1="8.7864"/>
+  <Proper type1="" type2="n2" type3="p4" type4="" periodicity1="2" phase1="3.14159265359" k1="27.8236"/>
+  <Proper type1="" type2="ne" type3="p4" type4="" periodicity1="2" phase1="3.14159265359" k1="27.8236"/>
+  <Proper type1="" type2="nf" type3="p4" type4="" periodicity1="2" phase1="3.14159265359" k1="27.8236"/>
+  <Proper type1="" type2="n2" type3="p5" type4="" periodicity1="2" phase1="3.14159265359" k1="27.8933333333"/>
+  <Proper type1="" type2="ne" type3="p5" type4="" periodicity1="3" phase1="3.14159265359" k1="4.184"/>
+  <Proper type1="" type2="nf" type3="p5" type4="" periodicity1="3" phase1="3.14159265359" k1="4.184"/>
+  <Proper type1="" type2="ne" type3="px" type4="" periodicity1="3" phase1="3.14159265359" k1="4.184"/>
+  <Proper type1="" type2="nf" type3="px" type4="" periodicity1="3" phase1="3.14159265359" k1="4.184"/>
+  <Proper type1="" type2="n2" type3="sh" type4="" periodicity1="2" phase1="3.14159265359" k1="8.7864"/>
+  <Proper type1="" type2="ne" type3="sh" type4="" periodicity1="2" phase1="3.14159265359" k1="8.7864"/>
+  <Proper type1="" type2="nf" type3="sh" type4="" periodicity1="2" phase1="3.14159265359" k1="8.7864"/>
+  <Proper type1="" type2="n2" type3="ss" type4="" periodicity1="2" phase1="3.14159265359" k1="11.7152" periodicity2="1" phase2="3.14159265359" k2="5.4392"/>
+  <Proper type1="" type2="ne" type3="ss" type4="" periodicity1="2" phase1="3.14159265359" k1="11.7152" periodicity2="1" phase2="3.14159265359" k2="5.4392"/>
+  <Proper type1="" type2="nf" type3="ss" type4="" periodicity1="2" phase1="3.14159265359" k1="11.7152" periodicity2="1" phase2="3.14159265359" k2="5.4392"/>
+  <Proper type1="" type2="n2" type3="s4" type4="" periodicity1="2" phase1="3.14159265359" k1="27.8236"/>
+  <Proper type1="" type2="ne" type3="sx" type4="" periodicity1="3" phase1="3.14159265359" k1="6.276"/>
+  <Proper type1="" type2="nf" type3="sx" type4="" periodicity1="3" phase1="3.14159265359" k1="6.276"/>
+  <Proper type1="" type2="n2" type3="s6" type4="" periodicity1="2" phase1="3.14159265359" k1="27.8933333333"/>
+  <Proper type1="" type2="ne" type3="sy" type4="" periodicity1="3" phase1="3.14159265359" k1="2.092" periodicity2="1" phase2="3.14159265359" k2="28.4512"/>
+  <Proper type1="" type2="nf" type3="sy" type4="" periodicity1="3" phase1="3.14159265359" k1="2.092" periodicity2="1" phase2="3.14159265359" k2="28.4512"/>
+  <Proper type1="" type2="n3" type3="n3" type4="" periodicity1="2" phase1="0.0" k1="9.414"/>
+  <Proper type1="" type2="n3" type3="n4" type4="" periodicity1="3" phase1="0.0" k1="1.046"/>
+  <Proper type1="" type2="n3" type3="na" type4="" periodicity1="2" phase1="0.0" k1="6.6944"/>
+  <Proper type1="" type2="n3" type3="nh" type4="" periodicity1="2" phase1="0.0" k1="7.9496"/>
+  <Proper type1="" type2="n3" type3="no" type4="" periodicity1="2" phase1="3.14159265359" k1="16.736"/>
+  <Proper type1="" type2="n3" type3="oh" type4="" periodicity1="2" phase1="0.0" k1="9.2048"/>
+  <Proper type1="" type2="n3" type3="os" type4="" periodicity1="2" phase1="0.0" k1="7.5312"/>
+  <Proper type1="" type2="n3" type3="p2" type4="" periodicity1="2" phase1="3.14159265359" k1="13.3888"/>
+  <Proper type1="" type2="n3" type3="pe" type4="" periodicity1="2" phase1="3.14159265359" k1="13.3888"/>
+  <Proper type1="" type2="n3" type3="pf" type4="" periodicity1="2" phase1="3.14159265359" k1="13.3888"/>
+  <Proper type1="" type2="n3" type3="p3" type4="" periodicity1="2" phase1="0.0" k1="9.8324"/>
+  <Proper type1="" type2="n3" type3="p4" type4="" periodicity1="2" phase1="3.14159265359" k1="8.7864"/>
+  <Proper type1="" type2="n3" type3="px" type4="" periodicity1="2" phase1="3.14159265359" k1="8.7864"/>
+  <Proper type1="" type2="n3" type3="p5" type4="" periodicity1="2" phase1="3.14159265359" k1="12.552"/>
+  <Proper type1="" type2="n3" type3="py" type4="" periodicity1="2" phase1="3.14159265359" k1="12.552"/>
+  <Proper type1="" type2="n3" type3="sh" type4="" periodicity1="2" phase1="0.0" k1="12.9704"/>
+  <Proper type1="" type2="n3" type3="ss" type4="" periodicity1="2" phase1="0.0" k1="10.8784"/>
+  <Proper type1="" type2="n3" type3="s4" type4="" periodicity1="2" phase1="0.0" k1="15.69"/>
+  <Proper type1="" type2="n3" type3="sx" type4="" periodicity1="2" phase1="0.0" k1="15.69"/>
+  <Proper type1="" type2="n3" type3="s6" type4="" periodicity1="2" phase1="0.0" k1="13.1098666667"/>
+  <Proper type1="" type2="n3" type3="sy" type4="" periodicity1="2" phase1="0.0" k1="13.1098666667"/>
+  <Proper type1="" type2="n4" type3="n4" type4="" periodicity1="3" phase1="0.0" k1="0.790311111111"/>
+  <Proper type1="" type2="n4" type3="na" type4="" periodicity1="3" phase1="0.0" k1="0.976266666667"/>
+  <Proper type1="" type2="n4" type3="nh" type4="" periodicity1="3" phase1="0.0" k1="0.767066666667"/>
+  <Proper type1="" type2="n4" type3="no" type4="" periodicity1="3" phase1="3.14159265359" k1="0.348666666667"/>
+  <Proper type1="" type2="n4" type3="oh" type4="" periodicity1="3" phase1="0.0" k1="1.39466666667"/>
+  <Proper type1="" type2="n4" type3="os" type4="" periodicity1="3" phase1="0.0" k1="2.37093333333"/>
+  <Proper type1="" type2="n4" type3="p2" type4="" periodicity1="3" phase1="3.14159265359" k1="0.697333333333"/>
+  <Proper type1="" type2="n4" type3="pe" type4="" periodicity1="3" phase1="3.14159265359" k1="0.697333333333"/>
+  <Proper type1="" type2="n4" type3="pf" type4="" periodicity1="3" phase1="3.14159265359" k1="0.697333333333"/>
+  <Proper type1="" type2="n4" type3="p3" type4="" periodicity1="3" phase1="0.0" k1="0.6276"/>
+  <Proper type1="" type2="n4" type3="p4" type4="" periodicity1="3" phase1="0.0" k1="0.2092"/>
+  <Proper type1="" type2="n4" type3="px" type4="" periodicity1="3" phase1="0.0" k1="0.2092"/>
+  <Proper type1="" type2="n4" type3="p5" type4="" periodicity1="3" phase1="0.0" k1="0.371911111111"/>
+  <Proper type1="" type2="n4" type3="py" type4="" periodicity1="3" phase1="0.0" k1="0.371911111111"/>
+  <Proper type1="" type2="n4" type3="sh" type4="" periodicity1="3" phase1="0.0" k1="2.78933333333"/>
+  <Proper type1="" type2="n4" type3="ss" type4="" periodicity1="3" phase1="0.0" k1="1.39466666667"/>
+  <Proper type1="" type2="n4" type3="s4" type4="" periodicity1="3" phase1="0.0" k1="1.18546666667"/>
+  <Proper type1="" type2="n4" type3="sx" type4="" periodicity1="3" phase1="0.0" k1="1.18546666667"/>
+  <Proper type1="" type2="n4" type3="s6" type4="" periodicity1="3" phase1="0.0" k1="0.557866666667"/>
+  <Proper type1="" type2="n4" type3="sy" type4="" periodicity1="3" phase1="0.0" k1="0.557866666667"/>
+  <Proper type1="" type2="na" type3="na" type4="" periodicity1="2" phase1="0.0" k1="3.7656"/>
+  <Proper type1="" type2="na" type3="nh" type4="" periodicity1="2" phase1="0.0" k1="5.0208"/>
+  <Proper type1="" type2="na" type3="no" type4="" periodicity1="2" phase1="3.14159265359" k1="25.104"/>
+  <Proper type1="" type2="na" type3="oh" type4="" periodicity1="2" phase1="0.0" k1="4.184"/>
+  <Proper type1="" type2="na" type3="os" type4="" periodicity1="2" phase1="0.0" k1="2.7196"/>
+  <Proper type1="" type2="na" type3="p2" type4="" periodicity1="2" phase1="3.14159265359" k1="4.184"/>
+  <Proper type1="" type2="na" type3="pe" type4="" periodicity1="2" phase1="3.14159265359" k1="4.184"/>
+  <Proper type1="" type2="na" type3="pf" type4="" periodicity1="2" phase1="3.14159265359" k1="4.184"/>
+  <Proper type1="" type2="na" type3="p3" type4="" periodicity1="2" phase1="0.0" k1="6.0668"/>
+  <Proper type1="" type2="na" type3="p4" type4="" periodicity1="3" phase1="0.0" k1="4.6024"/>
+  <Proper type1="" type2="na" type3="px" type4="" periodicity1="3" phase1="0.0" k1="4.6024"/>
+  <Proper type1="" type2="na" type3="p5" type4="" periodicity1="2" phase1="3.14159265359" k1="3.48666666667"/>
+  <Proper type1="" type2="na" type3="py" type4="" periodicity1="2" phase1="3.14159265359" k1="3.48666666667"/>
+  <Proper type1="" type2="na" type3="sh" type4="" periodicity1="2" phase1="0.0" k1="7.5312"/>
+  <Proper type1="" type2="na" type3="ss" type4="" periodicity1="2" phase1="0.0" k1="32.6352"/>
+  <Proper type1="" type2="na" type3="s4" type4="" periodicity1="2" phase1="0.0" k1="4.3932"/>
+  <Proper type1="" type2="na" type3="sx" type4="" periodicity1="2" phase1="0.0" k1="4.3932"/>
+  <Proper type1="" type2="na" type3="s6" type4="" periodicity1="2" phase1="3.14159265359" k1="15.3413333333"/>
+  <Proper type1="" type2="na" type3="sy" type4="" periodicity1="2" phase1="3.14159265359" k1="15.3413333333"/>
+  <Proper type1="" type2="nh" type3="nh" type4="" periodicity1="3" phase1="3.14159265359" k1="7.5312"/>
+  <Proper type1="" type2="nh" type3="no" type4="" periodicity1="2" phase1="3.14159265359" k1="10.6692"/>
+  <Proper type1="" type2="nh" type3="oh" type4="" periodicity1="2" phase1="0.0" k1="6.276"/>
+  <Proper type1="" type2="nh" type3="os" type4="" periodicity1="1" phase1="0.0" k1="6.276"/>
+  <Proper type1="" type2="nh" type3="p2" type4="" periodicity1="2" phase1="3.14159265359" k1="5.8576"/>
+  <Proper type1="" type2="nh" type3="pe" type4="" periodicity1="2" phase1="3.14159265359" k1="5.8576"/>
+  <Proper type1="" type2="nh" type3="pf" type4="" periodicity1="2" phase1="3.14159265359" k1="5.8576"/>
+  <Proper type1="" type2="nh" type3="p3" type4="" periodicity1="2" phase1="0.0" k1="9.8324"/>
+  <Proper type1="" type2="nh" type3="p4" type4="" periodicity1="3" phase1="0.0" k1="4.9162"/>
+  <Proper type1="" type2="nh" type3="px" type4="" periodicity1="3" phase1="0.0" k1="4.9162"/>
+  <Proper type1="" type2="nh" type3="p5" type4="" periodicity1="2" phase1="0.0" k1="3.3472"/>
+  <Proper type1="" type2="nh" type3="py" type4="" periodicity1="2" phase1="0.0" k1="3.3472"/>
+  <Proper type1="" type2="nh" type3="sh" type4="" periodicity1="2" phase1="0.0" k1="6.6944"/>
+  <Proper type1="" type2="nh" type3="ss" type4="" periodicity1="2" phase1="0.0" k1="8.7864"/>
+  <Proper type1="" type2="nh" type3="s4" type4="" periodicity1="2" phase1="0.0" k1="3.138" periodicity2="3" phase2="3.14159265359" k2="0.4184"/>
+  <Proper type1="" type2="nh" type3="sx" type4="" periodicity1="2" phase1="0.0" k1="3.138" periodicity2="3" phase2="3.14159265359" k2="0.4184"/>
+  <Proper type1="" type2="nh" type3="s6" type4="" periodicity1="2" phase1="3.14159265359" k1="0.4184"/>
+  <Proper type1="" type2="nh" type3="sy" type4="" periodicity1="2" phase1="3.14159265359" k1="0.4184"/>
+  <Proper type1="" type2="no" type3="no" type4="" periodicity1="4" phase1="3.14159265359" k1="1.6736" periodicity2="2" phase2="3.14159265359" k2="7.5312"/>
+  <Proper type1="" type2="no" type3="oh" type4="" periodicity1="2" phase1="3.14159265359" k1="16.3176"/>
+  <Proper type1="" type2="no" type3="os" type4="" periodicity1="2" phase1="3.14159265359" k1="12.552"/>
+  <Proper type1="" type2="no" type3="p2" type4="" periodicity1="2" phase1="3.14159265359" k1="1.2552"/>
+  <Proper type1="" type2="no" type3="pe" type4="" periodicity1="2" phase1="3.14159265359" k1="1.2552"/>
+  <Proper type1="" type2="no" type3="pf" type4="" periodicity1="2" phase1="3.14159265359" k1="1.2552"/>
+  <Proper type1="" type2="no" type3="p3" type4="" periodicity1="2" phase1="3.14159265359" k1="7.9496"/>
+  <Proper type1="" type2="no" type3="p4" type4="" periodicity1="2" phase1="3.14159265359" k1="2.4058"/>
+  <Proper type1="" type2="no" type3="px" type4="" periodicity1="2" phase1="3.14159265359" k1="2.4058"/>
+  <Proper type1="" type2="no" type3="p5" type4="" periodicity1="2" phase1="0.0" k1="10.0416" periodicity2="3" phase2="0.0" k2="1.6736"/>
+  <Proper type1="" type2="no" type3="py" type4="" periodicity1="2" phase1="0.0" k1="10.0416" periodicity2="3" phase2="0.0" k2="1.6736"/>
+  <Proper type1="" type2="no" type3="sh" type4="" periodicity1="2" phase1="3.14159265359" k1="9.6232"/>
+  <Proper type1="" type2="no" type3="ss" type4="" periodicity1="2" phase1="3.14159265359" k1="11.2968"/>
+  <Proper type1="" type2="no" type3="s4" type4="" periodicity1="2" phase1="3.14159265359" k1="10.8784"/>
+  <Proper type1="" type2="no" type3="sx" type4="" periodicity1="2" phase1="3.14159265359" k1="10.8784"/>
+  <Proper type1="" type2="no" type3="s6" type4="" periodicity1="2" phase1="0.0" k1="1.39466666667"/>
+  <Proper type1="" type2="no" type3="sy" type4="" periodicity1="2" phase1="0.0" k1="1.39466666667"/>
+  <Proper type1="" type2="oh" type3="oh" type4="" periodicity1="2" phase1="0.0" k1="6.6944"/>
+  <Proper type1="" type2="oh" type3="os" type4="" periodicity1="2" phase1="0.0" k1="6.6944"/>
+  <Proper type1="" type2="oh" type3="p2" type4="" periodicity1="2" phase1="3.14159265359" k1="6.276"/>
+  <Proper type1="" type2="oh" type3="pe" type4="" periodicity1="2" phase1="3.14159265359" k1="6.276"/>
+  <Proper type1="" type2="oh" type3="pf" type4="" periodicity1="2" phase1="3.14159265359" k1="6.276"/>
+  <Proper type1="" type2="oh" type3="p3" type4="" periodicity1="3" phase1="3.14159265359" k1="1.6736"/>
+  <Proper type1="" type2="oh" type3="p4" type4="" periodicity1="1" phase1="0.0" k1="2.9288"/>
+  <Proper type1="" type2="oh" type3="px" type4="" periodicity1="1" phase1="0.0" k1="2.9288"/>
+  <Proper type1="" type2="oh" type3="p5" type4="" periodicity1="3" phase1="0.0" k1="2.23146666667"/>
+  <Proper type1="" type2="oh" type3="py" type4="" periodicity1="3" phase1="0.0" k1="2.23146666667"/>
+  <Proper type1="" type2="oh" type3="sh" type4="" periodicity1="2" phase1="0.0" k1="10.0416"/>
+  <Proper type1="" type2="oh" type3="ss" type4="" periodicity1="2" phase1="0.0" k1="10.0416"/>
+  <Proper type1="" type2="oh" type3="s4" type4="" periodicity1="1" phase1="0.0" k1="20.92"/>
+  <Proper type1="" type2="oh" type3="sx" type4="" periodicity1="1" phase1="0.0" k1="20.92"/>
+  <Proper type1="" type2="oh" type3="s6" type4="" periodicity1="1" phase1="3.14159265359" k1="39.748"/>
+  <Proper type1="" type2="oh" type3="sy" type4="" periodicity1="1" phase1="3.14159265359" k1="39.748"/>
+  <Proper type1="" type2="os" type3="os" type4="" periodicity1="1" phase1="0.0" k1="4.184"/>
+  <Proper type1="" type2="os" type3="ss" type4="" periodicity1="2" phase1="0.0" k1="9.2048"/>
+  <Proper type1="" type2="os" type3="sh" type4="" periodicity1="2" phase1="0.0" k1="7.5312"/>
+  <Proper type1="" type2="os" type3="s4" type4="" periodicity1="3" phase1="0.0" k1="6.9036"/>
+  <Proper type1="" type2="os" type3="sx" type4="" periodicity1="3" phase1="0.0" k1="6.9036"/>
+  <Proper type1="" type2="os" type3="s6" type4="" periodicity1="2" phase1="3.14159265359" k1="5.0208"/>
+  <Proper type1="" type2="os" type3="sy" type4="" periodicity1="2" phase1="3.14159265359" k1="5.0208"/>
+  <Proper type1="" type2="os" type3="p2" type4="" periodicity1="2" phase1="3.14159265359" k1="12.552" periodicity2="1" phase2="3.14159265359" k2="8.368"/>
+  <Proper type1="" type2="os" type3="pe" type4="" periodicity1="2" phase1="3.14159265359" k1="12.552" periodicity2="1" phase2="3.14159265359" k2="8.368"/>
+  <Proper type1="" type2="os" type3="pf" type4="" periodicity1="2" phase1="3.14159265359" k1="12.552" periodicity2="1" phase2="3.14159265359" k2="8.368"/>
+  <Proper type1="" type2="os" type3="p3" type4="" periodicity1="2" phase1="0.0" k1="9.2048"/>
+  <Proper type1="" type2="os" type3="p4" type4="" periodicity1="2" phase1="3.14159265359" k1="4.3932"/>
+  <Proper type1="" type2="os" type3="px" type4="" periodicity1="2" phase1="3.14159265359" k1="4.3932"/>
+  <Proper type1="" type2="os" type3="p5" type4="" periodicity1="2" phase1="0.0" k1="3.3472"/>
+  <Proper type1="" type2="os" type3="py" type4="" periodicity1="2" phase1="0.0" k1="3.3472"/>
+  <Proper type1="" type2="p2" type3="p2" type4="" periodicity1="2" phase1="3.14159265359" k1="27.6144"/>
+  <Proper type1="" type2="p2" type3="pe" type4="" periodicity1="2" phase1="3.14159265359" k1="27.6144"/>
+  <Proper type1="" type2="p2" type3="pf" type4="" periodicity1="2" phase1="3.14159265359" k1="27.6144"/>
+  <Proper type1="" type2="p2" type3="pc" type4="" periodicity1="2" phase1="3.14159265359" k1="27.6144"/>
+  <Proper type1="" type2="p2" type3="pd" type4="" periodicity1="2" phase1="3.14159265359" k1="27.6144"/>
+  <Proper type1="" type2="pe" type3="pe" type4="" periodicity1="2" phase1="3.14159265359" k1="5.0208"/>
+  <Proper type1="" type2="pf" type3="pf" type4="" periodicity1="2" phase1="3.14159265359" k1="5.0208"/>
+  <Proper type1="" type2="pc" type3="pc" type4="" periodicity1="2" phase1="3.14159265359" k1="30.1248"/>
+  <Proper type1="" type2="pd" type3="pd" type4="" periodicity1="2" phase1="3.14159265359" k1="30.1248"/>
+  <Proper type1="" type2="pc" type3="pd" type4="" periodicity1="2" phase1="3.14159265359" k1="30.1248"/>
+  <Proper type1="" type2="p2" type3="p3" type4="" periodicity1="1" phase1="0.0" k1="5.0208"/>
+  <Proper type1="" type2="pe" type3="p3" type4="" periodicity1="1" phase1="0.0" k1="5.0208"/>
+  <Proper type1="" type2="pf" type3="p3" type4="" periodicity1="1" phase1="0.0" k1="5.0208"/>
+  <Proper type1="" type2="p2" type3="p4" type4="" periodicity1="2" phase1="3.14159265359" k1="27.8236"/>
+  <Proper type1="" type2="pe" type3="px" type4="" periodicity1="2" phase1="0.0" k1="10.2508"/>
+  <Proper type1="" type2="pf" type3="px" type4="" periodicity1="2" phase1="0.0" k1="10.2508"/>
+  <Proper type1="" type2="p2" type3="p5" type4="" periodicity1="2" phase1="3.14159265359" k1="27.8933333333"/>
+  <Proper type1="" type2="pe" type3="py" type4="" periodicity1="1" phase1="0.0" k1="7.9496"/>
+  <Proper type1="" type2="pf" type3="py" type4="" periodicity1="1" phase1="0.0" k1="7.9496"/>
+  <Proper type1="" type2="p2" type3="sh" type4="" periodicity1="2" phase1="3.14159265359" k1="5.8576"/>
+  <Proper type1="" type2="pe" type3="sh" type4="" periodicity1="2" phase1="3.14159265359" k1="5.8576"/>
+  <Proper type1="" type2="pf" type3="sh" type4="" periodicity1="2" phase1="3.14159265359" k1="5.8576"/>
+  <Proper type1="" type2="p2" type3="ss" type4="" periodicity1="2" phase1="3.14159265359" k1="5.8576"/>
+  <Proper type1="" type2="pe" type3="ss" type4="" periodicity1="2" phase1="3.14159265359" k1="5.8576"/>
+  <Proper type1="" type2="pf" type3="ss" type4="" periodicity1="2" phase1="3.14159265359" k1="5.8576"/>
+  <Proper type1="" type2="p2" type3="s4" type4="" periodicity1="2" phase1="3.14159265359" k1="27.8236"/>
+  <Proper type1="" type2="pe" type3="sx" type4="" periodicity1="2" phase1="0.0" k1="6.276"/>
+  <Proper type1="" type2="pf" type3="sx" type4="" periodicity1="2" phase1="0.0" k1="6.276"/>
+  <Proper type1="" type2="p2" type3="s6" type4="" periodicity1="2" phase1="3.14159265359" k1="27.8933333333"/>
+  <Proper type1="" type2="pe" type3="sy" type4="" periodicity1="3" phase1="3.14159265359" k1="1.6736"/>
+  <Proper type1="" type2="pf" type3="sy" type4="" periodicity1="3" phase1="3.14159265359" k1="1.6736"/>
+  <Proper type1="" type2="p3" type3="p3" type4="" periodicity1="3" phase1="0.0" k1="2.092"/>
+  <Proper type1="" type2="p3" type3="p4" type4="" periodicity1="1" phase1="0.0" k1="3.7656"/>
+  <Proper type1="" type2="p3" type3="px" type4="" periodicity1="1" phase1="0.0" k1="3.7656"/>
+  <Proper type1="" type2="p3" type3="p5" type4="" periodicity1="2" phase1="3.14159265359" k1="7.67066666667"/>
+  <Proper type1="" type2="p3" type3="py" type4="" periodicity1="2" phase1="3.14159265359" k1="7.67066666667"/>
+  <Proper type1="" type2="p3" type3="sh" type4="" periodicity1="2" phase1="0.0" k1="19.2464"/>
+  <Proper type1="" type2="p3" type3="ss" type4="" periodicity1="3" phase1="0.0" k1="4.8116"/>
+  <Proper type1="" type2="p3" type3="s4" type4="" periodicity1="2" phase1="0.0" k1="16.1084"/>
+  <Proper type1="" type2="p3" type3="sx" type4="" periodicity1="2" phase1="0.0" k1="16.1084"/>
+  <Proper type1="" type2="p3" type3="s6" type4="" periodicity1="3" phase1="0.0" k1="1.11573333333"/>
+  <Proper type1="" type2="p3" type3="sy" type4="" periodicity1="3" phase1="0.0" k1="1.11573333333"/>
+  <Proper type1="" type2="p4" type3="p4" type4="" periodicity1="2" phase1="3.14159265359" k1="27.8236"/>
+  <Proper type1="" type2="px" type3="px" type4="" periodicity1="2" phase1="3.14159265359" k1="6.0668"/>
+  <Proper type1="" type2="p4" type3="p5" type4="" periodicity1="2" phase1="3.14159265359" k1="27.8236"/>
+  <Proper type1="" type2="px" type3="py" type4="" periodicity1="2" phase1="3.14159265359" k1="1.32493333333"/>
+  <Proper type1="" type2="p4" type3="s4" type4="" periodicity1="2" phase1="3.14159265359" k1="27.8236"/>
+  <Proper type1="" type2="px" type3="sx" type4="" periodicity1="1" phase1="0.0" k1="3.5564"/>
+  <Proper type1="" type2="p4" type3="s6" type4="" periodicity1="2" phase1="3.14159265359" k1="27.8236"/>
+  <Proper type1="" type2="px" type3="sy" type4="" periodicity1="3" phase1="0.0" k1="0.488133333333"/>
+  <Proper type1="" type2="p4" type3="sh" type4="" periodicity1="1" phase1="3.14159265359" k1="1.046"/>
+  <Proper type1="" type2="px" type3="sh" type4="" periodicity1="1" phase1="3.14159265359" k1="1.046"/>
+  <Proper type1="" type2="p4" type3="ss" type4="" periodicity1="2" phase1="3.14159265359" k1="2.5104"/>
+  <Proper type1="" type2="px" type3="ss" type4="" periodicity1="2" phase1="3.14159265359" k1="2.5104"/>
+  <Proper type1="" type2="p5" type3="p5" type4="" periodicity1="2" phase1="3.14159265359" k1="27.8933333333"/>
+  <Proper type1="" type2="py" type3="py" type4="" periodicity1="2" phase1="0.0" k1="2.5104"/>
+  <Proper type1="" type2="p5" type3="sh" type4="" periodicity1="3" phase1="0.0" k1="1.2552"/>
+  <Proper type1="" type2="py" type3="sh" type4="" periodicity1="3" phase1="0.0" k1="1.2552"/>
+  <Proper type1="" type2="p5" type3="ss" type4="" periodicity1="2" phase1="3.14159265359" k1="15.8992"/>
+  <Proper type1="" type2="py" type3="ss" type4="" periodicity1="2" phase1="3.14159265359" k1="15.8992"/>
+  <Proper type1="" type2="p5" type3="s4" type4="" periodicity1="2" phase1="3.14159265359" k1="27.8933333333"/>
+  <Proper type1="" type2="py" type3="sx" type4="" periodicity1="3" phase1="0.0" k1="1.11573333333"/>
+  <Proper type1="" type2="p5" type3="s6" type4="" periodicity1="2" phase1="3.14159265359" k1="27.8933333333"/>
+  <Proper type1="" type2="py" type3="sy" type4="" periodicity1="3" phase1="0.0" k1="1.16222222222"/>
+  <Proper type1="" type2="sh" type3="sh" type4="" periodicity1="3" phase1="0.0" k1="23.4304"/>
+  <Proper type1="" type2="sh" type3="ss" type4="" periodicity1="3" phase1="0.0" k1="22.1752"/>
+  <Proper type1="" type2="sh" type3="s4" type4="" periodicity1="3" phase1="0.0" k1="2.9288"/>
+  <Proper type1="" type2="sh" type3="sx" type4="" periodicity1="3" phase1="0.0" k1="2.9288"/>
+  <Proper type1="" type2="sh" type3="s6" type4="" periodicity1="2" phase1="3.14159265359" k1="19.5253333333"/>
+  <Proper type1="" type2="sh" type3="sy" type4="" periodicity1="2" phase1="3.14159265359" k1="19.5253333333"/>
+  <Proper type1="" type2="ss" type3="ss" type4="" periodicity1="3" phase1="0.0" k1="0.0"/>
+  <Proper type1="" type2="ss" type3="s4" type4="" periodicity1="3" phase1="0.0" k1="1.2552"/>
+  <Proper type1="" type2="ss" type3="sx" type4="" periodicity1="3" phase1="0.0" k1="1.2552"/>
+  <Proper type1="" type2="ss" type3="s6" type4="" periodicity1="2" phase1="3.14159265359" k1="12.8309333333"/>
+  <Proper type1="" type2="ss" type3="sy" type4="" periodicity1="2" phase1="3.14159265359" k1="12.8309333333"/>
+  <Proper type1="" type2="s4" type3="s4" type4="" periodicity1="2" phase1="3.14159265359" k1="27.8236"/>
+  <Proper type1="" type2="sx" type3="sx" type4="" periodicity1="3" phase1="0.0" k1="2.615"/>
+  <Proper type1="" type2="s4" type3="s6" type4="" periodicity1="2" phase1="3.14159265359" k1="27.8933333333"/>
+  <Proper type1="" type2="sx" type3="sy" type4="" periodicity1="2" phase1="3.14159265359" k1="18.1306666667"/>
+  <Proper type1="" type2="s6" type3="s6" type4="" periodicity1="2" phase1="3.14159265359" k1="27.8933333333"/>
+  <Proper type1="" type2="sy" type3="sy" type4="" periodicity1="2" phase1="3.14159265359" k1="0.650844444444"/>
+  <Proper type1="" type2="cf" type3="pe" type4="" periodicity1="2" phase1="3.14159265359" k1="27.8236"/>
+  <Proper type1="" type2="nd" type3="os" type4="" periodicity1="2" phase1="3.14159265359" k1="20.0832"/>
+  <Proper type1="" type2="nd" type3="ss" type4="" periodicity1="2" phase1="3.14159265359" k1="20.0832"/>
+  <Proper type1="" type2="nf" type3="pe" type4="" periodicity1="2" phase1="3.14159265359" k1="22.5936"/>
+  <Proper type1="c2" type2="ne" type3="p5" type4="o" periodicity1="3" phase1="0.0" k1="0.0" periodicity2="1" phase2="0.0" k2="9.6232"/>
+  <Proper type1="c2" type2="nf" type3="p5" type4="o" periodicity1="3" phase1="0.0" k1="0.0" periodicity2="1" phase2="0.0" k2="9.6232"/>
+  <Proper type1="ce" type2="ne" type3="p5" type4="o" periodicity1="3" phase1="0.0" k1="0.0" periodicity2="1" phase2="0.0" k2="9.6232"/>
+  <Proper type1="ce" type2="nf" type3="p5" type4="o" periodicity1="3" phase1="0.0" k1="0.0" periodicity2="1" phase2="0.0" k2="9.6232"/>
+  <Proper type1="cf" type2="ne" type3="p5" type4="o" periodicity1="3" phase1="0.0" k1="0.0" periodicity2="1" phase2="0.0" k2="9.6232"/>
+  <Proper type1="cf" type2="nf" type3="p5" type4="o" periodicity1="3" phase1="0.0" k1="0.0" periodicity2="1" phase2="0.0" k2="9.6232"/>
+  <Proper type1="hn" type2="n" type3="c" type4="o" periodicity1="2" phase1="3.14159265359" k1="10.46" periodicity2="1" phase2="0.0" k2="8.368"/>
+  <Proper type1="c3" type2="n3" type3="p5" type4="o" periodicity1="2" phase1="3.14159265359" k1="12.552" periodicity2="3" phase2="0.0" k2="9.6232"/>
+  <Proper type1="oh" type2="p5" type3="os" type4="c3" periodicity1="3" phase1="0.0" k1="1.046" periodicity2="2" phase2="0.0" k2="5.0208"/>
+  <Proper type1="h1" type2="c3" type3="c" type4="o" periodicity1="1" phase1="0.0" k1="3.3472" periodicity2="3" phase2="3.14159265359" k2="0.33472"/>
+  <Proper type1="ho" type2="oh" type3="c" type4="o" periodicity1="2" phase1="3.14159265359" k1="9.6232" periodicity2="1" phase2="0.0" k2="7.9496"/>
+  <Proper type1="c2" type2="c2" type3="c" type4="o" periodicity1="2" phase1="3.14159265359" k1="9.1002" periodicity2="3" phase2="0.0" k2="1.2552"/>
+  <Proper type1="c3" type2="c3" type3="os" type4="c" periodicity1="3" phase1="0.0" k1="1.602472" periodicity2="1" phase2="3.14159265359" k2="3.3472"/>
+  <Proper type1="c3" type2="os" type3="c3" type4="na" periodicity1="3" phase1="0.0" k1="1.602472" periodicity2="2" phase2="0.0" k2="2.7196"/>
+  <Proper type1="o" type2="c" type3="os" type4="c3" periodicity1="2" phase1="3.14159265359" k1="11.2968" periodicity2="1" phase2="3.14159265359" k2="5.8576"/>
+  <Proper type1="os" type2="c3" type3="na" type4="c2" periodicity1="2" phase1="0.0" k1="0.0" periodicity2="1" phase2="0.0" k2="10.46"/>
+  <Proper type1="h1" type2="c3" type3="c3" type4="os" periodicity1="3" phase1="0.0" k1="0.0" periodicity2="1" phase2="0.0" k2="1.046"/>
+  <Proper type1="h1" type2="c3" type3="c3" type4="oh" periodicity1="3" phase1="0.0" k1="0.0" periodicity2="1" phase2="0.0" k2="1.046"/>
+  <Proper type1="h1" type2="c3" type3="c3" type4="f" periodicity1="3" phase1="0.0" k1="0.0" periodicity2="1" phase2="0.0" k2="0.79496"/>
+  <Proper type1="h1" type2="c3" type3="c3" type4="cl" periodicity1="3" phase1="0.0" k1="0.0" periodicity2="1" phase2="0.0" k2="1.046"/>
+  <Proper type1="h1" type2="c3" type3="c3" type4="br" periodicity1="3" phase1="0.0" k1="0.0" periodicity2="1" phase2="0.0" k2="2.3012"/>
+  <Proper type1="hc" type2="c3" type3="c3" type4="os" periodicity1="3" phase1="0.0" k1="0.0" periodicity2="1" phase2="0.0" k2="1.046"/>
+  <Proper type1="c3" type2="n4" type3="c3" type4="ca" periodicity1="3" phase1="0.0" k1="0.652704" periodicity2="2" phase2="0.0" k2="2.9288"/>
+  <Proper type1="oh" type2="c3" type3="c3" type4="n4" periodicity1="3" phase1="0.0" k1="0.602496" periodicity2="2" phase2="0.0" k2="5.4392"/>
+  <Proper type1="c3" type2="c3" type3="n4" type4="c3" periodicity1="3" phase1="0.0" k1="0.652704"/>
+  <Proper type1="c3" type2="c" type3="os" type4="p5" periodicity1="2" phase1="3.14159265359" k1="11.2968" periodicity2="1" phase2="3.14159265359" k2="8.368"/>
+  <Proper type1="c" type2="os" type3="p5" type4="o" periodicity1="2" phase1="0.0" k1="3.3472" periodicity2="1" phase2="0.0" k2="4.6024" periodicity3="3" phase3="3.14159265359" k3="2.092"/>
+  <Proper type1="c3" type2="c3" type3="os" type4="p5" periodicity1="3" phase1="0.0" k1="1.602472" periodicity2="1" phase2="3.14159265359" k2="16.5268"/>
+  <Proper type1="c3" type2="os" type3="p5" type4="o" periodicity1="2" phase1="0.0" k1="3.3472" periodicity2="3" phase2="0.0" k2="2.3012"/>
+  <Proper type1="ca" type2="ca" type3="os" type4="p5" periodicity1="2" phase1="3.14159265359" k1="7.322"/>
+  <Proper type1="ca" type2="os" type3="p5" type4="o" periodicity1="2" phase1="3.14159265359" k1="3.3472" periodicity2="3" phase2="0.0" k2="0.4184"/>
+  <Proper type1="br" type2="c3" type3="c3" type4="br" periodicity1="3" phase1="0.0" k1="2.092" periodicity2="1" phase2="0.0" k2="7.61488"/>
+  <Proper type1="c" type2="n" type3="c2" type4="c2" periodicity1="2" phase1="3.14159265359" k1="6.56888" periodicity2="1" phase2="3.14159265359" k2="6.40152"/>
+  <Proper type1="c3" type2="ss" type3="c2" type4="c2" periodicity1="2" phase1="3.14159265359" k1="5.35552" periodicity2="3" phase2="3.14159265359" k2="5.0208"/>
+  <Proper type1="c3" type2="c2" type3="c2" type4="c3" periodicity1="2" phase1="3.14159265359" k1="22.13336" periodicity2="1" phase2="3.14159265359" k2="1.6736"/>
+  <Proper type1="c3" type2="c3" type3="c3" type4="c3" periodicity1="3" phase1="0.0" k1="0.54392" periodicity2="2" phase2="3.14159265359" k2="1.21336" periodicity3="1" phase3="0.0" k3="0.46024"/>
+  <Proper type1="n" type2="c" type3="c3" type4="c3" periodicity1="4" phase1="3.14159265359" k1="0.0" periodicity2="2" phase2="3.14159265359" k2="2.97064"/>
+  <Proper type1="c3" type2="os" type3="c3" type4="c3" periodicity1="3" phase1="0.0" k1="3.80744" periodicity2="2" phase2="0.0" k2="4.184" periodicity3="1" phase3="0.0" k3="0.0"/>
+  <Proper type1="ca" type2="nh" type3="n3" type4="c3" periodicity1="2" phase1="0.0" k1="4.68608"/>
+  <Proper type1="hs" type2="sh" type3="ss" type4="c3" periodicity1="3" phase1="0.0" k1="6.6944" periodicity2="2" phase2="0.0" k2="11.75704"/>
+  <Proper type1="ho" type2="oh" type3="nh" type4="ca" periodicity1="1" phase1="0.0" k1="5.98312" periodicity2="2" phase2="0.0" k2="2.092"/>
+  <Proper type1="cl" type2="c3" type3="c3" type4="cl" periodicity1="3" phase1="0.0" k1="2.092" periodicity2="1" phase2="0.0" k2="3.89112"/>
+  <Proper type1="c" type2="n" type3="c3" type4="c3" periodicity1="4" phase1="3.14159265359" k1="2.7196" periodicity2="3" phase2="3.14159265359" k2="0.12552" periodicity3="1" phase3="0.0" k3="9.45584"/>
+  <Proper type1="c2" type2="p2" type3="n" type4="c" periodicity1="2" phase1="3.14159265359" k1="6.19232" periodicity2="1" phase2="3.14159265359" k2="8.9956"/>
+  <Proper type1="f" type2="c3" type3="c3" type4="f" periodicity1="3" phase1="0.0" k1="4.184" periodicity2="1" phase2="3.14159265359" k2="2.67776"/>
+  <Proper type1="hc" type2="c3" type3="c2" type4="c2" periodicity1="3" phase1="3.14159265359" k1="1.50624" periodicity2="1" phase2="0.0" k2="6.15048"/>
+  <Proper type1="hc" type2="c3" type3="c3" type4="br" periodicity1="3" phase1="0.0" k1="0.87864" periodicity2="1" phase2="0.0" k2="0.33472"/>
+  <Proper type1="hc" type2="c3" type3="c3" type4="c3" periodicity1="3" phase1="0.0" k1="0.33472"/>
+  <Proper type1="hc" type2="c3" type3="c3" type4="cl" periodicity1="3" phase1="0.0" k1="0.92048" periodicity2="1" phase2="3.14159265359" k2="1.046"/>
+  <Proper type1="hc" type2="c3" type3="c3" type4="f" periodicity1="3" phase1="0.0" k1="0.92048" periodicity2="1" phase2="3.14159265359" k2="8.24248"/>
+  <Proper type1="hc" type2="c3" type3="c3" type4="hc" periodicity1="3" phase1="0.0" k1="0.50208"/>
+  <Proper type1="hc" type2="c3" type3="c3" type4="oh" periodicity1="3" phase1="0.0" k1="0.75312" periodicity2="1" phase2="0.0" k2="2.13384"/>
+  <Proper type1="n" type2="c" type3="c3" type4="n" periodicity1="1" phase1="3.14159265359" k1="0.4184" periodicity2="2" phase2="3.14159265359" k2="8.87008"/>
+  <Proper type1="oh" type2="c3" type3="c3" type4="os" periodicity1="3" phase1="0.0" k1="4.22584" periodicity2="2" phase2="0.0" k2="0.0" periodicity3="1" phase3="3.14159265359" k3="0.08368"/>
+  <Proper type1="os" type2="p5" type3="os" type4="c3" periodicity1="3" phase1="0.0" k1="0.0" periodicity2="2" phase2="0.0" k2="10.92024"/>
+  <Proper type1="c3" type2="n" type3="c" type4="c3" periodicity1="2" phase1="3.14159265359" k1="1.08784" periodicity2="1" phase2="0.0" k2="2.092"/>
+  <Proper type1="c3" type2="os" type3="c" type4="c3" periodicity1="1" phase1="3.14159265359" k1="6.61072" periodicity2="2" phase2="3.14159265359" k2="13.30512" periodicity3="3" phase3="0.0" k3="3.05432"/>
+  <Proper type1="hs" type2="sh" type3="c" type4="c3" periodicity1="2" phase1="3.14159265359" k1="4.51872" periodicity2="1" phase2="3.14159265359" k2="8.03328"/>
+  <Proper type1="os" type2="c3" type3="os" type4="c3" periodicity1="3" phase1="3.14159265359" k1="0.0" periodicity2="2" phase2="0.0" k2="5.18816" periodicity3="1" phase3="3.14159265359" k3="4.05848"/>
+  <Proper type1="c3" type2="ss" type3="ss" type4="c3" periodicity1="2" phase1="0.0" k1="13.1796" periodicity2="3" phase2="0.0" k2="3.72376"/>
+  <Proper type1="o" type2="c" type3="c3" type4="hc" periodicity1="1" phase1="0.0" k1="3.47272" periodicity2="3" phase2="3.14159265359" k2="0.16736"/>
+  <Proper type1="ho" type2="oh" type3="c3" type4="c3" periodicity1="3" phase1="0.0" k1="0.0"/>
+  <Proper type1="oh" type2="c3" type3="c3" type4="oh" periodicity1="3" phase1="0.0" k1="3.7656" periodicity2="2" phase2="0.0" k2="4.72792"/>
+  <Proper type1="os" type2="c3" type3="c3" type4="os" periodicity1="3" phase1="0.0" k1="0.0" periodicity2="2" phase2="3.14159265359" k2="0.0" periodicity3="1" phase3="3.14159265359" k3="0.71128"/>
+  <Proper type1="c1" type2="c1" type3="c3" type4="c1" periodicity1="2" phase1="0.0" k1="0.0"/>
+  <Proper type1="c2" type2="c2" type3="c3" type4="c2" periodicity1="2" phase1="0.0" k1="0.468608"/>
+  <Proper type1="c2" type2="ce" type3="ca" type4="ca" periodicity1="2" phase1="3.14159265359" k1="2.585712"/>
+  <Proper type1="c2" type2="ce" type3="ce" type4="c3" periodicity1="2" phase1="3.14159265359" k1="2.092"/>
+  <Proper type1="c2" type2="cf" type3="cd" type4="cc" periodicity1="2" phase1="3.14159265359" k1="2.092"/>
+  <Proper type1="c2" type2="n2" type3="c3" type4="n2" periodicity1="2" phase1="3.14159265359" k1="6.56888" periodicity2="1" phase2="3.14159265359" k2="11.42232"/>
+  <Proper type1="c2" type2="n2" type3="na" type4="cd" periodicity1="2" phase1="3.14159265359" k1="6.5898"/>
+  <Proper type1="c2" type2="n2" type3="n" type4="c" periodicity1="1" phase1="3.14159265359" k1="11.67336"/>
+  <Proper type1="c2" type2="n2" type3="nh" type4="c2" periodicity1="2" phase1="0.0" k1="5.0208"/>
+  <Proper type1="c2" type2="ne" type3="ca" type4="ca" periodicity1="3" phase1="0.0" k1="2.07108"/>
+  <Proper type1="c2" type2="ne" type3="ce" type4="c2" periodicity1="2" phase1="3.14159265359" k1="0.71128"/>
+  <Proper type1="c2" type2="ne" type3="ce" type4="c3" periodicity1="2" phase1="0.0" k1="3.43088"/>
+  <Proper type1="c2" type2="nh" type3="c2" type4="c2" periodicity1="2" phase1="3.14159265359" k1="4.10032"/>
+  <Proper type1="c2" type2="nh" type3="c2" type4="c3" periodicity1="2" phase1="3.14159265359" k1="13.13776"/>
+  <Proper type1="c2" type2="nh" type3="c3" type4="h1" periodicity1="3" phase1="0.0" k1="1.6736"/>
+  <Proper type1="c2" type2="nh" type3="ca" type4="ca" periodicity1="2" phase1="3.14159265359" k1="2.3012"/>
+  <Proper type1="c2" type2="nh" type3="nh" type4="c2" periodicity1="3" phase1="0.0" k1="12.25912"/>
+  <Proper type1="c2" type2="p2" type3="c3" type4="p2" periodicity1="1" phase1="3.14159265359" k1="8.66088"/>
+  <Proper type1="c2" type2="p2" type3="n4" type4="hn" periodicity1="3" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="c2" type2="p2" type3="na" type4="cc" periodicity1="2" phase1="3.14159265359" k1="7.65672"/>
+  <Proper type1="c2" type2="p2" type3="nh" type4="c2" periodicity1="2" phase1="3.14159265359" k1="5.56472"/>
+  <Proper type1="c2" type2="p2" type3="nh" type4="c3" periodicity1="2" phase1="3.14159265359" k1="10.0416"/>
+  <Proper type1="c2" type2="p2" type3="nh" type4="ca" periodicity1="1" phase1="3.14159265359" k1="7.86592"/>
+  <Proper type1="c2" type2="pe" type3="ca" type4="ca" periodicity1="2" phase1="3.14159265359" k1="4.45596"/>
+  <Proper type1="c2" type2="pe" type3="ce" type4="c2" periodicity1="2" phase1="3.14159265359" k1="3.4518"/>
+  <Proper type1="c2" type2="pe" type3="ce" type4="c3" periodicity1="1" phase1="3.14159265359" k1="15.22976"/>
+  <Proper type1="c2" type2="pe" type3="ne" type4="c2" periodicity1="1" phase1="0.0" k1="1.21336"/>
+  <Proper type1="c2" type2="pe" type3="pe" type4="c2" periodicity1="2" phase1="3.14159265359" k1="2.84512"/>
+  <Proper type1="c3" type2="c2" type3="nh" type4="ca" periodicity1="2" phase1="3.14159265359" k1="4.85344" periodicity2="1" phase2="0.0" k2="7.86592"/>
+  <Proper type1="c3" type2="c3" type3="cc" type4="ca" periodicity1="3" phase1="0.0" k1="0.343088"/>
+  <Proper type1="c3" type2="c" type3="c3" type4="c3" periodicity1="2" phase1="3.14159265359" k1="1.389088"/>
+  <Proper type1="c3" type2="c" type3="ce" type4="c3" periodicity1="2" phase1="0.0" k1="17.19624"/>
+  <Proper type1="c3" type2="ce" type3="ce" type4="c3" periodicity1="2" phase1="3.14159265359" k1="2.092"/>
+  <Proper type1="c3" type2="n2" type3="c2" type4="c3" periodicity1="2" phase1="3.14159265359" k1="43.38808"/>
+  <Proper type1="c3" type2="n3" type3="n3" type4="c3" periodicity1="2" phase1="0.0" k1="9.66504"/>
+  <Proper type1="c3" type2="n3" type3="nh" type4="c2" periodicity1="2" phase1="0.0" k1="5.66932"/>
+  <Proper type1="c3" type2="n4" type3="ca" type4="ca" periodicity1="2" phase1="0.0" k1="6.25508"/>
+  <Proper type1="c3" type2="n4" type3="n4" type4="c3" periodicity1="3" phase1="0.0" k1="1.020896"/>
+  <Proper type1="c3" type2="nh" type3="c2" type4="c2" periodicity1="2" phase1="3.14159265359" k1="3.9748" periodicity2="3" phase2="3.14159265359" k2="4.68608"/>
+  <Proper type1="c3" type2="nh" type3="c2" type4="c3" periodicity1="2" phase1="3.14159265359" k1="10.43908"/>
+  <Proper type1="c3" type2="os" type3="c2" type4="c2" periodicity1="2" phase1="3.14159265359" k1="10.54368" periodicity2="1" phase2="3.14159265359" k2="8.368"/>
+  <Proper type1="c3" type2="os" type3="c2" type4="c3" periodicity1="2" phase1="3.14159265359" k1="20.04136"/>
+  <Proper type1="c3" type2="os" type3="c3" type4="h1" periodicity1="3" phase1="0.0" k1="1.410008"/>
+  <Proper type1="c3" type2="os" type3="ca" type4="ca" periodicity1="2" phase1="3.14159265359" k1="6.73624"/>
+  <Proper type1="c3" type2="os" type3="n2" type4="c2" periodicity1="2" phase1="3.14159265359" k1="9.2048" periodicity2="3" phase2="3.14159265359" k2="3.7656"/>
+  <Proper type1="c3" type2="os" type3="n3" type4="c3" periodicity1="2" phase1="0.0" k1="3.51456"/>
+  <Proper type1="c3" type2="os" type3="n4" type4="c3" periodicity1="3" phase1="3.14159265359" k1="2.59408"/>
+  <Proper type1="c3" type2="os" type3="na" type4="cc" periodicity1="2" phase1="0.0" k1="0.79496"/>
+  <Proper type1="c3" type2="os" type3="n" type4="c" periodicity1="2" phase1="0.0" k1="1.75728"/>
+  <Proper type1="c3" type2="os" type3="nh" type4="c2" periodicity1="1" phase1="0.0" k1="4.8116"/>
+  <Proper type1="c3" type2="os" type3="nh" type4="ca" periodicity1="1" phase1="0.0" k1="2.092"/>
+  <Proper type1="c3" type2="os" type3="no" type4="o" periodicity1="2" phase1="3.14159265359" k1="10.52276"/>
+  <Proper type1="c3" type2="os" type3="oh" type4="ho" periodicity1="2" phase1="0.0" k1="4.22584"/>
+  <Proper type1="c3" type2="os" type3="os" type4="c3" periodicity1="1" phase1="0.0" k1="1.58992"/>
+  <Proper type1="c3" type2="os" type3="p2" type4="c2" periodicity1="2" phase1="3.14159265359" k1="12.30096" periodicity2="1" phase2="3.14159265359" k2="7.7404"/>
+  <Proper type1="c3" type2="p3" type3="c2" type4="c2" periodicity1="2" phase1="0.0" k1="1.242648"/>
+  <Proper type1="c3" type2="p3" type3="c2" type4="c3" periodicity1="2" phase1="3.14159265359" k1="3.9748"/>
+  <Proper type1="c3" type2="p3" type3="ca" type4="ca" periodicity1="2" phase1="3.14159265359" k1="0.740568"/>
+  <Proper type1="c3" type2="p3" type3="n2" type4="c2" periodicity1="2" phase1="3.14159265359" k1="20.92"/>
+  <Proper type1="c3" type2="p3" type3="n3" type4="c3" periodicity1="2" phase1="0.0" k1="11.9244"/>
+  <Proper type1="c3" type2="p3" type3="n4" type4="c3" periodicity1="3" phase1="0.0" k1="0.280328"/>
+  <Proper type1="c3" type2="p3" type3="na" type4="cc" periodicity1="2" phase1="0.0" k1="4.2886"/>
+  <Proper type1="c3" type2="p3" type3="n" type4="c" periodicity1="2" phase1="0.0" k1="7.65672"/>
+  <Proper type1="c3" type2="p3" type3="nh" type4="c2" periodicity1="2" phase1="0.0" k1="7.7404"/>
+  <Proper type1="c3" type2="p3" type3="no" type4="o" periodicity1="2" phase1="3.14159265359" k1="5.8576"/>
+  <Proper type1="c3" type2="p3" type3="oh" type4="ho" periodicity1="3" phase1="3.14159265359" k1="1.00416"/>
+  <Proper type1="c3" type2="p3" type3="p2" type4="c2" periodicity1="1" phase1="0.0" k1="0.8368"/>
+  <Proper type1="c3" type2="p3" type3="p3" type4="c3" periodicity1="3" phase1="0.0" k1="1.569"/>
+  <Proper type1="c3" type2="p4" type3="n3" type4="c3" periodicity1="2" phase1="3.14159265359" k1="7.439152"/>
+  <Proper type1="c3" type2="p4" type3="n4" type4="hn" periodicity1="3" phase1="0.0" k1="0.02092"/>
+  <Proper type1="c3" type2="p4" type3="na" type4="cc" periodicity1="3" phase1="0.0" k1="4.184" periodicity2="2" phase2="3.14159265359" k2="2.67776"/>
+  <Proper type1="c3" type2="p4" type3="nh" type4="c2" periodicity1="1" phase1="0.0" k1="3.7656"/>
+  <Proper type1="c3" type2="p4" type3="nh" type4="ca" periodicity1="3" phase1="3.14159265359" k1="0.0" periodicity2="2" phase2="3.14159265359" k2="3.51456"/>
+  <Proper type1="c3" type2="p4" type3="os" type4="c3" periodicity1="2" phase1="3.14159265359" k1="2.5104"/>
+  <Proper type1="c3" type2="p4" type3="p3" type4="c3" periodicity1="1" phase1="0.0" k1="5.8576"/>
+  <Proper type1="c3" type2="px" type3="ca" type4="ca" periodicity1="2" phase1="3.14159265359" k1="1.807488"/>
+  <Proper type1="c3" type2="px" type3="c" type4="c3" periodicity1="2" phase1="0.0" k1="0.0" periodicity2="1" phase2="3.14159265359" k2="2.42672"/>
+  <Proper type1="c3" type2="px" type3="ce" type4="c2" periodicity1="2" phase1="0.0" k1="4.72792"/>
+  <Proper type1="c3" type2="px" type3="ce" type4="c3" periodicity1="2" phase1="3.14159265359" k1="3.38904"/>
+  <Proper type1="c3" type2="px" type3="ne" type4="c2" periodicity1="3" phase1="0.0" k1="2.55224" periodicity2="1" phase2="0.0" k2="6.02496"/>
+  <Proper type1="c3" type2="px" type3="pe" type4="c2" periodicity1="2" phase1="0.0" k1="6.54796"/>
+  <Proper type1="c3" type2="s4" type3="c3" type4="h1" periodicity1="3" phase1="0.0" k1="0.489528"/>
+  <Proper type1="c3" type2="s4" type3="n3" type4="c3" periodicity1="2" phase1="0.0" k1="12.9704"/>
+  <Proper type1="c3" type2="s4" type3="n4" type4="c3" periodicity1="3" phase1="0.0" k1="0.8368"/>
+  <Proper type1="c3" type2="s4" type3="na" type4="cc" periodicity1="2" phase1="0.0" k1="2.3012"/>
+  <Proper type1="c3" type2="s4" type3="nh" type4="c2" periodicity1="2" phase1="3.14159265359" k1="0.98324" periodicity2="3" phase2="0.0" k2="2.092" periodicity3="1" phase3="0.0" k3="5.447568"/>
+  <Proper type1="c3" type2="s4" type3="no" type4="o" periodicity1="2" phase1="3.14159265359" k1="4.72792"/>
+  <Proper type1="c3" type2="s4" type3="oh" type4="ho" periodicity1="1" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="c3" type2="s4" type3="os" type4="c3" periodicity1="1" phase1="3.14159265359" k1="5.48104"/>
+  <Proper type1="c3" type2="s4" type3="p3" type4="c3" periodicity1="2" phase1="0.0" k1="9.28848"/>
+  <Proper type1="c3" type2="s4" type3="sh" type4="hs" periodicity1="3" phase1="0.0" k1="0.0" periodicity2="2" phase2="3.14159265359" k2="2.34304"/>
+  <Proper type1="c3" type2="s4" type3="ss" type4="c3" periodicity1="3" phase1="0.0" k1="0.2092"/>
+  <Proper type1="c3" type2="s6" type3="c3" type4="h1" periodicity1="3" phase1="0.0" k1="0.372376"/>
+  <Proper type1="c3" type2="s6" type3="n3" type4="c3" periodicity1="2" phase1="0.0" k1="15.10424"/>
+  <Proper type1="c3" type2="s6" type3="n4" type4="c3" periodicity1="1" phase1="0.0" k1="6.15048"/>
+  <Proper type1="c3" type2="s6" type3="na" type4="cc" periodicity1="2" phase1="3.14159265359" k1="16.476592"/>
+  <Proper type1="c3" type2="s6" type3="n" type4="c" periodicity1="2" phase1="3.14159265359" k1="3.213312"/>
+  <Proper type1="c3" type2="s6" type3="nh" type4="c2" periodicity1="2" phase1="0.0" k1="2.790728"/>
+  <Proper type1="c3" type2="s6" type3="no" type4="o" periodicity1="2" phase1="0.0" k1="1.456032"/>
+  <Proper type1="c3" type2="s6" type3="oh" type4="ho" periodicity1="1" phase1="3.14159265359" k1="48.91096"/>
+  <Proper type1="c3" type2="s6" type3="os" type4="c3" periodicity1="2" phase1="3.14159265359" k1="2.230072"/>
+  <Proper type1="c3" type2="s6" type3="p3" type4="c3" periodicity1="3" phase1="0.0" k1="0.765672"/>
+  <Proper type1="c3" type2="s6" type3="sh" type4="hs" periodicity1="2" phase1="3.14159265359" k1="18.062328"/>
+  <Proper type1="c3" type2="s6" type3="ss" type4="c3" periodicity1="2" phase1="3.14159265359" k1="10.0416"/>
+  <Proper type1="c3" type2="ss" type3="c2" type4="c3" periodicity1="2" phase1="3.14159265359" k1="8.4726"/>
+  <Proper type1="c3" type2="ss" type3="c3" type4="c3" periodicity1="3" phase1="0.0" k1="0.698728"/>
+  <Proper type1="c3" type2="ss" type3="c3" type4="h1" periodicity1="3" phase1="0.0" k1="0.92048"/>
+  <Proper type1="c3" type2="ss" type3="ca" type4="ca" periodicity1="2" phase1="3.14159265359" k1="3.138"/>
+  <Proper type1="c3" type2="ss" type3="n2" type4="c2" periodicity1="2" phase1="3.14159265359" k1="5.6484" periodicity2="1" phase2="3.14159265359" k2="5.77392"/>
+  <Proper type1="c3" type2="ss" type3="n3" type4="c3" periodicity1="2" phase1="0.0" k1="11.21312"/>
+  <Proper type1="c3" type2="ss" type3="n4" type4="c3" periodicity1="3" phase1="0.0" k1="1.63176"/>
+  <Proper type1="c3" type2="ss" type3="n" type4="c" periodicity1="2" phase1="0.0" k1="2.092"/>
+  <Proper type1="c3" type2="ss" type3="nh" type4="c2" periodicity1="2" phase1="0.0" k1="4.6024"/>
+  <Proper type1="c3" type2="ss" type3="no" type4="o" periodicity1="2" phase1="3.14159265359" k1="9.60228"/>
+  <Proper type1="c3" type2="ss" type3="oh" type4="ho" periodicity1="2" phase1="0.0" k1="8.91192"/>
+  <Proper type1="c3" type2="ss" type3="os" type4="c3" periodicity1="2" phase1="0.0" k1="7.28016"/>
+  <Proper type1="c3" type2="ss" type3="p2" type4="c2" periodicity1="2" phase1="3.14159265359" k1="12.42648"/>
+  <Proper type1="c3" type2="ss" type3="p3" type4="c3" periodicity1="2" phase1="0.0" k1="15.69"/>
+  <Proper type1="c3" type2="ss" type3="p4" type4="c3" periodicity1="2" phase1="3.14159265359" k1="2.38488"/>
+  <Proper type1="c3" type2="sx" type3="ca" type4="ca" periodicity1="2" phase1="0.0" k1="2.67776"/>
+  <Proper type1="c3" type2="sx" type3="ce" type4="c2" periodicity1="2" phase1="0.0" k1="6.10864" periodicity2="3" phase2="3.14159265359" k2="6.276"/>
+  <Proper type1="c3" type2="sx" type3="ce" type4="c3" periodicity1="3" phase1="0.0" k1="6.276" periodicity2="2" phase2="0.0" k2="17.40544" periodicity3="1" phase3="3.14159265359" k3="12.9704"/>
+  <Proper type1="c3" type2="sx" type3="ne" type4="c2" periodicity1="3" phase1="3.14159265359" k1="4.184" periodicity2="1" phase2="3.14159265359" k2="7.9496"/>
+  <Proper type1="c3" type2="sx" type3="pe" type4="c2" periodicity1="2" phase1="0.0" k1="17.53096"/>
+  <Proper type1="c3" type2="sx" type3="px" type4="c3" periodicity1="1" phase1="0.0" k1="11.17128"/>
+  <Proper type1="c3" type2="sx" type3="sx" type4="c3" periodicity1="1" phase1="0.0" k1="12.21728"/>
+  <Proper type1="c3" type2="sx" type3="sy" type4="c3" periodicity1="2" phase1="3.14159265359" k1="20.66896"/>
+  <Proper type1="c3" type2="sy" type3="ca" type4="ca" periodicity1="2" phase1="3.14159265359" k1="5.10448"/>
+  <Proper type1="c3" type2="sy" type3="ce" type4="c2" periodicity1="2" phase1="3.14159265359" k1="3.91204"/>
+  <Proper type1="c3" type2="sy" type3="ce" type4="c3" periodicity1="3" phase1="0.0" k1="2.67776" periodicity2="2" phase2="3.14159265359" k2="1.393272" periodicity3="1" phase3="3.14159265359" k3="4.35136"/>
+  <Proper type1="c3" type2="sy" type3="ne" type4="c2" periodicity1="3" phase1="3.14159265359" k1="1.42256" periodicity2="1" phase2="3.14159265359" k2="31.241928"/>
+  <Proper type1="c3" type2="sy" type3="pe" type4="c2" periodicity1="3" phase1="3.14159265359" k1="0.991608"/>
+  <Proper type1="c3" type2="sy" type3="px" type4="c3" periodicity1="3" phase1="0.0" k1="0.259408"/>
+  <Proper type1="c3" type2="sy" type3="sy" type4="c3" periodicity1="2" phase1="0.0" k1="1.581552"/>
+  <Proper type1="ca" type2="c3" type3="c3" type4="c" periodicity1="3" phase1="0.0" k1="0.4184"/>
+  <Proper type1="ca" type2="c3" type3="c3" type4="n" periodicity1="3" phase1="0.0" k1="0.87864"/>
+  <Proper type1="ca" type2="ca" type3="c3" type4="ca" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="ca" type2="ca" type3="ce" type4="c3" periodicity1="2" phase1="3.14159265359" k1="2.25936"/>
+  <Proper type1="ca" type2="ca" type3="os" type4="c" periodicity1="2" phase1="3.14159265359" k1="2.7196"/>
+  <Proper type1="ca" type2="cf" type3="ce" type4="ca" periodicity1="2" phase1="3.14159265359" k1="35.60584"/>
+  <Proper type1="ca" type2="c" type3="os" type4="c3" periodicity1="2" phase1="3.14159265359" k1="11.23404"/>
+  <Proper type1="ca" type2="cp" type3="cp" type4="ca" periodicity1="2" phase1="3.14159265359" k1="3.32628"/>
+  <Proper type1="ca" type2="nh" type3="c2" type4="c2" periodicity1="1" phase1="3.14159265359" k1="8.03328"/>
+  <Proper type1="ca" type2="nh" type3="n2" type4="c2" periodicity1="3" phase1="3.14159265359" k1="5.73208" periodicity2="2" phase2="0.0" k2="8.368" periodicity3="1" phase3="3.14159265359" k3="0.0"/>
+  <Proper type1="ca" type2="nh" type3="n4" type4="c3" periodicity1="3" phase1="0.0" k1="0.4184"/>
+  <Proper type1="ca" type2="nh" type3="na" type4="cd" periodicity1="2" phase1="0.0" k1="2.9288"/>
+  <Proper type1="ca" type2="nh" type3="n" type4="c" periodicity1="2" phase1="0.0" k1="2.53132"/>
+  <Proper type1="ca" type2="nh" type3="nh" type4="c2" periodicity1="3" phase1="0.0" k1="6.23416"/>
+  <Proper type1="ca" type2="nh" type3="nh" type4="ca" periodicity1="1" phase1="0.0" k1="19.20456"/>
+  <Proper type1="ca" type2="nh" type3="no" type4="o" periodicity1="2" phase1="3.14159265359" k1="2.59408"/>
+  <Proper type1="ca" type2="nh" type3="p3" type4="c3" periodicity1="2" phase1="3.14159265359" k1="8.11696" periodicity2="3" phase2="0.0" k2="2.25936"/>
+  <Proper type1="ca" type2="nh" type3="p5" type4="os" periodicity1="2" phase1="0.0" k1="1.953928"/>
+  <Proper type1="ca" type2="nh" type3="s4" type4="c3" periodicity1="2" phase1="0.0" k1="5.20908" periodicity2="3" phase2="0.0" k2="0.9414"/>
+  <Proper type1="ca" type2="nh" type3="s6" type4="c3" periodicity1="3" phase1="0.0" k1="8.07512"/>
+  <Proper type1="ca" type2="nh" type3="ss" type4="c3" periodicity1="2" phase1="3.14159265359" k1="5.39736" periodicity2="1" phase2="3.14159265359" k2="4.97896"/>
+  <Proper type1="ca" type2="nh" type3="sy" type4="ca" periodicity1="2" phase1="3.14159265359" k1="0.4184" periodicity2="3" phase2="0.0" k2="4.14216"/>
+  <Proper type1="ca" type2="os" type3="c" type4="o" periodicity1="2" phase1="3.14159265359" k1="5.3346"/>
+  <Proper type1="c" type2="c3" type3="c3" type4="n" periodicity1="3" phase1="0.0" k1="0.87864"/>
+  <Proper type1="c" type2="c3" type3="n" type4="c" periodicity1="2" phase1="3.14159265359" k1="1.63176" periodicity2="1" phase2="0.0" k2="2.67776"/>
+  <Proper type1="cc" type2="na" type3="c2" type4="c2" periodicity1="2" phase1="3.14159265359" k1="3.045952"/>
+  <Proper type1="cc" type2="na" type3="c2" type4="c3" periodicity1="2" phase1="3.14159265359" k1="4.707"/>
+  <Proper type1="cc" type2="na" type3="ca" type4="ca" periodicity1="2" phase1="3.14159265359" k1="2.522952"/>
+  <Proper type1="cc" type2="na" type3="na" type4="cd" periodicity1="2" phase1="0.0" k1="1.6736"/>
+  <Proper type1="cc" type2="na" type3="nh" type4="c2" periodicity1="2" phase1="0.0" k1="2.9288"/>
+  <Proper type1="cc" type2="n" type3="c" type4="c3" periodicity1="2" phase1="3.14159265359" k1="2.092"/>
+  <Proper type1="cd" type2="cc" type3="c3" type4="c3" periodicity1="3" phase1="3.14159265359" k1="0.656888"/>
+  <Proper type1="cd" type2="na" type3="c3" type4="na" periodicity1="2" phase1="0.0" k1="0.096232"/>
+  <Proper type1="c" type2="n" type3="c2" type4="c3" periodicity1="1" phase1="3.14159265359" k1="6.31784"/>
+  <Proper type1="c" type2="n" type3="c3" type4="n" periodicity1="2" phase1="0.0" k1="8.70272"/>
+  <Proper type1="c" type2="n" type3="ca" type4="ca" periodicity1="2" phase1="3.14159265359" k1="3.9748"/>
+  <Proper type1="c" type2="n" type3="n" type4="c" periodicity1="2" phase1="3.14159265359" k1="12.552" periodicity2="1" phase2="0.0" k2="10.41816"/>
+  <Proper type1="c" type2="n" type3="nh" type4="c2" periodicity1="2" phase1="0.0" k1="2.5104"/>
+  <Proper type1="c" type2="os" type3="c" type4="c3" periodicity1="1" phase1="3.14159265359" k1="8.28432"/>
+  <Proper type1="cz" type2="nh" type3="c3" type4="c3" periodicity1="2" phase1="3.14159265359" k1="1.037632"/>
+  <Proper type1="h1" type2="c3" type3="n2" type4="c2" periodicity1="3" phase1="3.14159265359" k1="0.69036"/>
+  <Proper type1="h1" type2="c3" type3="n3" type4="c3" periodicity1="3" phase1="0.0" k1="0.9414"/>
+  <Proper type1="h1" type2="c3" type3="na" type4="cc" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="h1" type2="c3" type3="n" type4="c" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="h1" type2="c3" type3="nh" type4="ca" periodicity1="2" phase1="0.0" k1="1.389088"/>
+  <Proper type1="h1" type2="c3" type3="no" type4="o" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="h1" type2="c3" type3="os" type4="p5" periodicity1="3" phase1="0.0" k1="0.907928"/>
+  <Proper type1="hc" type2="c3" type3="c2" type4="c3" periodicity1="2" phase1="0.0" k1="1.29704"/>
+  <Proper type1="hc" type2="c3" type3="c3" type4="i" periodicity1="3" phase1="0.0" k1="0.87864"/>
+  <Proper type1="hc" type2="c3" type3="c3" type4="n3" periodicity1="3" phase1="0.0" k1="0.4184"/>
+  <Proper type1="hc" type2="c3" type3="ca" type4="ca" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="hc" type2="c3" type3="p2" type4="c2" periodicity1="2" phase1="3.14159265359" k1="3.903672"/>
+  <Proper type1="hc" type2="c3" type3="p3" type4="c3" periodicity1="3" phase1="0.0" k1="0.60668"/>
+  <Proper type1="hc" type2="c3" type3="p4" type4="c3" periodicity1="3" phase1="0.0" k1="0.2092"/>
+  <Proper type1="hn" type2="n3" type3="c3" type4="c3" periodicity1="3" phase1="0.0" k1="0.907928"/>
+  <Proper type1="hn" type2="n4" type3="c2" type4="c2" periodicity1="3" phase1="3.14159265359" k1="0.343088"/>
+  <Proper type1="hn" type2="n4" type3="c2" type4="c3" periodicity1="3" phase1="0.0" k1="0.364008"/>
+  <Proper type1="hn" type2="n4" type3="c3" type4="hx" periodicity1="3" phase1="0.0" k1="0.456056"/>
+  <Proper type1="hn" type2="n4" type3="n2" type4="c2" periodicity1="2" phase1="3.14159265359" k1="36.245992"/>
+  <Proper type1="hn" type2="n4" type3="n3" type4="c3" periodicity1="3" phase1="0.0" k1="0.786592"/>
+  <Proper type1="hn" type2="n4" type3="na" type4="cd" periodicity1="3" phase1="0.0" k1="0.6276"/>
+  <Proper type1="hn" type2="n4" type3="n" type4="c" periodicity1="2" phase1="0.0" k1="6.04588"/>
+  <Proper type1="hn" type2="n4" type3="nh" type4="c2" periodicity1="3" phase1="0.0" k1="0.891192"/>
+  <Proper type1="hn" type2="nh" type3="na" type4="cd" periodicity1="2" phase1="0.0" k1="3.355568"/>
+  <Proper type1="ho" type2="oh" type3="c2" type4="c2" periodicity1="2" phase1="3.14159265359" k1="4.68608"/>
+  <Proper type1="ho" type2="oh" type3="c2" type4="c3" periodicity1="1" phase1="3.14159265359" k1="6.31784"/>
+  <Proper type1="ho" type2="oh" type3="c3" type4="h1" periodicity1="3" phase1="0.0" k1="0.472792"/>
+  <Proper type1="ho" type2="oh" type3="ca" type4="ca" periodicity1="2" phase1="3.14159265359" k1="3.49364"/>
+  <Proper type1="ho" type2="oh" type3="n2" type4="c2" periodicity1="2" phase1="3.14159265359" k1="9.91608"/>
+  <Proper type1="ho" type2="oh" type3="n3" type4="c3" periodicity1="2" phase1="0.0" k1="5.14632"/>
+  <Proper type1="ho" type2="oh" type3="n4" type4="c3" periodicity1="3" phase1="0.0" k1="1.42256"/>
+  <Proper type1="ho" type2="oh" type3="na" type4="cc" periodicity1="2" phase1="0.0" k1="1.84096"/>
+  <Proper type1="ho" type2="oh" type3="nh" type4="c2" periodicity1="2" phase1="0.0" k1="3.5564"/>
+  <Proper type1="ho" type2="oh" type3="no" type4="o" periodicity1="2" phase1="3.14159265359" k1="5.69024"/>
+  <Proper type1="ho" type2="oh" type3="oh" type4="ho" periodicity1="2" phase1="0.0" k1="5.06264"/>
+  <Proper type1="ho" type2="oh" type3="p2" type4="c2" periodicity1="2" phase1="3.14159265359" k1="5.89944"/>
+  <Proper type1="ho" type2="oh" type3="p4" type4="c3" periodicity1="1" phase1="3.14159265359" k1="3.47272"/>
+  <Proper type1="ho" type2="oh" type3="p5" type4="o" periodicity1="3" phase1="0.0" k1="1.535528"/>
+  <Proper type1="hs" type2="sh" type3="c2" type4="c2" periodicity1="2" phase1="3.14159265359" k1="2.67776"/>
+  <Proper type1="hs" type2="sh" type3="c2" type4="c3" periodicity1="1" phase1="3.14159265359" k1="6.10864"/>
+  <Proper type1="hs" type2="sh" type3="c3" type4="h1" periodicity1="3" phase1="0.0" k1="0.598312"/>
+  <Proper type1="hs" type2="sh" type3="ca" type4="ca" periodicity1="2" phase1="3.14159265359" k1="0.43932"/>
+  <Proper type1="hs" type2="sh" type3="n2" type4="c2" periodicity1="2" phase1="3.14159265359" k1="7.99144"/>
+  <Proper type1="hs" type2="sh" type3="n3" type4="c3" periodicity1="2" phase1="0.0" k1="13.97456"/>
+  <Proper type1="hs" type2="sh" type3="n4" type4="c3" periodicity1="3" phase1="0.0" k1="2.092"/>
+  <Proper type1="hs" type2="sh" type3="na" type4="cc" periodicity1="2" phase1="0.0" k1="5.25092"/>
+  <Proper type1="hs" type2="sh" type3="nh" type4="c2" periodicity1="2" phase1="0.0" k1="3.32628"/>
+  <Proper type1="hs" type2="sh" type3="no" type4="o" periodicity1="2" phase1="3.14159265359" k1="5.4392"/>
+  <Proper type1="hs" type2="sh" type3="oh" type4="ho" periodicity1="2" phase1="0.0" k1="8.40984"/>
+  <Proper type1="hs" type2="sh" type3="os" type4="c3" periodicity1="2" phase1="0.0" k1="7.7404"/>
+  <Proper type1="hs" type2="sh" type3="p2" type4="c2" periodicity1="2" phase1="3.14159265359" k1="3.72376"/>
+  <Proper type1="hs" type2="sh" type3="p3" type4="c3" periodicity1="2" phase1="0.0" k1="15.0624"/>
+  <Proper type1="hs" type2="sh" type3="p4" type4="c3" periodicity1="1" phase1="3.14159265359" k1="2.44764"/>
+  <Proper type1="hs" type2="sh" type3="p5" type4="os" periodicity1="2" phase1="0.0" k1="12.09176" periodicity2="1" phase2="0.0" k2="5.39736"/>
+  <Proper type1="hs" type2="sh" type3="sh" type4="hs" periodicity1="2" phase1="0.0" k1="11.04576"/>
+  <Proper type1="n2" type2="c2" type3="c3" type4="c2" periodicity1="2" phase1="3.14159265359" k1="2.334672"/>
+  <Proper type1="n3" type2="c3" type3="c3" type4="c3" periodicity1="3" phase1="0.0" k1="0.87864"/>
+  <Proper type1="n3" type2="c3" type3="c3" type4="ca" periodicity1="3" phase1="0.0" k1="0.4184"/>
+  <Proper type1="n3" type2="c3" type3="n3" type4="hn" periodicity1="2" phase1="0.0" k1="7.322"/>
+  <Proper type1="n4" type2="c3" type3="c3" type4="c3" periodicity1="3" phase1="0.0" k1="0.87864"/>
+  <Proper type1="n4" type2="c3" type3="n4" type4="hn" periodicity1="3" phase1="0.0" k1="0.4184"/>
+  <Proper type1="n" type2="c3" type3="c3" type4="c3" periodicity1="3" phase1="0.0" k1="0.4184"/>
+  <Proper type1="nh" type2="c3" type3="c3" type4="c3" periodicity1="3" phase1="0.0" k1="0.87864"/>
+  <Proper type1="o" type2="c" type3="c3" type4="c3" periodicity1="2" phase1="3.14159265359" k1="0.12552" periodicity2="3" phase2="3.14159265359" k2="2.3012" periodicity3="1" phase3="0.0" k3="3.09616"/>
+  <Proper type1="oh" type2="c3" type3="c3" type4="c3" periodicity1="3" phase1="0.0" k1="0.87864"/>
+  <Proper type1="oh" type2="c3" type3="c3" type4="c" periodicity1="3" phase1="0.0" k1="0.87864"/>
+  <Proper type1="oh" type2="c3" type3="c3" type4="n" periodicity1="3" phase1="0.0" k1="0.422584"/>
+  <Proper type1="oh" type2="c3" type3="oh" type4="ho" periodicity1="2" phase1="0.0" k1="6.56888"/>
+  <Proper type1="o" type2="no" type3="c2" type4="c2" periodicity1="2" phase1="3.14159265359" k1="1.665232"/>
+  <Proper type1="o" type2="no" type3="c2" type4="c3" periodicity1="2" phase1="3.14159265359" k1="2.76144"/>
+  <Proper type1="o" type2="no" type3="c3" type4="no" periodicity1="2" phase1="3.14159265359" k1="21.00368"/>
+  <Proper type1="o" type2="no" type3="ca" type4="ca" periodicity1="2" phase1="3.14159265359" k1="2.9288"/>
+  <Proper type1="o" type2="no" type3="cd" type4="cc" periodicity1="2" phase1="3.14159265359" k1="4.4978"/>
+  <Proper type1="o" type2="no" type3="n2" type4="c2" periodicity1="2" phase1="3.14159265359" k1="4.30952"/>
+  <Proper type1="o" type2="no" type3="n3" type4="c3" periodicity1="2" phase1="3.14159265359" k1="9.07928"/>
+  <Proper type1="o" type2="no" type3="n4" type4="c3" periodicity1="2" phase1="3.14159265359" k1="5.23"/>
+  <Proper type1="o" type2="no" type3="na" type4="cc" periodicity1="2" phase1="3.14159265359" k1="4.56056"/>
+  <Proper type1="o" type2="no" type3="nh" type4="c2" periodicity1="2" phase1="3.14159265359" k1="0.0"/>
+  <Proper type1="o" type2="no" type3="no" type4="o" periodicity1="4" phase1="3.14159265359" k1="0.6276" periodicity2="2" phase2="3.14159265359" k2="6.0668"/>
+  <Proper type1="o" type2="no" type3="p2" type4="c2" periodicity1="2" phase1="3.14159265359" k1="4.14216"/>
+  <Proper type1="o" type2="no" type3="p4" type4="c3" periodicity1="2" phase1="3.14159265359" k1="2.100368"/>
+  <Proper type1="o" type2="py" type3="ne" type4="c2" periodicity1="3" phase1="3.14159265359" k1="3.7656" periodicity2="1" phase2="0.0" k2="10.29264"/>
+  <Proper type1="o" type2="s4" type3="c3" type4="s4" periodicity1="1" phase1="3.14159265359" k1="5.60656"/>
+  <Proper type1="o" type2="s6" type3="c3" type4="s6" periodicity1="3" phase1="0.0" k1="0.384928"/>
+  <Proper type1="os" type2="c" type3="c3" type4="c" periodicity1="2" phase1="3.14159265359" k1="8.368" periodicity2="1" phase2="3.14159265359" k2="7.7404"/>
+  <Proper type1="os" type2="p3" type3="os" type4="c3" periodicity1="2" phase1="0.0" k1="8.53536"/>
+  <Proper type1="os" type2="p5" type3="n3" type4="c3" periodicity1="2" phase1="3.14159265359" k1="20.92"/>
+  <Proper type1="os" type2="p5" type3="n4" type4="c3" periodicity1="3" phase1="0.0" k1="0.598312"/>
+  <Proper type1="os" type2="p5" type3="na" type4="cc" periodicity1="2" phase1="3.14159265359" k1="9.12112"/>
+  <Proper type1="os" type2="p5" type3="nh" type4="c2" periodicity1="2" phase1="0.0" k1="2.092"/>
+  <Proper type1="os" type2="p5" type3="no" type4="o" periodicity1="2" phase1="0.0" k1="11.434872" periodicity2="3" phase2="0.0" k2="1.326328"/>
+  <Proper type1="os" type2="p5" type3="p3" type4="c3" periodicity1="2" phase1="3.14159265359" k1="8.38892"/>
+  <Proper type1="os" type2="p5" type3="ss" type4="c3" periodicity1="2" phase1="3.14159265359" k1="18.689928"/>
+  <Proper type1="os" type2="py" type3="ca" type4="ca" periodicity1="2" phase1="3.14159265359" k1="7.5312"/>
+  <Proper type1="os" type2="py" type3="ce" type4="c2" periodicity1="2" phase1="3.14159265359" k1="7.393128"/>
+  <Proper type1="os" type2="py" type3="ce" type4="c3" periodicity1="2" phase1="3.14159265359" k1="17.5728"/>
+  <Proper type1="os" type2="py" type3="pe" type4="c2" periodicity1="1" phase1="0.0" k1="10.740328"/>
+  <Proper type1="os" type2="py" type3="py" type4="c3" periodicity1="2" phase1="0.0" k1="1.615024"/>
+  <Proper type1="os" type2="py" type3="py" type4="os" periodicity1="2" phase1="0.0" k1="1.619208"/>
+  <Proper type1="os" type2="py" type3="sx" type4="c3" periodicity1="3" phase1="0.0" k1="1.456032"/>
+  <Proper type1="os" type2="py" type3="sy" type4="c3" periodicity1="2" phase1="0.0" k1="11.96624" periodicity2="1" phase2="0.0" k2="1.58992"/>
+  <Proper type1="p3" type2="c3" type3="p3" type4="hp" periodicity1="3" phase1="0.0" k1="0.89956"/>
+  <Proper type1="s" type2="c" type3="c3" type4="c" periodicity1="2" phase1="3.14159265359" k1="1.389088"/>
+  <Proper type1="sh" type2="c3" type3="c3" type4="n" periodicity1="3" phase1="0.0" k1="0.87864"/>
+  <Proper type1="sh" type2="c3" type3="sh" type4="hs" periodicity1="3" phase1="0.0" k1="0.347272"/>
+  <Proper type1="ss" type2="c3" type3="ss" type4="c3" periodicity1="3" phase1="0.0" k1="2.079448"/>
+  <Proper type1="c3" type2="c3" type3="ca" type4="ca" periodicity1="2" phase1="3.14159265359" k1="1.02508"/>
+  <Proper type1="ca" type2="ca" type3="c" type4="o" periodicity1="2" phase1="3.14159265359" k1="2.18614"/>
+  <Proper type1="o" type2="c" type3="c3" type4="c" periodicity1="1" phase1="0.0" k1="5.69024" periodicity2="3" phase2="3.14159265359" k2="0.75312"/>
+  <Proper type1="os" type2="c3" type3="c" type4="o" periodicity1="2" phase1="3.14159265359" k1="2.63592" periodicity2="3" phase2="3.14159265359" k2="4.184" periodicity3="1" phase3="0.0" k3="0.33472"/>
+  <Proper type1="c2" type2="ce" type3="cs" type4="c3" periodicity1="2" phase1="0.0" k1="9.12112"/>
+  <Proper type1="c2" type2="ce" type3="c" type4="c3" periodicity1="2" phase1="0.0" k1="12.42648"/>
+  <Proper type1="c2" type2="ce" type3="ce" type4="c2" periodicity1="2" phase1="3.14159265359" k1="2.092"/>
+  <Proper type1="c2" type2="n" type3="c" type4="c3" periodicity1="1" phase1="3.14159265359" k1="3.22168"/>
+  <Proper type1="c2" type2="n" type3="cs" type4="c3" periodicity1="2" phase1="3.14159265359" k1="11.853272"/>
+  <Proper type1="c2" type2="ne" type3="c" type4="c3" periodicity1="1" phase1="3.14159265359" k1="8.70272"/>
+  <Proper type1="c2" type2="ne" type3="cs" type4="c3" periodicity1="1" phase1="3.14159265359" k1="19.53928"/>
+  <Proper type1="c2" type2="pe" type3="c" type4="c3" periodicity1="1" phase1="3.14159265359" k1="7.322"/>
+  <Proper type1="c2" type2="pe" type3="cs" type4="c3" periodicity1="1" phase1="3.14159265359" k1="12.38464"/>
+  <Proper type1="c3" type2="cs" type3="cs" type4="c3" periodicity1="2" phase1="3.14159265359" k1="1.90372"/>
+  <Proper type1="c3" type2="c" type3="c" type4="c3" periodicity1="2" phase1="3.14159265359" k1="2.142208"/>
+  <Proper type1="c3" type2="c" type3="cs" type4="c3" periodicity1="2" phase1="3.14159265359" k1="3.3472"/>
+  <Proper type1="c3" type2="c" type3="n" type4="ca" periodicity1="2" phase1="3.14159265359" k1="3.138" periodicity2="3" phase2="0.0" k2="2.092"/>
+  <Proper type1="c3" type2="cs" type3="n" type4="ca" periodicity1="2" phase1="3.14159265359" k1="16.371992"/>
+  <Proper type1="c3" type2="n7" type3="c3" type4="c3" periodicity1="3" phase1="3.14159265359" k1="0.08368" periodicity2="2" phase2="0.0" k2="0.2092"/>
+  <Proper type1="c3" type2="n3" type3="c3" type4="c3" periodicity1="3" phase1="0.0" k1="2.42672" periodicity2="2" phase2="3.14159265359" k2="1.17152"/>
+  <Proper type1="c3" type2="n" type3="cs" type4="c3" periodicity1="2" phase1="3.14159265359" k1="8.368" periodicity2="1" phase2="0.0" k2="9.66504"/>
+  <Proper type1="c3" type2="nu" type3="ca" type4="ca" periodicity1="2" phase1="3.14159265359" k1="2.3012"/>
+  <Proper type1="c3" type2="nh" type3="ca" type4="ca" periodicity1="2" phase1="3.14159265359" k1="3.066872"/>
+  <Proper type1="c3" type2="os" type3="cs" type4="c3" periodicity1="1" phase1="0.0" k1="0.50208" periodicity2="2" phase2="3.14159265359" k2="14.51848" periodicity3="3" phase3="0.0" k3="3.05432"/>
+  <Proper type1="c3" type2="p3" type3="c" type4="c3" periodicity1="2" phase1="3.14159265359" k1="6.434992"/>
+  <Proper type1="c3" type2="p3" type3="cs" type4="c3" periodicity1="2" phase1="3.14159265359" k1="8.5772"/>
+  <Proper type1="c3" type2="ss" type3="c" type4="c3" periodicity1="2" phase1="3.14159265359" k1="8.7864"/>
+  <Proper type1="c3" type2="ss" type3="cs" type4="c3" periodicity1="2" phase1="3.14159265359" k1="14.99964"/>
+  <Proper type1="c3" type2="sx" type3="c" type4="c3" periodicity1="2" phase1="0.0" k1="3.9748" periodicity2="1" phase2="3.14159265359" k2="6.10864"/>
+  <Proper type1="c3" type2="sx" type3="cs" type4="c3" periodicity1="2" phase1="3.14159265359" k1="0.0" periodicity2="1" phase2="3.14159265359" k2="3.43088"/>
+  <Proper type1="c3" type2="sy" type3="cs" type4="c3" periodicity1="2" phase1="0.0" k1="0.698728"/>
+  <Proper type1="c3" type2="sy" type3="c" type4="c3" periodicity1="2" phase1="0.0" k1="3.485272"/>
+  <Proper type1="ca" type2="ca" type3="c" type4="c3" periodicity1="2" phase1="3.14159265359" k1="2.309568"/>
+  <Proper type1="ca" type2="ca" type3="cs" type4="c3" periodicity1="2" phase1="3.14159265359" k1="2.63592"/>
+  <Proper type1="c" type2="c3" type3="c3" type4="c3" periodicity1="3" phase1="0.0" k1="0.4184"/>
+  <Proper type1="c" type2="n" type3="cs" type4="c3" periodicity1="2" phase1="0.0" k1="2.38488"/>
+  <Proper type1="c" type2="n" type3="c" type4="c3" periodicity1="2" phase1="3.14159265359" k1="0.0" periodicity2="1" phase2="3.14159265359" k2="7.19648"/>
+  <Proper type1="hc" type2="c3" type3="c" type4="c3" periodicity1="2" phase1="0.0" k1="0.0"/>
+  <Proper type1="hc" type2="c3" type3="cs" type4="c3" periodicity1="2" phase1="0.0" k1="2.78236"/>
+  <Proper type1="hn" type2="n4" type3="c" type4="c3" periodicity1="2" phase1="3.14159265359" k1="4.2886" periodicity2="4" phase2="3.14159265359" k2="1.52716"/>
+  <Proper type1="hn" type2="n4" type3="cs" type4="c3" periodicity1="2" phase1="3.14159265359" k1="3.9748" periodicity2="4" phase2="0.0" k2="3.11708"/>
+  <Proper type1="ho" type2="oh" type3="c" type4="c3" periodicity1="2" phase1="3.14159265359" k1="7.44752"/>
+  <Proper type1="ho" type2="oh" type3="cs" type4="c3" periodicity1="2" phase1="3.14159265359" k1="12.21728"/>
+  <Proper type1="hs" type2="sh" type3="cs" type4="c3" periodicity1="2" phase1="3.14159265359" k1="11.25496" periodicity2="1" phase2="3.14159265359" k2="5.81576"/>
+  <Proper type1="o" type2="n" type3="c" type4="c3" periodicity1="2" phase1="3.14159265359" k1="1.54808"/>
+  <Proper type1="o" type2="n" type3="cs" type4="c3" periodicity1="2" phase1="0.0" k1="2.17568"/>
+  <Proper type1="o" type2="p5" type3="c3" type4="p5" periodicity1="2" phase1="3.14159265359" k1="10.83656" periodicity2="1" phase2="0.0" k2="13.26328"/>
+  <Proper type1="os" type2="py" type3="c" type4="c3" periodicity1="2" phase1="0.0" k1="9.91608"/>
+  <Proper type1="os" type2="py" type3="cs" type4="c3" periodicity1="2" phase1="0.0" k1="2.092"/>
+  <Improper type1="c" type2="" type3="o" type4="o" periodicity1="2" phase1="3.14159265359" k1="4.6024"/>
+  <Improper type1="c" type2="" type3="" type4="o" periodicity1="2" phase1="3.14159265359" k1="43.932"/>
+  <Improper type1="ca" type2="" type3="" type4="ha" periodicity1="2" phase1="3.14159265359" k1="4.6024"/>
+  <Improper type1="n" type2="" type3="" type4="hn" periodicity1="2" phase1="3.14159265359" k1="4.6024"/>
+  <Improper type1="n2" type2="" type3="" type4="hn" periodicity1="2" phase1="3.14159265359" k1="4.6024"/>
+  <Improper type1="na" type2="" type3="" type4="hn" periodicity1="2" phase1="3.14159265359" k1="4.6024"/>
+  <Improper type1="n" type2="" type3="c3" type4="c3" periodicity1="2" phase1="3.14159265359" k1="4.6024"/>
+  <Improper type1="ca" type2="" type3="n2" type4="n2" periodicity1="2" phase1="3.14159265359" k1="43.932"/>
+  <Improper type1="c2" type2="c" type3="c2" type4="c3" periodicity1="2" phase1="3.14159265359" k1="4.6024"/>
+  <Improper type1="ca" type2="c" type3="c3" type4="ca" periodicity1="2" phase1="3.14159265359" k1="4.6024"/>
+  <Improper type1="n" type2="c" type3="c3" type4="hn" periodicity1="2" phase1="3.14159265359" k1="4.6024"/>
+  <Improper type1="n" type2="c" type3="c3" type4="o" periodicity1="2" phase1="3.14159265359" k1="4.6024"/>
+  <Improper type1="na" type2="c2" type3="c2" type4="c3" periodicity1="2" phase1="3.14159265359" k1="4.6024"/>
+  <Improper type1="c2" type2="c2" type3="c3" type4="hc" periodicity1="2" phase1="3.14159265359" k1="4.6024"/>
+  <Improper type1="ca" type2="c2" type3="c3" type4="hc" periodicity1="2" phase1="3.14159265359" k1="4.6024"/>
+  <Improper type1="c" type2="c2" type3="hc" type4="o" periodicity1="2" phase1="3.14159265359" k1="4.6024"/>
+  <Improper type1="c" type2="c3" type3="o" type4="oh" periodicity1="2" phase1="3.14159265359" k1="4.6024"/>
+  <Improper type1="c2" type2="c2" type3="c3" type4="n2" periodicity1="2" phase1="3.14159265359" k1="4.6024"/>
+  <Improper type1="c2" type2="c2" type3="c3" type4="na" periodicity1="2" phase1="3.14159265359" k1="4.6024"/>
+  <Improper type1="ca" type2="c3" type3="ca" type4="n2" periodicity1="2" phase1="3.14159265359" k1="4.6024"/>
+  <Improper type1="ca" type2="c3" type3="ca" type4="na" periodicity1="2" phase1="3.14159265359" k1="4.6024"/>
+  <Improper type1="ca" type2="c2" type3="ca" type4="ca" periodicity1="2" phase1="3.14159265359" k1="4.6024"/>
+  <Improper type1="ca" type2="c3" type3="ca" type4="ca" periodicity1="2" phase1="3.14159265359" k1="4.6024"/>
+  <Improper type1="ca" type2="ca" type3="ca" type4="f" periodicity1="2" phase1="3.14159265359" k1="4.6024"/>
+  <Improper type1="ca" type2="ca" type3="ca" type4="cl" periodicity1="2" phase1="3.14159265359" k1="4.6024"/>
+  <Improper type1="ca" type2="br" type3="ca" type4="ca" periodicity1="2" phase1="3.14159265359" k1="4.6024"/>
+  <Improper type1="ca" type2="ca" type3="ca" type4="i" periodicity1="2" phase1="3.14159265359" k1="4.6024"/>
+  <Improper type1="c" type2="ca" type3="ca" type4="oh" periodicity1="2" phase1="3.14159265359" k1="4.6024"/>
+  <Improper type1="na" type2="c3" type3="ca" type4="ca" periodicity1="2" phase1="3.14159265359" k1="4.6024"/>
+  <Improper type1="c" type2="ca" type3="hc" type4="o" periodicity1="2" phase1="3.14159265359" k1="4.6024"/>
+  <Improper type1="ca" type2="ca" type3="n2" type4="n2" periodicity1="2" phase1="3.14159265359" k1="4.6024"/>
+  <Improper type1="c" type2="hc" type3="o" type4="oh" periodicity1="2" phase1="3.14159265359" k1="4.6024"/>
+  <Improper type1="c" type2="hc" type3="o" type4="os" periodicity1="2" phase1="3.14159265359" k1="4.6024"/>
+  <Improper type1="ca" type2="c2" type3="n2" type4="n2" periodicity1="2" phase1="3.14159265359" k1="4.6024"/>
+  <Improper type1="ca" type2="n2" type3="n2" type4="na" periodicity1="2" phase1="3.14159265359" k1="4.6024"/>
+ </PeriodicTorsionForce>
+ <NonbondedForce coulomb14scale="0.833333333333" lj14scale="0.5">
+  <UseAttributeFromResidue name="charge"/>
+  <Atom type="c" sigma="0.331521230994" epsilon="0.4133792"/>
+  <Atom type="cs" sigma="0.331521230994" epsilon="0.4133792"/>
+  <Atom type="c1" sigma="0.347895949434" epsilon="0.6677664"/>
+  <Atom type="c2" sigma="0.331521230994" epsilon="0.4133792"/>
+  <Atom type="c3" sigma="0.339770953124" epsilon="0.4510352"/>
+  <Atom type="ca" sigma="0.331521230994" epsilon="0.4133792"/>
+  <Atom type="cp" sigma="0.331521230994" epsilon="0.4133792"/>
+  <Atom type="cq" sigma="0.331521230994" epsilon="0.4133792"/>
+  <Atom type="cc" sigma="0.331521230994" epsilon="0.4133792"/>
+  <Atom type="cd" sigma="0.331521230994" epsilon="0.4133792"/>
+  <Atom type="ce" sigma="0.331521230994" epsilon="0.4133792"/>
+  <Atom type="cf" sigma="0.331521230994" epsilon="0.4133792"/>
+  <Atom type="cg" sigma="0.347895949434" epsilon="0.6677664"/>
+  <Atom type="ch" sigma="0.347895949434" epsilon="0.6677664"/>
+  <Atom type="cx" sigma="0.339770953124" epsilon="0.4510352"/>
+  <Atom type="cy" sigma="0.339770953124" epsilon="0.4510352"/>
+  <Atom type="cu" sigma="0.331521230994" epsilon="0.4133792"/>
+  <Atom type="cv" sigma="0.331521230994" epsilon="0.4133792"/>
+  <Atom type="cz" sigma="0.331521230994" epsilon="0.4133792"/>
+  <Atom type="h1" sigma="0.242199725514" epsilon="0.0870272"/>
+  <Atom type="h2" sigma="0.224381751151" epsilon="0.0870272"/>
+  <Atom type="h3" sigma="0.206563776788" epsilon="0.0870272"/>
+  <Atom type="h4" sigma="0.253638865055" epsilon="0.0673624"/>
+  <Atom type="h5" sigma="0.244729877873" epsilon="0.0673624"/>
+  <Atom type="ha" sigma="0.262547852236" epsilon="0.0673624"/>
+  <Atom type="hc" sigma="0.260017699876" epsilon="0.0870272"/>
+  <Atom type="hn" sigma="0.110649620793" epsilon="0.04184"/>
+  <Atom type="ho" sigma="0.0537924646013" epsilon="0.0196648"/>
+  <Atom type="hp" sigma="0.107460203382" epsilon="0.0602496"/>
+  <Atom type="hs" sigma="0.108903459305" epsilon="0.0518816"/>
+  <Atom type="hw" sigma="1.0" epsilon="0.0"/>
+  <Atom type="hx" sigma="0.188745802425" epsilon="0.0870272"/>
+  <Atom type="f" sigma="0.303422285424" epsilon="0.3481088"/>
+  <Atom type="cl" sigma="0.346595237305" epsilon="1.1037392"/>
+  <Atom type="br" sigma="0.361259430206" epsilon="1.6451488"/>
+  <Atom type="i" sigma="0.384119891313" epsilon="2.073172"/>
+  <Atom type="n" sigma="0.318086478325" epsilon="0.6845024"/>
+  <Atom type="n1" sigma="0.327351824993" epsilon="0.4594032"/>
+  <Atom type="n2" sigma="0.338416787073" epsilon="0.3937144"/>
+  <Atom type="n3" sigma="0.336510263816" epsilon="0.3589872"/>
+  <Atom type="n4" sigma="0.249950544361" epsilon="16.2121632"/>
+  <Atom type="na" sigma="0.320580994736" epsilon="0.8543728"/>
+  <Atom type="nb" sigma="0.338416787073" epsilon="0.3937144"/>
+  <Atom type="nc" sigma="0.338416787073" epsilon="0.3937144"/>
+  <Atom type="nd" sigma="0.338416787073" epsilon="0.3937144"/>
+  <Atom type="ne" sigma="0.338416787073" epsilon="0.3937144"/>
+  <Atom type="nf" sigma="0.338416787073" epsilon="0.3937144"/>
+  <Atom type="nh" sigma="0.318995195017" epsilon="0.89956"/>
+  <Atom type="no" sigma="0.336510263816" epsilon="0.3589872"/>
+  <Atom type="ns" sigma="0.326995465506" epsilon="0.4912016"/>
+  <Atom type="nt" sigma="0.335904452688" epsilon="0.3560584"/>
+  <Atom type="nx" sigma="0.258859531543" epsilon="10.6495352"/>
+  <Atom type="ny" sigma="0.267768518724" epsilon="7.0956456"/>
+  <Atom type="nz" sigma="0.276677505906" epsilon="4.79068"/>
+  <Atom type="n+" sigma="0.285586493087" epsilon="3.2752352"/>
+  <Atom type="nu" sigma="0.327904182199" epsilon="0.646428"/>
+  <Atom type="nv" sigma="0.33681316938" epsilon="0.468608"/>
+  <Atom type="n7" sigma="0.350764643306" epsilon="0.2184048"/>
+  <Atom type="n8" sigma="0.365019022796" epsilon="0.1351432"/>
+  <Atom type="n9" sigma="0.404468018036" epsilon="0.039748"/>
+  <Atom type="o" sigma="0.304812087425" epsilon="0.6121192"/>
+  <Atom type="oh" sigma="0.324287133403" epsilon="0.389112"/>
+  <Atom type="os" sigma="0.315609779888" epsilon="0.3037584"/>
+  <Atom type="ow" sigma="1.0" epsilon="0.0"/>
+  <Atom type="p2" sigma="0.36940224449" epsilon="0.960228"/>
+  <Atom type="p3" sigma="0.36940224449" epsilon="0.960228"/>
+  <Atom type="p4" sigma="0.36940224449" epsilon="0.960228"/>
+  <Atom type="p5" sigma="0.36940224449" epsilon="0.960228"/>
+  <Atom type="pb" sigma="0.36940224449" epsilon="0.960228"/>
+  <Atom type="pc" sigma="0.36940224449" epsilon="0.960228"/>
+  <Atom type="pd" sigma="0.36940224449" epsilon="0.960228"/>
+  <Atom type="pe" sigma="0.36940224449" epsilon="0.960228"/>
+  <Atom type="pf" sigma="0.36940224449" epsilon="0.960228"/>
+  <Atom type="px" sigma="0.36940224449" epsilon="0.960228"/>
+  <Atom type="py" sigma="0.36940224449" epsilon="0.960228"/>
+  <Atom type="s" sigma="0.353241341743" epsilon="1.1815616"/>
+  <Atom type="s2" sigma="0.353241341743" epsilon="1.1815616"/>
+  <Atom type="s4" sigma="0.353241341743" epsilon="1.1815616"/>
+  <Atom type="s6" sigma="0.353241341743" epsilon="1.1815616"/>
+  <Atom type="sh" sigma="0.353241341743" epsilon="1.1815616"/>
+  <Atom type="ss" sigma="0.353241341743" epsilon="1.1815616"/>
+  <Atom type="sx" sigma="0.353241341743" epsilon="1.1815616"/>
+  <Atom type="sy" sigma="0.353241341743" epsilon="1.1815616"/>
+ </NonbondedForce>
+</ForceField>


### PR DESCRIPTION
This adds gaff2 as an option for forcefield template generators.

Note that I borrowed a gaff2 xml file from @rafwiewiora, 
Source and commit hash: https://github.com/choderalab/openmm-forcefields/blob/5e26b3996b6422ae477c3a1a5f8ad095ef588897/amber/ffxml/gaff2.xml