### PR TITLE
Remove unneeded deps in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,29 +1,13 @@
 """openmoltools: Tools for Small Molecules, Antechamber, OpenMM, and More.
 """
 
-from __future__ import print_function
 DOCLINES = __doc__.split("\n")
 
-import os
-import sys
-import shutil
-import tempfile
-import subprocess
-from distutils.ccompiler import new_compiler
-from setuptools import setup, Extension
-
-import numpy
-try:
-    from Cython.Distutils import build_ext
-    setup_kwargs = {'cmdclass': {'build_ext': build_ext}}
-    cython_extension = 'pyx'
-except ImportError:
-    setup_kwargs = {}
-    cython_extension = 'c'
+from setuptools import setup
 
 ##########################
 VERSION = "0.0.0dev0"
-ISRELEASED = False 
+ISRELEASED = False
 __version__ = VERSION
 ##########################
 
@@ -46,20 +30,21 @@ Operating System :: MacOS
 
 extensions = []
 
-setup(name='openmoltools',
-      author='Kyle A. Beauchamp',
-      author_email='kyleabeauchamp@gmail.com',
-      description=DOCLINES[0],
-      long_description="\n".join(DOCLINES[2:]),
-      version=__version__,
-      license='MIT',
-      url='http://github.com/choderalab/openmoltools',
-      platforms=['Linux', 'Mac OS-X', 'Unix'],
-      classifiers=CLASSIFIERS.splitlines(),
-      packages=["openmoltools", "openmoltools.tests"],
-      zip_safe=False,
-      scripts=['scripts/generate_example_data.py', 'scripts/processAmberForceField.py'],
-      ext_modules=extensions,
-      package_data={'openmoltools': ['chemicals/*/*', 'parameters/*']},  # Install all data directories of the form testsystems/data/X/
-      **setup_kwargs
-      )
+setup(
+    name="openmoltools",
+    author="Kyle A. Beauchamp",
+    author_email="kyleabeauchamp@gmail.com",
+    description=DOCLINES[0],
+    long_description="\n".join(DOCLINES[2:]),
+    version=__version__,
+    license="MIT",
+    url="http://github.com/choderalab/openmoltools",
+    platforms=["Linux", "Mac OS-X", "Unix"],
+    classifiers=CLASSIFIERS.splitlines(),
+    packages=["openmoltools", "openmoltools.tests"],
+    zip_safe=False,
+    scripts=["scripts/generate_example_data.py", "scripts/processAmberForceField.py"],
+    ext_modules=extensions,
+    # Install all data directories of the form testsystems/data/X/
+    package_data={"openmoltools": ["chemicals/*/*", "parameters/*"]},
+)


### PR DESCRIPTION
In preparation for conda-forge, I am trimming dependencies to the minimum. Numpy and Cython are null imports in setup.py and _not_ needed. Seems to be more like a template leftover. This should be into a patch release.