### PR TITLE
Remove Libgfortran dependency pin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ script:
   - conda update --quiet --yes --all
   # Install OpenEye toolkit
   - conda install --yes --quiet pip
-  - pip install $OPENEYE_CHANNEL openeye-toolkits && python -c "import openeye; print(openeye.__version__)"
+  - pip install $OPENEYE_CHANNEL openeye-toolkits$OPENEYE_PIN && python -c "import openeye; print(openeye.__version__)"
   # Build the recipe
   - conda build devtools/conda-recipe
   # Install the package
@@ -58,11 +58,11 @@ script:
 env:
   matrix:
     # OpenEye production
-    - CONDA_PY=27 python=2.7 OPENEYE_CHANNEL="-i https://pypi.anaconda.org/OpenEye/simple/"
+    - CONDA_PY=27 python=2.7 OPENEYE_CHANNEL="-i https://pypi.anaconda.org/OpenEye/simple/" OPENEYE_PIN="==2017.10.1"
     - CONDA_PY=35 python=3.5 OPENEYE_CHANNEL="-i https://pypi.anaconda.org/OpenEye/simple/"
     - CONDA_PY=36 python=3.6 OPENEYE_CHANNEL="-i https://pypi.anaconda.org/OpenEye/simple/"
     # OpenEye beta
-    - CONDA_PY=27 python=2.7 OPENEYE_CHANNEL="--pre -i https://pypi.anaconda.org/OpenEye/simple/"
+    - CONDA_PY=27 python=2.7 OPENEYE_CHANNEL="--pre -i https://pypi.anaconda.org/OpenEye/simple/" OPENEYE_PIN="==2017.10.1"
     - CONDA_PY=35 python=3.5 OPENEYE_CHANNEL="--pre -i https://pypi.anaconda.org/OpenEye/simple/"
     - CONDA_PY=36 python=3.6 OPENEYE_CHANNEL="--pre -i https://pypi.anaconda.org/OpenEye/simple/"
 

--- a/README.md
+++ b/README.md
@@ -36,3 +36,12 @@ To test your installation, use the following command:
 ```
 nosetests openmoltools -v --exe
 ```
+
+## Python 2.7 builds are deprecated
+
+Version 0.8.3 will be the last version of this package to build with Python 2.7.
+With the OpenEye toolkits no longer being depolyed on Python 2.7 as of 2018.2.1, 
+we have decided to deprecate support for that Python version as well. 
+Version 0.8.3 was tested against the 2017.10.1 version of the OpenEye Toolkits for 
+compatibility.
+

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -37,7 +37,6 @@ requirements:
     - ambermini
     - pytables
     - parmed
-    - libgfortran ==1.0 # [linux]
     - rdkit    # rdkit is an optional dependency, may want to comment this out for the release version.
 
 test:


### PR DESCRIPTION
Remove the libgfotran pinned dependency as its been almost 2 years since that fix went in. I'm assuming SciPy should have fixed its problems related to that and pinning to 1.0 seems backwards as it now has a 3.0 release. 

Any objections or reasons this should not happen, @jchodera, @davidlmobley ?