### PR TITLE
Apply packmol docs suggestions for box size with PBC

### DIFF
--- a/openmoltools/packmol.py
+++ b/openmoltools/packmol.py
@@ -237,7 +237,8 @@ def approximate_volume(pdb_filenames, n_molecules_list, box_scaleup_factor=2.0):
     return box_size
 
 
-def approximate_volume_by_density( smiles_strings, n_molecules_list, density = 1.0, box_scaleup_factor = 1.1):
+def approximate_volume_by_density(smiles_strings, n_molecules_list, density=1.0,
+                                  box_scaleup_factor=1.1, box_buffer=2.0):
     """Generate an approximate box size based on the number and molecular weight of molecules present, and a target density for the final solvated mixture. If no density is specified, the target density is assumed to be 1 g/ml.
 
     Parameters
@@ -250,6 +251,11 @@ def approximate_volume_by_density( smiles_strings, n_molecules_list, density = 1
         Factor by which the estimated box size is increased
     density : float, optional, default 1.0
         Target density for final system in g/ml
+    box_buffer : float [ANGSTROMS], optional, default 2.0.
+        This quantity is added to the final estimated box size
+        (after scale-up). With periodic boundary conditions,
+        packmol docs suggests to leave an extra 2 Angstroms
+        buffer during packing.
 
     Returns
     -------
@@ -281,7 +287,7 @@ def approximate_volume_by_density( smiles_strings, n_molecules_list, density = 1
     edge = vol**(1./3.)
 
     #Compute final box size
-    box_size = edge*box_scaleup_factor/units.angstroms
+    box_size = edge*box_scaleup_factor/units.angstroms# + box_buffer
 
     return box_size
 

--- a/openmoltools/tests/test_packmol.py
+++ b/openmoltools/tests/test_packmol.py
@@ -100,6 +100,9 @@ def test_packmol_simulation_ternary_bydensity():
     size = packmol.approximate_volume_by_density( smiles_list, [12, 22, 46] )
     trj = packmol.pack_box(pdb_filenames, [12, 22, 46], box_size = size)
 
+    # The box size should be set as expected (in nanometers).
+    assert all(trj.unitcell_lengths[0] == [size/10.0, size/10.0, size/10.0])
+
     xyz = trj.openmm_positions(0)
     top = trj.top.to_openmm()
     top.setUnitCellDimensions(mm.Vec3(*trj.unitcell_lengths[0])*u.nanometer)

--- a/setup.py
+++ b/setup.py
@@ -24,8 +24,8 @@ except ImportError:
 
 
 ##########################
-VERSION = "0.8.1.dev0"
-ISRELEASED = False
+VERSION = "0.8.1"
+ISRELEASED = True
 __version__ = VERSION
 ##########################
 


### PR DESCRIPTION
Packmol does not support periodic boundary conditions. Their [docs suggests](http://www.ime.unicamp.br/~martinez/packmol/userguide.shtml#pbc) to pack the molecules in a box 2 angstroms smaller.

I've also made a modification to `openmoltools.pack_box` so that all temporary files created by the function are deleted at the end of the execution (`tempfile.mktemp` does not delete them automatically).