### PR TITLE
Write out multiple conformers

### DIFF
--- a/openmoltools/openeye.py
+++ b/openmoltools/openeye.py
@@ -334,7 +334,7 @@ def molecule_to_mol2(molecule, tripos_mol2_filename=None, conformer=0, residue_n
     ofs = oechem.oemolostream(tripos_mol2_filename)
     ofs.SetFormat(oechem.OEFormat_MOL2H)
     for k, mol in enumerate(molecule.GetConfs()):
-        if k == conformer or not conformer:
+        if k == conformer or conformer is None:
             # Standardize will override molecular properties(atom names etc.)
             if standardize:
                 oechem.OEWriteMolecule(ofs, mol)

--- a/openmoltools/openeye.py
+++ b/openmoltools/openeye.py
@@ -303,6 +303,7 @@ def molecule_to_mol2(molecule, tripos_mol2_filename=None, conformer=0, residue_n
         name.tripos.mol2, where name is the name of the OE molecule.
     conformer : int, optional, default=0
         Save this frame
+        If None, save all conformers
     residue_name : str, optional, default="MOL"
         OpenEye writes mol2 files with <0> as the residue / ligand name.
         This chokes many mol2 parsers, so we replace it with a string of
@@ -333,7 +334,7 @@ def molecule_to_mol2(molecule, tripos_mol2_filename=None, conformer=0, residue_n
     ofs = oechem.oemolostream(tripos_mol2_filename)
     ofs.SetFormat(oechem.OEFormat_MOL2H)
     for k, mol in enumerate(molecule.GetConfs()):
-        if k == conformer:
+        if k == conformer or not conformer:
             # Standardize will override molecular properties(atom names etc.)
             if standardize:
                 oechem.OEWriteMolecule(ofs, mol)

--- a/openmoltools/tests/test_openeye.py
+++ b/openmoltools/tests/test_openeye.py
@@ -92,7 +92,7 @@ def test_output_mol2_multiple_confs():
     with open("testing mol2 multiple conformers.tripos.mol2", "r") as outfile:
         text = outfile.read()
     # This should not find the text we added, to make sure the molecule is standardized.
-    assert text.count("MOLECULE") is 2
+    assert text.count("@<TRIPOS>MOLECULE") > 1
 
 
 @skipIf(not HAVE_OE, "Cannot test openeye module without OpenEye tools.")

--- a/openmoltools/tests/test_openeye.py
+++ b/openmoltools/tests/test_openeye.py
@@ -91,7 +91,7 @@ def test_output_mol2_multiple_confs():
     openmoltools.openeye.molecule_to_mol2(multiple_conformers, tripos_mol2_filename="testing mol2 multiple conformers.tripos.mol2", conformer=None)
     with open("testing mol2 multiple conformers.tripos.mol2", "r") as outfile:
         text = outfile.read()
-    # This should not find the text we added, to make sure the molecule is standardized.
+    # This should find more than one conformation
     assert text.count("@<TRIPOS>MOLECULE") > 1
 
 

--- a/openmoltools/tests/test_openeye.py
+++ b/openmoltools/tests/test_openeye.py
@@ -85,6 +85,17 @@ def test_output_mol2_no_standardize():
 
 
 @skipIf(not HAVE_OE, "Cannot test openeye module without OpenEye tools.")
+def test_output_mol2_multiple_confs():
+    molecule = openmoltools.openeye.iupac_to_oemol("butanol")
+    multiple_conformers = openmoltools.openeye.generate_conformers(molecule)
+    openmoltools.openeye.molecule_to_mol2(multiple_conformers, tripos_mol2_filename="testing mol2 multiple conformers.tripos.mol2", conformer=None)
+    with open("testing mol2 multiple conformers.tripos.mol2", "r") as outfile:
+        text = outfile.read()
+    # This should not find the text we added, to make sure the molecule is standardized.
+    assert text.count("MOLECULE") is 2
+
+
+@skipIf(not HAVE_OE, "Cannot test openeye module without OpenEye tools.")
 def test_butanol():
     m0 = openmoltools.openeye.iupac_to_oemol("butanol")
     m1 = openmoltools.openeye.get_charges(m0, keep_confs=-1)


### PR DESCRIPTION
I added an option to write out all conformers in a multiconformer molecule to mol2 file. 