### PR TITLE
Update bond order perception and pre-generate residue templates

### DIFF
--- a/openmoltools/forcefield_generators.py
+++ b/openmoltools/forcefield_generators.py
@@ -343,7 +343,7 @@ def generateResidueTemplate(molecule, residue_atoms=None, normalize=True, gaff_v
     # Generate ffxml file contents for parmchk-generated frcmod output.
     leaprc = StringIO('parm = loadamberparams %s' % frcmod_filename)
     params = parmed.amber.AmberParameterSet.from_leaprc(leaprc)
-    params = parmed.openmm.OpenMMParameterSet.from_parameterset(params)
+    params = parmed.openmm.OpenMMParameterSet.from_parameterset(params, remediate_residues=False)
     ffxml = StringIO()
     params.write(ffxml)
     return template, ffxml.getvalue()


### PR DESCRIPTION
Summary of changes:
- Pass bond order from oemol to topology and back (if this is not possible, use antechamber to perceive bond order)
- Update `generateForcefieldFromMolecules` for use in the Perses `KinaseInhibitorTestSystem` (see PR: https://github.com/choderalab/perses/pull/492)