### PR TITLE
fixing forcefield_generators to be compatible with openmm 7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,6 +65,7 @@ install:
   - conda install --yes --use-local openmoltools-dev
 
 script:
+  - nosetests --nocapture openmoltools/tests/test_forcefield_generators.py
   - pytest -v --cov=openmoltools --cov-config setup.cfg openmoltools/tests/
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,18 +5,18 @@ sudo: false
 
 # Will only test on Linux be default, special includes are needed for OSX
 python:
-    - 3.5
     - 3.6
+    - 3.7
 
 matrix:
   include:
     # Extra includes for OSX since python language is not available by default on OSX
     - os: osx
       language: generic
-      env: PYTHON_VER=3.5
+      env: PYTHON_VER=3.6
     - os: osx
       language: generic
-      env: PYTHON_VER=3.6
+      env: PYTHON_VER=3.7
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,16 @@ matrix:
     # Extra includes for OSX since python language is not available by default on OSX
     - os: osx
       language: generic
-      env: PYTHON_VER=3.6
+      env: PYTHON_VER=3.6 OPENMM_CHANNEL=omnia OPENMM_VERSION=7.3
     - os: osx
       language: generic
-      env: PYTHON_VER=3.7
+      env: PYTHON_VER=3.7 OPENMM_CHANNEL=omnia OPENMM_VERSION=7.3
+    - os: osx
+      language: generic
+      env: PYTHON_VER=3.6 OPENMM_CHANNEL="omnia/label/beta" OPENMM_VERSION=7.4
+    - os: osx
+      language: generic
+      env: PYTHON_VER=3.7 OPENMM_CHANNEL="omnia/label/beta" OPENMM_VERSION=7.4
 
 env:
   global:
@@ -50,6 +56,7 @@ install:
   - conda install --yes -c openeye openeye-toolkits && python -c "import openeye; print(openeye.__version__)"
   # Install other testing dependencies
   - conda install --yes --quiet nose nose-timer
+  - conda install --yes --quiet -c $OPENMM_CHANNEL openmm==$OPENMM_VERSION
   - conda install --yes --quiet openmmtools
   - conda install --yes --quiet packmol
   - conda install --yes --quiet rdkit

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -30,6 +30,8 @@ requirements:
     - pandas
     - six
     - mdtraj
+    - lxml
+    - pymbar
     - numpy
     - numpydoc
     - scipy

--- a/openmoltools/forcefield_generators.py
+++ b/openmoltools/forcefield_generators.py
@@ -329,6 +329,11 @@ def generateResidueTemplate(molecule, residue_atoms=None, normalize=True, gaff_v
         parameters = { 'charge' : charge }
         atom_template = ForceField._TemplateAtomData(atomname, typename, element, parameters)
         template.atoms.append(atom_template)
+        if hasattr(template, 'atomIndices'):
+            template.atomIndices[atom_template.name] = len(template.atoms)-1
+        # with openmm 7.4 this can be written as
+        # template.addAtom(atom_template)
+        # but this isn't compatible with openmm 7.3
     for bond in molecule.GetBonds():
         if (bond.GetBgn() in residue_atoms) and (bond.GetEnd() in residue_atoms):
             template.addBondByName(bond.GetBgn().GetName(), bond.GetEnd().GetName())

--- a/openmoltools/forcefield_generators.py
+++ b/openmoltools/forcefield_generators.py
@@ -328,12 +328,13 @@ def generateResidueTemplate(molecule, residue_atoms=None, normalize=True, gaff_v
         charge = atom.GetPartialCharge()
         parameters = { 'charge' : charge }
         atom_template = ForceField._TemplateAtomData(atomname, typename, element, parameters)
-        template.atoms.append(atom_template)
         if hasattr(template, 'atomIndices'):
-            template.atomIndices[atom_template.name] = len(template.atoms)-1
-        # with openmm 7.4 this can be written as
-        # template.addAtom(atom_template)
-        # but this isn't compatible with openmm 7.3
+            # OpenMM 7.4 and later
+            template.addAtom(atom_template)
+        else:
+            # OpenMM 7.3 and earlier
+            template.atoms.append(atom_template)
+
     for bond in molecule.GetBonds():
         if (bond.GetBgn() in residue_atoms) and (bond.GetEnd() in residue_atoms):
             template.addBondByName(bond.GetBgn().GetName(), bond.GetEnd().GetName())


### PR DESCRIPTION
In openmm 7.4, the class `_TemplateData` has a dictionary attribute `atomIndices`, which is populated by the function `addAtom()`, which is also not in previous openmm's.

`atomIndices` are required to use the function `getAtomIndexByName()`.

This PR allows for compatibility for both omm 7.3 and 7.4, with the 7.4-specific code in the comments for future use.