### PR TITLE
Bump to 0.9.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ script:
   # Update everything
   - conda update --quiet --yes --all
   # Install OpenEye toolkit
-  - conda install $OPENEYE_CHANNEL openeye-toolkits && python -c "import openeye; print(openeye.__version__)"
+  - conda install --yes $OPENEYE_CHANNEL openeye-toolkits && python -c "import openeye; print(openeye.__version__)"
   # Build the recipe
   - conda build devtools/conda-recipe
   # Install the package

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,8 +41,7 @@ script:
   # Update everything
   - conda update --quiet --yes --all
   # Install OpenEye toolkit
-  - conda install --yes --quiet pip
-  - pip install $OPENEYE_CHANNEL openeye-toolkits$OPENEYE_PIN && python -c "import openeye; print(openeye.__version__)"
+  - conda install $OPENEYE_CHANNEL openeye-toolkits && python -c "import openeye; print(openeye.__version__)"
   # Build the recipe
   - conda build devtools/conda-recipe
   # Install the package
@@ -58,13 +57,11 @@ script:
 env:
   matrix:
     # OpenEye production
-    - CONDA_PY=27 python=2.7 OPENEYE_CHANNEL="-i https://pypi.anaconda.org/OpenEye/simple/" OPENEYE_PIN="==2017.10.1"
-    - CONDA_PY=35 python=3.5 OPENEYE_CHANNEL="-i https://pypi.anaconda.org/OpenEye/simple/"
-    - CONDA_PY=36 python=3.6 OPENEYE_CHANNEL="-i https://pypi.anaconda.org/OpenEye/simple/"
+    - CONDA_PY=35 python=3.5 OPENEYE_CHANNEL="-c openeye"
+    - CONDA_PY=36 python=3.6 OPENEYE_CHANNEL="-c openeye"
     # OpenEye beta
-    - CONDA_PY=27 python=2.7 OPENEYE_CHANNEL="--pre -i https://pypi.anaconda.org/OpenEye/simple/" OPENEYE_PIN="==2017.10.1"
-    - CONDA_PY=35 python=3.5 OPENEYE_CHANNEL="--pre -i https://pypi.anaconda.org/OpenEye/simple/"
-    - CONDA_PY=36 python=3.6 OPENEYE_CHANNEL="--pre -i https://pypi.anaconda.org/OpenEye/simple/"
+    - CONDA_PY=35 python=3.5 OPENEYE_CHANNEL="-c openeye/label/dev"
+    - CONDA_PY=36 python=3.6 OPENEYE_CHANNEL="-c openeye/label/dev"
 
   global:
     - ORGNAME="omnia"

--- a/setup.py
+++ b/setup.py
@@ -22,8 +22,8 @@ except ImportError:
     cython_extension = 'c'
 
 ##########################
-VERSION = "0.8.3"
-ISRELEASED = True
+VERSION = "0.9.0dev0"
+ISRELEASED = False
 __version__ = VERSION
 ##########################
 


### PR DESCRIPTION
Also switches OpenEye source location from `pip` to `conda`
Stops tests on Python 2.7